### PR TITLE
Change type limit from `int32` to `int64`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -208,12 +208,16 @@ export namespace OpenApi {
       default?: boolean;
     }
     export interface IInteger extends __ISignificant<"integer"> {
-      /** @type int */ default?: number;
-      /** @type int */ minimum?: number;
-      /** @type int */ maximum?: number;
+      /** @type int64 */ default?: number;
+      /** @type int64 */ minimum?: number;
+      /** @type int64 */ maximum?: number;
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
-      /** @type uint */ multipleOf?: number;
+      /**
+       * @type uint64
+       * @exclusiveMinimum 0
+       */
+      multipleOf?: number;
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number;
@@ -221,7 +225,7 @@ export namespace OpenApi {
       maximum?: number;
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
-      multipleOf?: number;
+      /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
     export interface IString extends __ISignificant<"string"> {
       contentMediaType?: string;
@@ -252,20 +256,20 @@ export namespace OpenApi {
         | "relative-json-pointer"
         | (string & {});
       pattern?: string;
-      /** @type uint */ minLength?: number;
-      /** @type uint */ maxLength?: number;
+      /** @type uint64 */ minLength?: number;
+      /** @type uint64 */ maxLength?: number;
     }
 
     export interface IArray extends __ISignificant<"array"> {
       items: IJsonSchema;
-      /** @type uint */ minItems?: number;
-      /** @type uint */ maxItems?: number;
+      /** @type uint64 */ minItems?: number;
+      /** @type uint64 */ maxItems?: number;
     }
     export interface ITuple extends __ISignificant<"array"> {
       prefixItems: IJsonSchema[];
       additionalItems: boolean | IJsonSchema;
-      /** @type uint */ minItems?: number;
-      /** @type uint */ maxItems?: number;
+      /** @type uint64 */ minItems?: number;
+      /** @type uint64 */ maxItems?: number;
     }
     export interface IObject extends __ISignificant<"object"> {
       properties?: Record<string, IJsonSchema>;

--- a/src/OpenApiV3.ts
+++ b/src/OpenApiV3.ts
@@ -166,13 +166,17 @@ export namespace OpenApiV3 {
       enum?: boolean[];
     }
     export interface IInteger extends __ISignificant<"integer"> {
-      /** @type int */ default?: number;
-      /** @type int */ enum?: number[];
-      /** @type int */ minimum?: number;
-      /** @type int */ maximum?: number;
+      /** @type int64 */ default?: number;
+      /** @type int64 */ enum?: number[];
+      /** @type int64 */ minimum?: number;
+      /** @type int64 */ maximum?: number;
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
-      /** @type uint */ multipleOf?: number;
+      /**
+       * @type uint64
+       * @exclusiveMinimum 0
+       */
+      multipleOf?: number;
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number;
@@ -181,7 +185,7 @@ export namespace OpenApiV3 {
       maximum?: number;
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
-      multipleOf?: number;
+      /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
     export interface IString extends __ISignificant<"string"> {
       default?: string;
@@ -212,15 +216,15 @@ export namespace OpenApiV3 {
         | "relative-json-pointer"
         | (string & {});
       pattern?: string;
-      /** @type uint */ minLength?: number;
-      /** @type uint */ maxLength?: number;
+      /** @type uint64 */ minLength?: number;
+      /** @type uint64 */ maxLength?: number;
     }
 
     export interface IArray extends __ISignificant<"array"> {
       items: IJsonSchema;
       uniqueItems?: boolean;
-      /** @type uint */ minItems?: number;
-      /** @type uint */ maxItems?: number;
+      /** @type uint64 */ minItems?: number;
+      /** @type uint64 */ maxItems?: number;
     }
     export interface IObject extends __ISignificant<"object"> {
       properties?: Record<string, IJsonSchema>;

--- a/src/OpenApiV3_1.ts
+++ b/src/OpenApiV3_1.ts
@@ -195,13 +195,17 @@ export namespace OpenApiV3_1 {
       enum?: boolean[];
     }
     export interface IInteger extends __ISignificant<"integer"> {
-      /** @type int */ default?: number;
-      /** @type int */ enum?: number[];
-      /** @type int */ minimum?: number;
-      /** @type int */ maximum?: number;
-      /** @type int */ exclusiveMinimum?: number | boolean;
-      /** @type int */ exclusiveMaximum?: number | boolean;
-      /** @type uint */ multipleOf?: number;
+      /** @type int64 */ default?: number;
+      /** @type int64 */ enum?: number[];
+      /** @type int64 */ minimum?: number;
+      /** @type int64 */ maximum?: number;
+      /** @type int64 */ exclusiveMinimum?: number | boolean;
+      /** @type int64 */ exclusiveMaximum?: number | boolean;
+      /**
+       * @type uint64
+       * @exclusiveMinimum 0
+       */
+      multipleOf?: number;
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number;
@@ -210,7 +214,7 @@ export namespace OpenApiV3_1 {
       maximum?: number;
       exclusiveMinimum?: number | boolean;
       exclusiveMaximum?: number | boolean;
-      multipleOf?: number;
+      /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
     export interface IString extends __ISignificant<"string"> {
       contentMediaType?: string;
@@ -242,8 +246,8 @@ export namespace OpenApiV3_1 {
         | "relative-json-pointer"
         | (string & {});
       pattern?: string;
-      /** @type uint */ minLength?: number;
-      /** @type uint */ maxLength?: number;
+      /** @type uint64 */ minLength?: number;
+      /** @type uint64 */ maxLength?: number;
     }
 
     export interface IUnknown extends __IAttribute {
@@ -265,8 +269,8 @@ export namespace OpenApiV3_1 {
       prefixItems?: IJsonSchema[];
       uniqueItems?: boolean;
       additionalItems?: boolean | IJsonSchema;
-      /** @type uint */ minItems?: number;
-      /** @type uint */ maxItems?: number;
+      /** @type uint64 */ minItems?: number;
+      /** @type uint64 */ maxItems?: number;
     }
     export interface IObject extends __ISignificant<"object"> {
       properties?: Record<string, IJsonSchema>;

--- a/src/SwaggerV2.ts
+++ b/src/SwaggerV2.ts
@@ -134,13 +134,17 @@ export namespace SwaggerV2 {
       enum?: boolean[];
     }
     export interface IInteger extends __ISignificant<"integer"> {
-      /** @type int */ default?: number;
-      /** @type int */ enum?: number[];
-      /** @type int */ minimum?: number;
-      /** @type int */ maximum?: number;
+      /** @type int64 */ default?: number;
+      /** @type int64 */ enum?: number[];
+      /** @type int64 */ minimum?: number;
+      /** @type int64 */ maximum?: number;
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
-      /** @type uint */ multipleOf?: number;
+      /**
+       * @type uint64
+       * @exclusiveMinimum 0
+       */
+      multipleOf?: number;
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number;
@@ -149,7 +153,7 @@ export namespace SwaggerV2 {
       maximum?: number;
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
-      multipleOf?: number;
+      /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
     export interface IString extends __ISignificant<"string"> {
       default?: string;
@@ -180,15 +184,15 @@ export namespace SwaggerV2 {
         | "relative-json-pointer"
         | (string & {});
       pattern?: string;
-      /** @type uint */ minLength?: number;
-      /** @type uint */ maxLength?: number;
+      /** @type uint64 */ minLength?: number;
+      /** @type uint64 */ maxLength?: number;
     }
 
     export interface IArray extends __ISignificant<"array"> {
       items: IJsonSchema;
       uniqueItems?: boolean;
-      /** @type uint */ minItems?: number;
-      /** @type uint */ maxItems?: number;
+      /** @type uint64 */ minItems?: number;
+      /** @type uint64 */ maxItems?: number;
     }
     export interface IObject extends __ISignificant<"object"> {
       properties?: Record<string, IJsonSchema>;


### PR DESCRIPTION
Type `integer` of JSON schema means not `int32`, but `int64`. 

Also, the `multipleOf` property must be positive value and it must be greater than zero. The zero value cannot be assigned.

This PR follows such spec of JSON schema, so that upgrade the patch version.