### PR TITLE
fix wrong logical operator on operation path parameters in v3.0

### DIFF
--- a/src/internal/OpenApiV3Converter.ts
+++ b/src/internal/OpenApiV3Converter.ts
@@ -57,7 +57,7 @@ export namespace OpenApiV3Converter {
     (input: OpenApiV3.IOperation): OpenApi.IOperation => ({
       ...input,
       parameters:
-        pathItem.parameters !== undefined && input.parameters !== undefined
+        pathItem.parameters !== undefined || input.parameters !== undefined
           ? [...(pathItem.parameters ?? []), ...(input.parameters ?? [])]
               .map((p) => {
                 if (!TypeChecker.isReference(p))


### PR DESCRIPTION
We want parameters if they exist in one of these 2 locations.

This behavior is also implemented in V3.1

https://github.com/samchon/openapi/blob/9e989a68580ef16378d4bf0d7e63eb8205493db8/src/internal/OpenApiV3_1Converter.ts#L88

And in V2

https://github.com/samchon/openapi/blob/9e989a68580ef16378d4bf0d7e63eb8205493db8/src/internal/SwaggerV2Converter.ts#L69

Both having **OR** and not **AND**

The end result is having undefined always.