### PR TITLE
fix build(use preserveModules)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "typescript-transform-paths": "^3.4.7",
     "typia": "^6.0.0"
   },
+  "sideEffects": false,
   "files": [
     "lib",
     "src",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,8 @@ module.exports = {
     format: "esm",
     entryFileNames: "[name].mjs",
     sourcemap: true,
+    preserveModules: true,
+    preserveModulesRoot: "src",
   },
   plugins: [
     typescript({


### PR DESCRIPTION
As same as we configure in `Typia` I would like to add 
- `preserveModules` in rollup config
- `sideEffects: false` in package.json