### PR TITLE
`IJsonSchema.ITuple.additionalItems` to be optional.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -267,7 +267,7 @@ export namespace OpenApi {
     }
     export interface ITuple extends __ISignificant<"array"> {
       prefixItems: IJsonSchema[];
-      additionalItems: boolean | IJsonSchema;
+      additionalItems?: boolean | IJsonSchema;
       /** @type uint64 */ minItems?: number;
       /** @type uint64 */ maxItems?: number;
     }

--- a/src/internal/OpenApiV3_1Converter.ts
+++ b/src/internal/OpenApiV3_1Converter.ts
@@ -390,7 +390,7 @@ export namespace OpenApiV3_1Converter {
                 typeof schema.additionalItems === "object" &&
                 schema.additionalItems !== null
                   ? convertSchema(schema.additionalItems)
-                  : schema.additionalItems ?? false,
+                  : schema.additionalItems,
             },
           } satisfies OpenApi.IJsonSchema.ITuple);
         else if (Array.isArray(schema.prefixItems))
@@ -403,7 +403,7 @@ export namespace OpenApiV3_1Converter {
                 typeof schema.additionalItems === "object" &&
                 schema.additionalItems !== null
                   ? convertSchema(schema.additionalItems)
-                  : schema.additionalItems ?? false,
+                  : schema.additionalItems,
             },
           });
         else if (schema.items === undefined)
@@ -412,7 +412,6 @@ export namespace OpenApiV3_1Converter {
             ...{
               items: undefined!,
               prefixItems: [],
-              additionalItems: false,
             },
           });
         else


### PR DESCRIPTION
As `IJsonSchema.IObject.additionalProperties` type is optional, also made `IJsonSchema.ITuple.additionalItems` to be optional for consistency.