### PR TITLE
Consider nullable typed default null case.

### DIFF
--- a/examples/v3.0/openai.json
+++ b/examples/v3.0/openai.json
@@ -1,0 +1,13127 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "OpenAI API",
+    "description": "The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details.",
+    "version": "2.1.0",
+    "termsOfService": "https://openai.com/policies/terms-of-use",
+    "contact": {
+      "name": "OpenAI Support",
+      "url": "https://help.openai.com/"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/openai/openai-openapi/blob/master/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.openai.com/v1"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Assistants",
+      "description": "Build Assistants that can call models and use tools."
+    },
+    {
+      "name": "Audio",
+      "description": "Turn audio into text or text into audio."
+    },
+    {
+      "name": "Chat",
+      "description": "Given a list of messages comprising a conversation, the model will return a response."
+    },
+    {
+      "name": "Completions",
+      "description": "Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position."
+    },
+    {
+      "name": "Embeddings",
+      "description": "Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms."
+    },
+    {
+      "name": "Fine-tuning",
+      "description": "Manage fine-tuning jobs to tailor a model to your specific training data."
+    },
+    {
+      "name": "Batch",
+      "description": "Create large batches of API requests to run asynchronously."
+    },
+    {
+      "name": "Files",
+      "description": "Files are used to upload documents that can be used with features like Assistants and Fine-tuning."
+    },
+    {
+      "name": "Uploads",
+      "description": "Use Uploads to upload large files in multiple parts."
+    },
+    {
+      "name": "Images",
+      "description": "Given a prompt and/or an input image, the model will generate a new image."
+    },
+    {
+      "name": "Models",
+      "description": "List and describe the various models available in the API."
+    },
+    {
+      "name": "Moderations",
+      "description": "Given a input text, outputs if the model classifies it as potentially harmful."
+    }
+  ],
+  "paths": {
+    "/chat/completions": {
+      "post": {
+        "operationId": "createChatCompletion",
+        "tags": [
+          "Chat"
+        ],
+        "summary": "Creates a model response for the given chat conversation.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateChatCompletionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateChatCompletionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create chat completion",
+          "group": "chat",
+          "returns": "Returns a [chat completion](/docs/api-reference/chat/object) object, or a streamed sequence of [chat completion chunk](/docs/api-reference/chat/streaming) objects if the request is streamed.\n",
+          "path": "create",
+          "examples": [
+            {
+              "title": "Default",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"messages\": [\n      {\n        \"role\": \"system\",\n        \"content\": \"You are a helpful assistant.\"\n      },\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      }\n    ]\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ncompletion = client.chat.completions.create(\n  model=\"VAR_model_id\",\n  messages=[\n    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n    {\"role\": \"user\", \"content\": \"Hello!\"}\n  ]\n)\n\nprint(completion.choices[0].message)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const completion = await openai.chat.completions.create({\n    messages: [{ role: \"system\", content: \"You are a helpful assistant.\" }],\n    model: \"VAR_model_id\",\n  });\n\n  console.log(completion.choices[0]);\n}\n\nmain();"
+              },
+              "response": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"model\": \"gpt-4o-mini\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nHello there, how may I assist you today?\",\n    },\n    \"logprobs\": null,\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n"
+            },
+            {
+              "title": "Image input",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"gpt-4-turbo\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"What'\\''s in this image?\"\n          },\n          {\n            \"type\": \"image_url\",\n            \"image_url\": {\n              \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\"\n            }\n          }\n        ]\n      }\n    ],\n    \"max_tokens\": 300\n  }'\n",
+                "python": "from openai import OpenAI\n\nclient = OpenAI()\n\nresponse = client.chat.completions.create(\n    model=\"gpt-4-turbo\",\n    messages=[\n        {\n            \"role\": \"user\",\n            \"content\": [\n                {\"type\": \"text\", \"text\": \"What's in this image?\"},\n                {\n                    \"type\": \"image_url\",\n                    \"image_url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n                },\n            ],\n        }\n    ],\n    max_tokens=300,\n)\n\nprint(response.choices[0])\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const response = await openai.chat.completions.create({\n    model: \"gpt-4-turbo\",\n    messages: [\n      {\n        role: \"user\",\n        content: [\n          { type: \"text\", text: \"What's in this image?\" },\n          {\n            type: \"image_url\",\n            image_url:\n              \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n          },\n        ],\n      },\n    ],\n  });\n  console.log(response.choices[0]);\n}\nmain();"
+              },
+              "response": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"model\": \"gpt-4o-mini\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nThis image shows a wooden boardwalk extending through a lush green marshland.\",\n    },\n    \"logprobs\": null,\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n"
+            },
+            {
+              "title": "Streaming",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"messages\": [\n      {\n        \"role\": \"system\",\n        \"content\": \"You are a helpful assistant.\"\n      },\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      }\n    ],\n    \"stream\": true\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ncompletion = client.chat.completions.create(\n  model=\"VAR_model_id\",\n  messages=[\n    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n    {\"role\": \"user\", \"content\": \"Hello!\"}\n  ],\n  stream=True\n)\n\nfor chunk in completion:\n  print(chunk.choices[0].delta)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const completion = await openai.chat.completions.create({\n    model: \"VAR_model_id\",\n    messages: [\n      {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n      {\"role\": \"user\", \"content\": \"Hello!\"}\n    ],\n    stream: true,\n  });\n\n  for await (const chunk of completion) {\n    console.log(chunk.choices[0].delta.content);\n  }\n}\n\nmain();"
+              },
+              "response": "{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-4o-mini\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"logprobs\":null,\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-4o-mini\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"logprobs\":null,\"finish_reason\":null}]}\n\n....\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-4o-mini\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}]}\n"
+            },
+            {
+              "title": "Functions",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n-H \"Content-Type: application/json\" \\\n-H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n-d '{\n  \"model\": \"gpt-4-turbo\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What'\\''s the weather like in Boston today?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_current_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state, e.g. San Francisco, CA\"\n            },\n            \"unit\": {\n              \"type\": \"string\",\n              \"enum\": [\"celsius\", \"fahrenheit\"]\n            }\n          },\n          \"required\": [\"location\"]\n        }\n      }\n    }\n  ],\n  \"tool_choice\": \"auto\"\n}'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ntools = [\n  {\n    \"type\": \"function\",\n    \"function\": {\n      \"name\": \"get_current_weather\",\n      \"description\": \"Get the current weather in a given location\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\",\n            \"description\": \"The city and state, e.g. San Francisco, CA\",\n          },\n          \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n        },\n        \"required\": [\"location\"],\n      },\n    }\n  }\n]\nmessages = [{\"role\": \"user\", \"content\": \"What's the weather like in Boston today?\"}]\ncompletion = client.chat.completions.create(\n  model=\"VAR_model_id\",\n  messages=messages,\n  tools=tools,\n  tool_choice=\"auto\"\n)\n\nprint(completion)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const messages = [{\"role\": \"user\", \"content\": \"What's the weather like in Boston today?\"}];\n  const tools = [\n      {\n        \"type\": \"function\",\n        \"function\": {\n          \"name\": \"get_current_weather\",\n          \"description\": \"Get the current weather in a given location\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"location\": {\n                \"type\": \"string\",\n                \"description\": \"The city and state, e.g. San Francisco, CA\",\n              },\n              \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n            },\n            \"required\": [\"location\"],\n          },\n        }\n      }\n  ];\n\n  const response = await openai.chat.completions.create({\n    model: \"gpt-4-turbo\",\n    messages: messages,\n    tools: tools,\n    tool_choice: \"auto\",\n  });\n\n  console.log(response);\n}\n\nmain();"
+              },
+              "response": "{\n  \"id\": \"chatcmpl-abc123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1699896916,\n  \"model\": \"gpt-4o-mini\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n            \"id\": \"call_abc123\",\n            \"type\": \"function\",\n            \"function\": {\n              \"name\": \"get_current_weather\",\n              \"arguments\": \"{\\n\\\"location\\\": \\\"Boston, MA\\\"\\n}\"\n            }\n          }\n        ]\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 82,\n    \"completion_tokens\": 17,\n    \"total_tokens\": 99\n  }\n}\n"
+            },
+            {
+              "title": "Logprobs",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      }\n    ],\n    \"logprobs\": true,\n    \"top_logprobs\": 2\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ncompletion = client.chat.completions.create(\n  model=\"VAR_model_id\",\n  messages=[\n    {\"role\": \"user\", \"content\": \"Hello!\"}\n  ],\n  logprobs=True,\n  top_logprobs=2\n)\n\nprint(completion.choices[0].message)\nprint(completion.choices[0].logprobs)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const completion = await openai.chat.completions.create({\n    messages: [{ role: \"user\", content: \"Hello!\" }],\n    model: \"VAR_model_id\",\n    logprobs: true,\n    top_logprobs: 2,\n  });\n\n  console.log(completion.choices[0]);\n}\n\nmain();"
+              },
+              "response": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1702685778,\n  \"model\": \"gpt-4o-mini\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": \"Hello! How can I assist you today?\"\n      },\n      \"logprobs\": {\n        \"content\": [\n          {\n            \"token\": \"Hello\",\n            \"logprob\": -0.31725305,\n            \"bytes\": [72, 101, 108, 108, 111],\n            \"top_logprobs\": [\n              {\n                \"token\": \"Hello\",\n                \"logprob\": -0.31725305,\n                \"bytes\": [72, 101, 108, 108, 111]\n              },\n              {\n                \"token\": \"Hi\",\n                \"logprob\": -1.3190403,\n                \"bytes\": [72, 105]\n              }\n            ]\n          },\n          {\n            \"token\": \"!\",\n            \"logprob\": -0.02380986,\n            \"bytes\": [\n              33\n            ],\n            \"top_logprobs\": [\n              {\n                \"token\": \"!\",\n                \"logprob\": -0.02380986,\n                \"bytes\": [33]\n              },\n              {\n                \"token\": \" there\",\n                \"logprob\": -3.787621,\n                \"bytes\": [32, 116, 104, 101, 114, 101]\n              }\n            ]\n          },\n          {\n            \"token\": \" How\",\n            \"logprob\": -0.000054669687,\n            \"bytes\": [32, 72, 111, 119],\n            \"top_logprobs\": [\n              {\n                \"token\": \" How\",\n                \"logprob\": -0.000054669687,\n                \"bytes\": [32, 72, 111, 119]\n              },\n              {\n                \"token\": \"<|end|>\",\n                \"logprob\": -10.953937,\n                \"bytes\": null\n              }\n            ]\n          },\n          {\n            \"token\": \" can\",\n            \"logprob\": -0.015801601,\n            \"bytes\": [32, 99, 97, 110],\n            \"top_logprobs\": [\n              {\n                \"token\": \" can\",\n                \"logprob\": -0.015801601,\n                \"bytes\": [32, 99, 97, 110]\n              },\n              {\n                \"token\": \" may\",\n                \"logprob\": -4.161023,\n                \"bytes\": [32, 109, 97, 121]\n              }\n            ]\n          },\n          {\n            \"token\": \" I\",\n            \"logprob\": -3.7697225e-6,\n            \"bytes\": [\n              32,\n              73\n            ],\n            \"top_logprobs\": [\n              {\n                \"token\": \" I\",\n                \"logprob\": -3.7697225e-6,\n                \"bytes\": [32, 73]\n              },\n              {\n                \"token\": \" assist\",\n                \"logprob\": -13.596657,\n                \"bytes\": [32, 97, 115, 115, 105, 115, 116]\n              }\n            ]\n          },\n          {\n            \"token\": \" assist\",\n            \"logprob\": -0.04571125,\n            \"bytes\": [32, 97, 115, 115, 105, 115, 116],\n            \"top_logprobs\": [\n              {\n                \"token\": \" assist\",\n                \"logprob\": -0.04571125,\n                \"bytes\": [32, 97, 115, 115, 105, 115, 116]\n              },\n              {\n                \"token\": \" help\",\n                \"logprob\": -3.1089056,\n                \"bytes\": [32, 104, 101, 108, 112]\n              }\n            ]\n          },\n          {\n            \"token\": \" you\",\n            \"logprob\": -5.4385737e-6,\n            \"bytes\": [32, 121, 111, 117],\n            \"top_logprobs\": [\n              {\n                \"token\": \" you\",\n                \"logprob\": -5.4385737e-6,\n                \"bytes\": [32, 121, 111, 117]\n              },\n              {\n                \"token\": \" today\",\n                \"logprob\": -12.807695,\n                \"bytes\": [32, 116, 111, 100, 97, 121]\n              }\n            ]\n          },\n          {\n            \"token\": \" today\",\n            \"logprob\": -0.0040071653,\n            \"bytes\": [32, 116, 111, 100, 97, 121],\n            \"top_logprobs\": [\n              {\n                \"token\": \" today\",\n                \"logprob\": -0.0040071653,\n                \"bytes\": [32, 116, 111, 100, 97, 121]\n              },\n              {\n                \"token\": \"?\",\n                \"logprob\": -5.5247097,\n                \"bytes\": [63]\n              }\n            ]\n          },\n          {\n            \"token\": \"?\",\n            \"logprob\": -0.0008108172,\n            \"bytes\": [63],\n            \"top_logprobs\": [\n              {\n                \"token\": \"?\",\n                \"logprob\": -0.0008108172,\n                \"bytes\": [63]\n              },\n              {\n                \"token\": \"?\\n\",\n                \"logprob\": -7.184561,\n                \"bytes\": [63, 10]\n              }\n            ]\n          }\n        ]\n      },\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 9,\n    \"total_tokens\": 18\n  },\n  \"system_fingerprint\": null\n}\n"
+            }
+          ]
+        }
+      }
+    },
+    "/completions": {
+      "post": {
+        "operationId": "createCompletion",
+        "tags": [
+          "Completions"
+        ],
+        "summary": "Creates a completion for the provided prompt and parameters.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCompletionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateCompletionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create completion",
+          "group": "completions",
+          "returns": "Returns a [completion](/docs/api-reference/completions/object) object, or a sequence of completion objects if the request is streamed.\n",
+          "legacy": true,
+          "examples": [
+            {
+              "title": "No streaming",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"prompt\": \"Say this is a test\",\n    \"max_tokens\": 7,\n    \"temperature\": 0\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.completions.create(\n  model=\"VAR_model_id\",\n  prompt=\"Say this is a test\",\n  max_tokens=7,\n  temperature=0\n)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const completion = await openai.completions.create({\n    model: \"VAR_model_id\",\n    prompt: \"Say this is a test.\",\n    max_tokens: 7,\n    temperature: 0,\n  });\n\n  console.log(completion);\n}\nmain();"
+              },
+              "response": "{\n  \"id\": \"cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7\",\n  \"object\": \"text_completion\",\n  \"created\": 1589478378,\n  \"model\": \"VAR_model_id\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [\n    {\n      \"text\": \"\\n\\nThis is indeed a test\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": \"length\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 5,\n    \"completion_tokens\": 7,\n    \"total_tokens\": 12\n  }\n}\n"
+            },
+            {
+              "title": "Streaming",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"prompt\": \"Say this is a test\",\n    \"max_tokens\": 7,\n    \"temperature\": 0,\n    \"stream\": true\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nfor chunk in client.completions.create(\n  model=\"VAR_model_id\",\n  prompt=\"Say this is a test\",\n  max_tokens=7,\n  temperature=0,\n  stream=True\n):\n  print(chunk.choices[0].text)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const stream = await openai.completions.create({\n    model: \"VAR_model_id\",\n    prompt: \"Say this is a test.\",\n    stream: true,\n  });\n\n  for await (const chunk of stream) {\n    console.log(chunk.choices[0].text)\n  }\n}\nmain();"
+              },
+              "response": "{\n  \"id\": \"cmpl-7iA7iJjj8V2zOkCGvWF2hAkDWBQZe\",\n  \"object\": \"text_completion\",\n  \"created\": 1690759702,\n  \"choices\": [\n    {\n      \"text\": \"This\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": null\n    }\n  ],\n  \"model\": \"gpt-3.5-turbo-instruct\"\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n}\n"
+            }
+          ]
+        }
+      }
+    },
+    "/images/generations": {
+      "post": {
+        "operationId": "createImage",
+        "tags": [
+          "Images"
+        ],
+        "summary": "Creates an image given a prompt.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateImageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImagesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create image",
+          "group": "images",
+          "returns": "Returns a list of [image](/docs/api-reference/images/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/images/generations \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"dall-e-3\",\n    \"prompt\": \"A cute baby sea otter\",\n    \"n\": 1,\n    \"size\": \"1024x1024\"\n  }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.images.generate(\n  model=\"dall-e-3\",\n  prompt=\"A cute baby sea otter\",\n  n=1,\n  size=\"1024x1024\"\n)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const image = await openai.images.generate({ model: \"dall-e-3\", prompt: \"A cute baby sea otter\" });\n\n  console.log(image.data);\n}\nmain();"
+            },
+            "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
+          }
+        }
+      }
+    },
+    "/images/edits": {
+      "post": {
+        "operationId": "createImageEdit",
+        "tags": [
+          "Images"
+        ],
+        "summary": "Creates an edited or extended image given an original image and a prompt.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateImageEditRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImagesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create image edit",
+          "group": "images",
+          "returns": "Returns a list of [image](/docs/api-reference/images/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/images/edits \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F image=\"@otter.png\" \\\n  -F mask=\"@mask.png\" \\\n  -F prompt=\"A cute baby sea otter wearing a beret\" \\\n  -F n=2 \\\n  -F size=\"1024x1024\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.images.edit(\n  image=open(\"otter.png\", \"rb\"),\n  mask=open(\"mask.png\", \"rb\"),\n  prompt=\"A cute baby sea otter wearing a beret\",\n  n=2,\n  size=\"1024x1024\"\n)\n",
+              "node.js": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const image = await openai.images.edit({\n    image: fs.createReadStream(\"otter.png\"),\n    mask: fs.createReadStream(\"mask.png\"),\n    prompt: \"A cute baby sea otter wearing a beret\",\n  });\n\n  console.log(image.data);\n}\nmain();"
+            },
+            "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
+          }
+        }
+      }
+    },
+    "/images/variations": {
+      "post": {
+        "operationId": "createImageVariation",
+        "tags": [
+          "Images"
+        ],
+        "summary": "Creates a variation of a given image.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateImageVariationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImagesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create image variation",
+          "group": "images",
+          "returns": "Returns a list of [image](/docs/api-reference/images/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/images/variations \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F image=\"@otter.png\" \\\n  -F n=2 \\\n  -F size=\"1024x1024\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nresponse = client.images.create_variation(\n  image=open(\"image_edit_original.png\", \"rb\"),\n  n=2,\n  size=\"1024x1024\"\n)\n",
+              "node.js": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const image = await openai.images.createVariation({\n    image: fs.createReadStream(\"otter.png\"),\n  });\n\n  console.log(image.data);\n}\nmain();"
+            },
+            "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
+          }
+        }
+      }
+    },
+    "/embeddings": {
+      "post": {
+        "operationId": "createEmbedding",
+        "tags": [
+          "Embeddings"
+        ],
+        "summary": "Creates an embedding vector representing the input text.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEmbeddingRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEmbeddingResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create embeddings",
+          "group": "embeddings",
+          "returns": "A list of [embedding](/docs/api-reference/embeddings/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/embeddings \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"input\": \"The food was delicious and the waiter...\",\n    \"model\": \"text-embedding-ada-002\",\n    \"encoding_format\": \"float\"\n  }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.embeddings.create(\n  model=\"text-embedding-ada-002\",\n  input=\"The food was delicious and the waiter...\",\n  encoding_format=\"float\"\n)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const embedding = await openai.embeddings.create({\n    model: \"text-embedding-ada-002\",\n    input: \"The quick brown fox jumped over the lazy dog\",\n    encoding_format: \"float\",\n  });\n\n  console.log(embedding);\n}\n\nmain();"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"embedding\",\n      \"embedding\": [\n        0.0023064255,\n        -0.009327292,\n        .... (1536 floats total for ada-002)\n        -0.0028842222,\n      ],\n      \"index\": 0\n    }\n  ],\n  \"model\": \"text-embedding-ada-002\",\n  \"usage\": {\n    \"prompt_tokens\": 8,\n    \"total_tokens\": 8\n  }\n}\n"
+          }
+        }
+      }
+    },
+    "/audio/speech": {
+      "post": {
+        "operationId": "createSpeech",
+        "tags": [
+          "Audio"
+        ],
+        "summary": "Generates audio from the input text.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSpeechRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "chunked"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create speech",
+          "group": "audio",
+          "returns": "The audio file content.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/audio/speech \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"tts-1\",\n    \"input\": \"The quick brown fox jumped over the lazy dog.\",\n    \"voice\": \"alloy\"\n  }' \\\n  --output speech.mp3\n",
+              "python": "from pathlib import Path\nimport openai\n\nspeech_file_path = Path(__file__).parent / \"speech.mp3\"\nresponse = openai.audio.speech.create(\n  model=\"tts-1\",\n  voice=\"alloy\",\n  input=\"The quick brown fox jumped over the lazy dog.\"\n)\nresponse.stream_to_file(speech_file_path)\n",
+              "node": "import fs from \"fs\";\nimport path from \"path\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nconst speechFile = path.resolve(\"./speech.mp3\");\n\nasync function main() {\n  const mp3 = await openai.audio.speech.create({\n    model: \"tts-1\",\n    voice: \"alloy\",\n    input: \"Today is a wonderful day to build something people love!\",\n  });\n  console.log(speechFile);\n  const buffer = Buffer.from(await mp3.arrayBuffer());\n  await fs.promises.writeFile(speechFile, buffer);\n}\nmain();\n"
+            }
+          }
+        }
+      }
+    },
+    "/audio/transcriptions": {
+      "post": {
+        "operationId": "createTranscription",
+        "tags": [
+          "Audio"
+        ],
+        "summary": "Transcribes audio into the input language.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTranscriptionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateTranscriptionResponseJson"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CreateTranscriptionResponseVerboseJson"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create transcription",
+          "group": "audio",
+          "returns": "The [transcription object](/docs/api-reference/audio/json-object) or a [verbose transcription object](/docs/api-reference/audio/verbose-json-object).",
+          "examples": [
+            {
+              "title": "Default",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/audio/transcriptions \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: multipart/form-data\" \\\n  -F file=\"@/path/to/file/audio.mp3\" \\\n  -F model=\"whisper-1\"\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\naudio_file = open(\"speech.mp3\", \"rb\")\ntranscript = client.audio.transcriptions.create(\n  model=\"whisper-1\",\n  file=audio_file\n)\n",
+                "node": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const transcription = await openai.audio.transcriptions.create({\n    file: fs.createReadStream(\"audio.mp3\"),\n    model: \"whisper-1\",\n  });\n\n  console.log(transcription.text);\n}\nmain();\n"
+              },
+              "response": "{\n  \"text\": \"Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that.\"\n}\n"
+            },
+            {
+              "title": "Word timestamps",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/audio/transcriptions \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: multipart/form-data\" \\\n  -F file=\"@/path/to/file/audio.mp3\" \\\n  -F \"timestamp_granularities[]=word\" \\\n  -F model=\"whisper-1\" \\\n  -F response_format=\"verbose_json\"\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\naudio_file = open(\"speech.mp3\", \"rb\")\ntranscript = client.audio.transcriptions.create(\n  file=audio_file,\n  model=\"whisper-1\",\n  response_format=\"verbose_json\",\n  timestamp_granularities=[\"word\"]\n)\n\nprint(transcript.words)\n",
+                "node": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const transcription = await openai.audio.transcriptions.create({\n    file: fs.createReadStream(\"audio.mp3\"),\n    model: \"whisper-1\",\n    response_format: \"verbose_json\",\n    timestamp_granularities: [\"word\"]\n  });\n\n  console.log(transcription.text);\n}\nmain();\n"
+              },
+              "response": "{\n  \"task\": \"transcribe\",\n  \"language\": \"english\",\n  \"duration\": 8.470000267028809,\n  \"text\": \"The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.\",\n  \"words\": [\n    {\n      \"word\": \"The\",\n      \"start\": 0.0,\n      \"end\": 0.23999999463558197\n    },\n    ...\n    {\n      \"word\": \"volleyball\",\n      \"start\": 7.400000095367432,\n      \"end\": 7.900000095367432\n    }\n  ]\n}\n"
+            },
+            {
+              "title": "Segment timestamps",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/audio/transcriptions \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: multipart/form-data\" \\\n  -F file=\"@/path/to/file/audio.mp3\" \\\n  -F \"timestamp_granularities[]=segment\" \\\n  -F model=\"whisper-1\" \\\n  -F response_format=\"verbose_json\"\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\naudio_file = open(\"speech.mp3\", \"rb\")\ntranscript = client.audio.transcriptions.create(\n  file=audio_file,\n  model=\"whisper-1\",\n  response_format=\"verbose_json\",\n  timestamp_granularities=[\"segment\"]\n)\n\nprint(transcript.words)\n",
+                "node": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const transcription = await openai.audio.transcriptions.create({\n    file: fs.createReadStream(\"audio.mp3\"),\n    model: \"whisper-1\",\n    response_format: \"verbose_json\",\n    timestamp_granularities: [\"segment\"]\n  });\n\n  console.log(transcription.text);\n}\nmain();\n"
+              },
+              "response": "{\n  \"task\": \"transcribe\",\n  \"language\": \"english\",\n  \"duration\": 8.470000267028809,\n  \"text\": \"The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.\",\n  \"segments\": [\n    {\n      \"id\": 0,\n      \"seek\": 0,\n      \"start\": 0.0,\n      \"end\": 3.319999933242798,\n      \"text\": \" The beach was a popular spot on a hot summer day.\",\n      \"tokens\": [\n        50364, 440, 7534, 390, 257, 3743, 4008, 322, 257, 2368, 4266, 786, 13, 50530\n      ],\n      \"temperature\": 0.0,\n      \"avg_logprob\": -0.2860786020755768,\n      \"compression_ratio\": 1.2363636493682861,\n      \"no_speech_prob\": 0.00985979475080967\n    },\n    ...\n  ]\n}\n"
+            }
+          ]
+        }
+      }
+    },
+    "/audio/translations": {
+      "post": {
+        "operationId": "createTranslation",
+        "tags": [
+          "Audio"
+        ],
+        "summary": "Translates audio into English.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTranslationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateTranslationResponseJson"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CreateTranslationResponseVerboseJson"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create translation",
+          "group": "audio",
+          "returns": "The translated text.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/audio/translations \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: multipart/form-data\" \\\n  -F file=\"@/path/to/file/german.m4a\" \\\n  -F model=\"whisper-1\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\naudio_file = open(\"speech.mp3\", \"rb\")\ntranscript = client.audio.translations.create(\n  model=\"whisper-1\",\n  file=audio_file\n)\n",
+              "node": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n    const translation = await openai.audio.translations.create({\n        file: fs.createReadStream(\"speech.mp3\"),\n        model: \"whisper-1\",\n    });\n\n    console.log(translation.text);\n}\nmain();\n"
+            },
+            "response": "{\n  \"text\": \"Hello, my name is Wolfgang and I come from Germany. Where are you heading today?\"\n}\n"
+          }
+        }
+      }
+    },
+    "/files": {
+      "get": {
+        "operationId": "listFiles",
+        "tags": [
+          "Files"
+        ],
+        "summary": "Returns a list of files that belong to the user's organization.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "purpose",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Only return files with the given purpose."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFilesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List files",
+          "group": "files",
+          "returns": "A list of [File](/docs/api-reference/files/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.files.list()\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.files.list();\n\n  for await (const file of list) {\n    console.log(file);\n  }\n}\n\nmain();"
+            },
+            "response": "{\n  \"data\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 175,\n      \"created_at\": 1613677385,\n      \"filename\": \"salesOverview.pdf\",\n      \"purpose\": \"assistants\",\n    },\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 140,\n      \"created_at\": 1613779121,\n      \"filename\": \"puppy.jsonl\",\n      \"purpose\": \"fine-tune\",\n    }\n  ],\n  \"object\": \"list\"\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createFile",
+        "tags": [
+          "Files"
+        ],
+        "summary": "Upload a file that can be used across various endpoints. Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB.\n\nThe Assistants API supports files up to 2 million tokens and of specific file types. See the [Assistants Tools guide](/docs/assistants/tools) for details.\n\nThe Fine-tuning API only supports `.jsonl` files. The input also has certain required formats for fine-tuning [chat](/docs/api-reference/fine-tuning/chat-input) or [completions](/docs/api-reference/fine-tuning/completions-input) models.\n\nThe Batch API only supports `.jsonl` files up to 100 MB in size. The input also has a specific required [format](/docs/api-reference/batch/request-input).\n\nPlease [contact us](https://help.openai.com/) if you need to increase these storage limits.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenAIFile"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Upload file",
+          "group": "files",
+          "returns": "The uploaded [File](/docs/api-reference/files/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@mydata.jsonl\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.files.create(\n  file=open(\"mydata.jsonl\", \"rb\"),\n  purpose=\"fine-tune\"\n)\n",
+              "node.js": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const file = await openai.files.create({\n    file: fs.createReadStream(\"mydata.jsonl\"),\n    purpose: \"fine-tune\",\n  });\n\n  console.log(file);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"file-abc123\",\n  \"object\": \"file\",\n  \"bytes\": 120000,\n  \"created_at\": 1677610602,\n  \"filename\": \"mydata.jsonl\",\n  \"purpose\": \"fine-tune\",\n}\n"
+          }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "delete": {
+        "operationId": "deleteFile",
+        "tags": [
+          "Files"
+        ],
+        "summary": "Delete a file.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the file to use for this request."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteFileResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Delete file",
+          "group": "files",
+          "returns": "Deletion status.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files/file-abc123 \\\n  -X DELETE \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.files.delete(\"file-abc123\")\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const file = await openai.files.del(\"file-abc123\");\n\n  console.log(file);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"file-abc123\",\n  \"object\": \"file\",\n  \"deleted\": true\n}\n"
+          }
+        }
+      },
+      "get": {
+        "operationId": "retrieveFile",
+        "tags": [
+          "Files"
+        ],
+        "summary": "Returns information about a specific file.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the file to use for this request."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenAIFile"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve file",
+          "group": "files",
+          "returns": "The [File](/docs/api-reference/files/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files/file-abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.files.retrieve(\"file-abc123\")\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const file = await openai.files.retrieve(\"file-abc123\");\n\n  console.log(file);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"file-abc123\",\n  \"object\": \"file\",\n  \"bytes\": 120000,\n  \"created_at\": 1677610602,\n  \"filename\": \"mydata.jsonl\",\n  \"purpose\": \"fine-tune\",\n}\n"
+          }
+        }
+      }
+    },
+    "/files/{file_id}/content": {
+      "get": {
+        "operationId": "downloadFile",
+        "tags": [
+          "Files"
+        ],
+        "summary": "Returns the contents of the specified file.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the file to use for this request."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve file content",
+          "group": "files",
+          "returns": "The file content.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files/file-abc123/content \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" > file.jsonl\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\ncontent = client.files.content(\"file-abc123\")\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const file = await openai.files.content(\"file-abc123\");\n\n  console.log(file);\n}\n\nmain();\n"
+            }
+          }
+        }
+      }
+    },
+    "/uploads": {
+      "post": {
+        "operationId": "createUpload",
+        "tags": [
+          "Uploads"
+        ],
+        "summary": "Creates an intermediate [Upload](/docs/api-reference/uploads/object) object that you can add [Parts](/docs/api-reference/uploads/part-object) to. Currently, an Upload can accept at most 8 GB in total and expires after an hour after you create it.\n\nOnce you complete the Upload, we will create a [File](/docs/api-reference/files/object) object that contains all the parts you uploaded. This File is usable in the rest of our platform as a regular File object.\n\nFor certain `purpose`s, the correct `mime_type` must be specified. Please refer to documentation for the supported MIME types for your use case:\n- [Assistants](/docs/assistants/tools/file-search/supported-files)\n\nFor guidance on the proper filename extensions for each purpose, please follow the documentation on [creating a File](/docs/api-reference/files/create).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUploadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Upload"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create upload",
+          "group": "uploads",
+          "returns": "The [Upload](/docs/api-reference/uploads/object) object with status `pending`.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/uploads \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"purpose\": \"fine-tune\",\n    \"filename\": \"training_examples.jsonl\",\n    \"bytes\": 2147483648,\n    \"mime_type\": \"text/jsonl\"\n  }'\n"
+            },
+            "response": "{\n  \"id\": \"upload_abc123\",\n  \"object\": \"upload\",\n  \"bytes\": 2147483648,\n  \"created_at\": 1719184911,\n  \"filename\": \"training_examples.jsonl\",\n  \"purpose\": \"fine-tune\",\n  \"status\": \"pending\",\n  \"expires_at\": 1719127296\n}\n"
+          }
+        }
+      }
+    },
+    "/uploads/{upload_id}/parts": {
+      "post": {
+        "operationId": "addUploadPart",
+        "tags": [
+          "Uploads"
+        ],
+        "summary": "Adds a [Part](/docs/api-reference/uploads/part-object) to an [Upload](/docs/api-reference/uploads/object) object. A Part represents a chunk of bytes from the file you are trying to upload. \n\nEach Part can be at most 64 MB, and you can add Parts until you hit the Upload maximum of 8 GB.\n\nIt is possible to add multiple Parts in parallel. You can decide the intended order of the Parts when you [complete the Upload](/docs/api-reference/uploads/complete).\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "upload_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "upload_abc123"
+            },
+            "description": "The ID of the Upload.\n"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/AddUploadPartRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadPart"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Add upload part",
+          "group": "uploads",
+          "returns": "The upload [Part](/docs/api-reference/uploads/part-object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/uploads/upload_abc123/parts\n  -F data=\"aHR0cHM6Ly9hcGkub3BlbmFpLmNvbS92MS91cGxvYWRz...\"\n"
+            },
+            "response": "{\n  \"id\": \"part_def456\",\n  \"object\": \"upload.part\",\n  \"created_at\": 1719185911,\n  \"upload_id\": \"upload_abc123\"\n}\n"
+          }
+        }
+      }
+    },
+    "/uploads/{upload_id}/complete": {
+      "post": {
+        "operationId": "completeUpload",
+        "tags": [
+          "Uploads"
+        ],
+        "summary": "Completes the [Upload](/docs/api-reference/uploads/object). \n\nWithin the returned Upload object, there is a nested [File](/docs/api-reference/files/object) object that is ready to use in the rest of the platform.\n\nYou can specify the order of the Parts by passing in an ordered list of the Part IDs.\n\nThe number of bytes uploaded upon completion must match the number of bytes initially specified when creating the Upload object. No Parts may be added after an Upload is completed.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "upload_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "upload_abc123"
+            },
+            "description": "The ID of the Upload.\n"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteUploadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Upload"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Complete upload",
+          "group": "uploads",
+          "returns": "The [Upload](/docs/api-reference/uploads/object) object with status `completed` with an additional `file` property containing the created usable File object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/uploads/upload_abc123/complete\n  -d '{\n    \"part_ids\": [\"part_def456\", \"part_ghi789\"]\n  }'\n"
+            },
+            "response": "{\n  \"id\": \"upload_abc123\",\n  \"object\": \"upload\",\n  \"bytes\": 2147483648,\n  \"created_at\": 1719184911,\n  \"filename\": \"training_examples.jsonl\",\n  \"purpose\": \"fine-tune\",\n  \"status\": \"completed\",\n  \"expires_at\": 1719127296,\n  \"file\": {\n    \"id\": \"file-xyz321\",\n    \"object\": \"file\",\n    \"bytes\": 2147483648,\n    \"created_at\": 1719186911,\n    \"filename\": \"training_examples.jsonl\",\n    \"purpose\": \"fine-tune\",\n  }\n}\n"
+          }
+        }
+      }
+    },
+    "/uploads/{upload_id}/cancel": {
+      "post": {
+        "operationId": "cancelUpload",
+        "tags": [
+          "Uploads"
+        ],
+        "summary": "Cancels the Upload. No Parts may be added after an Upload is cancelled.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "upload_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "upload_abc123"
+            },
+            "description": "The ID of the Upload.\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Upload"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Cancel upload",
+          "group": "uploads",
+          "returns": "The [Upload](/docs/api-reference/uploads/object) object with status `cancelled`.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/uploads/upload_abc123/cancel\n"
+            },
+            "response": "{\n  \"id\": \"upload_abc123\",\n  \"object\": \"upload\",\n  \"bytes\": 2147483648,\n  \"created_at\": 1719184911,\n  \"filename\": \"training_examples.jsonl\",\n  \"purpose\": \"fine-tune\",\n  \"status\": \"cancelled\",\n  \"expires_at\": 1719127296\n}\n"
+          }
+        }
+      }
+    },
+    "/fine_tuning/jobs": {
+      "post": {
+        "operationId": "createFineTuningJob",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "summary": "Creates a fine-tuning job which begins the process of creating a new model from a given dataset.\n\nResponse includes details of the enqueued job including job status and the name of the fine-tuned models once complete.\n\n[Learn more about fine-tuning](/docs/guides/fine-tuning)\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFineTuningJobRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FineTuningJob"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create fine-tuning job",
+          "group": "fine-tuning",
+          "returns": "A [fine-tuning.job](/docs/api-reference/fine-tuning/object) object.",
+          "examples": [
+            {
+              "title": "Default",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/fine_tuning/jobs \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-BK7bzQj3FfZFXr7DbL6xJwfo\",\n    \"model\": \"gpt-3.5-turbo\"\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.create(\n  training_file=\"file-abc123\",\n  model=\"gpt-3.5-turbo\"\n)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.create({\n    training_file: \"file-abc123\"\n  });\n\n  console.log(fineTune);\n}\n\nmain();\n"
+              },
+              "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0125\",\n  \"created_at\": 1614807352,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"queued\",\n  \"validation_file\": null,\n  \"training_file\": \"file-abc123\",\n}\n"
+            },
+            {
+              "title": "Epochs",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/fine_tuning/jobs \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-abc123\",\n    \"model\": \"gpt-3.5-turbo\",\n    \"hyperparameters\": {\n      \"n_epochs\": 2\n    }\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.create(\n  training_file=\"file-abc123\",\n  model=\"gpt-3.5-turbo\",\n  hyperparameters={\n    \"n_epochs\":2\n  }\n)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.create({\n    training_file: \"file-abc123\",\n    model: \"gpt-3.5-turbo\",\n    hyperparameters: { n_epochs: 2 }\n  });\n\n  console.log(fineTune);\n}\n\nmain();\n"
+              },
+              "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0125\",\n  \"created_at\": 1614807352,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"queued\",\n  \"validation_file\": null,\n  \"training_file\": \"file-abc123\",\n  \"hyperparameters\": {\"n_epochs\": 2},\n}\n"
+            },
+            {
+              "title": "Validation file",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/fine_tuning/jobs \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-abc123\",\n    \"validation_file\": \"file-abc123\",\n    \"model\": \"gpt-3.5-turbo\"\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.create(\n  training_file=\"file-abc123\",\n  validation_file=\"file-def456\",\n  model=\"gpt-3.5-turbo\"\n)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.create({\n    training_file: \"file-abc123\",\n    validation_file: \"file-abc123\"\n  });\n\n  console.log(fineTune);\n}\n\nmain();\n"
+              },
+              "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0125\",\n  \"created_at\": 1614807352,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"queued\",\n  \"validation_file\": \"file-abc123\",\n  \"training_file\": \"file-abc123\",\n}\n"
+            },
+            {
+              "title": "W&B Integration",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/fine_tuning/jobs \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-abc123\",\n    \"validation_file\": \"file-abc123\",\n    \"model\": \"gpt-3.5-turbo\",\n    \"integrations\": [\n      {\n        \"type\": \"wandb\",\n        \"wandb\": {\n          \"project\": \"my-wandb-project\",\n          \"name\": \"ft-run-display-name\"\n          \"tags\": [\n            \"first-experiment\", \"v2\"\n          ]\n        }\n      }\n    ]\n  }'\n"
+              },
+              "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0125\",\n  \"created_at\": 1614807352,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"queued\",\n  \"validation_file\": \"file-abc123\",\n  \"training_file\": \"file-abc123\",\n  \"integrations\": [\n    {\n      \"type\": \"wandb\",\n      \"wandb\": {\n        \"project\": \"my-wandb-project\",\n        \"entity\": None,\n        \"run_id\": \"ftjob-abc123\"\n      }\n    }\n  ]\n}\n"
+            }
+          ]
+        }
+      },
+      "get": {
+        "operationId": "listPaginatedFineTuningJobs",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "summary": "List your organization's fine-tuning jobs\n",
+        "parameters": [
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Identifier for the last job from the previous pagination request.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of fine-tuning jobs to retrieve.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListPaginatedFineTuningJobsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List fine-tuning jobs",
+          "group": "fine-tuning",
+          "returns": "A list of paginated [fine-tuning job](/docs/api-reference/fine-tuning/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine_tuning/jobs?limit=2 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.list()\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.fineTuning.jobs.list();\n\n  for await (const fineTune of list) {\n    console.log(fineTune);\n  }\n}\n\nmain();"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"fine_tuning.job.event\",\n      \"id\": \"ft-event-TjX0lMfOniCZX64t9PUQT5hn\",\n      \"created_at\": 1689813489,\n      \"level\": \"warn\",\n      \"message\": \"Fine tuning process stopping due to job cancellation\",\n      \"data\": null,\n      \"type\": \"message\"\n    },\n    { ... },\n    { ... }\n  ], \"has_more\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/fine_tuning/jobs/{fine_tuning_job_id}": {
+      "get": {
+        "operationId": "retrieveFineTuningJob",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "summary": "Get info about a fine-tuning job.\n\n[Learn more about fine-tuning](/docs/guides/fine-tuning)\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fine_tuning_job_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "ft-AF1WoRqd3aJAHsqc9NY7iL8F"
+            },
+            "description": "The ID of the fine-tuning job.\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FineTuningJob"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve fine-tuning job",
+          "group": "fine-tuning",
+          "returns": "The [fine-tuning](/docs/api-reference/fine-tuning/object) object with the given ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.retrieve(\"ftjob-abc123\")\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.retrieve(\"ftjob-abc123\");\n\n  console.log(fineTune);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"davinci-002\",\n  \"created_at\": 1692661014,\n  \"finished_at\": 1692661190,\n  \"fine_tuned_model\": \"ft:davinci-002:my-org:custom_suffix:7q8mpxmy\",\n  \"organization_id\": \"org-123\",\n  \"result_files\": [\n      \"file-abc123\"\n  ],\n  \"status\": \"succeeded\",\n  \"validation_file\": null,\n  \"training_file\": \"file-abc123\",\n  \"hyperparameters\": {\n      \"n_epochs\": 4,\n      \"batch_size\": 1,\n      \"learning_rate_multiplier\": 1.0\n  },\n  \"trained_tokens\": 5768,\n  \"integrations\": [],\n  \"seed\": 0,\n  \"estimated_finish\": 0\n}\n"
+          }
+        }
+      }
+    },
+    "/fine_tuning/jobs/{fine_tuning_job_id}/events": {
+      "get": {
+        "operationId": "listFineTuningEvents",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "summary": "Get status updates for a fine-tuning job.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fine_tuning_job_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "ft-AF1WoRqd3aJAHsqc9NY7iL8F"
+            },
+            "description": "The ID of the fine-tuning job to get events for.\n"
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Identifier for the last event from the previous pagination request.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of events to retrieve.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFineTuningJobEventsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List fine-tuning events",
+          "group": "fine-tuning",
+          "returns": "A list of fine-tuning event objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/events \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.list_events(\n  fine_tuning_job_id=\"ftjob-abc123\",\n  limit=2\n)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.fineTuning.list_events(id=\"ftjob-abc123\", limit=2);\n\n  for await (const fineTune of list) {\n    console.log(fineTune);\n  }\n}\n\nmain();"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"fine_tuning.job.event\",\n      \"id\": \"ft-event-ddTJfwuMVpfLXseO0Am0Gqjm\",\n      \"created_at\": 1692407401,\n      \"level\": \"info\",\n      \"message\": \"Fine tuning job successfully completed\",\n      \"data\": null,\n      \"type\": \"message\"\n    },\n    {\n      \"object\": \"fine_tuning.job.event\",\n      \"id\": \"ft-event-tyiGuB72evQncpH87xe505Sv\",\n      \"created_at\": 1692407400,\n      \"level\": \"info\",\n      \"message\": \"New fine-tuned model created: ft:gpt-3.5-turbo:openai::7p4lURel\",\n      \"data\": null,\n      \"type\": \"message\"\n    }\n  ],\n  \"has_more\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/fine_tuning/jobs/{fine_tuning_job_id}/cancel": {
+      "post": {
+        "operationId": "cancelFineTuningJob",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "summary": "Immediately cancel a fine-tune job.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fine_tuning_job_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "ft-AF1WoRqd3aJAHsqc9NY7iL8F"
+            },
+            "description": "The ID of the fine-tuning job to cancel.\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FineTuningJob"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Cancel fine-tuning",
+          "group": "fine-tuning",
+          "returns": "The cancelled [fine-tuning](/docs/api-reference/fine-tuning/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl -X POST https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/cancel \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.cancel(\"ftjob-abc123\")\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.cancel(\"ftjob-abc123\");\n\n  console.log(fineTune);\n}\nmain();"
+            },
+            "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0125\",\n  \"created_at\": 1689376978,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"hyperparameters\": {\n    \"n_epochs\":  \"auto\"\n  },\n  \"status\": \"cancelled\",\n  \"validation_file\": \"file-abc123\",\n  \"training_file\": \"file-abc123\"\n}\n"
+          }
+        }
+      }
+    },
+    "/fine_tuning/jobs/{fine_tuning_job_id}/checkpoints": {
+      "get": {
+        "operationId": "listFineTuningJobCheckpoints",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "summary": "List checkpoints for a fine-tuning job.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fine_tuning_job_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "ft-AF1WoRqd3aJAHsqc9NY7iL8F"
+            },
+            "description": "The ID of the fine-tuning job to get checkpoints for.\n"
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Identifier for the last checkpoint ID from the previous pagination request.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of checkpoints to retrieve.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFineTuningJobCheckpointsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List fine-tuning checkpoints",
+          "group": "fine-tuning",
+          "returns": "A list of fine-tuning [checkpoint objects](/docs/api-reference/fine-tuning/checkpoint-object) for a fine-tuning job.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/checkpoints \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n"
+            },
+            "response": "{\n  \"object\": \"list\"\n  \"data\": [\n    {\n      \"object\": \"fine_tuning.job.checkpoint\",\n      \"id\": \"ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB\",\n      \"created_at\": 1519129973,\n      \"fine_tuned_model_checkpoint\": \"ft:gpt-3.5-turbo-0125:my-org:custom-suffix:96olL566:ckpt-step-2000\",\n      \"metrics\": {\n        \"full_valid_loss\": 0.134,\n        \"full_valid_mean_token_accuracy\": 0.874\n      },\n      \"fine_tuning_job_id\": \"ftjob-abc123\",\n      \"step_number\": 2000,\n    },\n    {\n      \"object\": \"fine_tuning.job.checkpoint\",\n      \"id\": \"ftckpt_enQCFmOTGj3syEpYVhBRLTSy\",\n      \"created_at\": 1519129833,\n      \"fine_tuned_model_checkpoint\": \"ft:gpt-3.5-turbo-0125:my-org:custom-suffix:7q8mpxmy:ckpt-step-1000\",\n      \"metrics\": {\n        \"full_valid_loss\": 0.167,\n        \"full_valid_mean_token_accuracy\": 0.781\n      },\n      \"fine_tuning_job_id\": \"ftjob-abc123\",\n      \"step_number\": 1000,\n    },\n  ],\n  \"first_id\": \"ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB\",\n  \"last_id\": \"ftckpt_enQCFmOTGj3syEpYVhBRLTSy\",\n  \"has_more\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/models": {
+      "get": {
+        "operationId": "listModels",
+        "tags": [
+          "Models"
+        ],
+        "summary": "Lists the currently available models, and provides basic information about each one such as the owner and availability.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListModelsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List models",
+          "group": "models",
+          "returns": "A list of [model](/docs/api-reference/models/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/models \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.models.list()\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.models.list();\n\n  for await (const model of list) {\n    console.log(model);\n  }\n}\nmain();"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"model-id-0\",\n      \"object\": \"model\",\n      \"created\": 1686935002,\n      \"owned_by\": \"organization-owner\"\n    },\n    {\n      \"id\": \"model-id-1\",\n      \"object\": \"model\",\n      \"created\": 1686935002,\n      \"owned_by\": \"organization-owner\",\n    },\n    {\n      \"id\": \"model-id-2\",\n      \"object\": \"model\",\n      \"created\": 1686935002,\n      \"owned_by\": \"openai\"\n    },\n  ],\n  \"object\": \"list\"\n}\n"
+          }
+        }
+      }
+    },
+    "/models/{model}": {
+      "get": {
+        "operationId": "retrieveModel",
+        "tags": [
+          "Models"
+        ],
+        "summary": "Retrieves a model instance, providing basic information about the model such as the owner and permissioning.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "model",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "gpt-3.5-turbo"
+            },
+            "description": "The ID of the model to use for this request"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Model"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve model",
+          "group": "models",
+          "returns": "The [model](/docs/api-reference/models/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/models/VAR_model_id \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.models.retrieve(\"VAR_model_id\")\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const model = await openai.models.retrieve(\"VAR_model_id\");\n\n  console.log(model);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"VAR_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteModel",
+        "tags": [
+          "Models"
+        ],
+        "summary": "Delete a fine-tuned model. You must have the Owner role in your organization to delete a model.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "model",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "ft:gpt-3.5-turbo:acemeco:suffix:abc123"
+            },
+            "description": "The model to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteModelResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Delete a fine-tuned model",
+          "group": "models",
+          "returns": "Deletion status.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/models/ft:gpt-3.5-turbo:acemeco:suffix:abc123 \\\n  -X DELETE \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.models.delete(\"ft:gpt-3.5-turbo:acemeco:suffix:abc123\")\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const model = await openai.models.del(\"ft:gpt-3.5-turbo:acemeco:suffix:abc123\");\n\n  console.log(model);\n}\nmain();"
+            },
+            "response": "{\n  \"id\": \"ft:gpt-3.5-turbo:acemeco:suffix:abc123\",\n  \"object\": \"model\",\n  \"deleted\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/moderations": {
+      "post": {
+        "operationId": "createModeration",
+        "tags": [
+          "Moderations"
+        ],
+        "summary": "Classifies if text is potentially harmful.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateModerationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateModerationResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create moderation",
+          "group": "moderations",
+          "returns": "A [moderation](/docs/api-reference/moderations/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/moderations \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"input\": \"I want to kill them.\"\n  }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmoderation = client.moderations.create(input=\"I want to kill them.\")\nprint(moderation)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const moderation = await openai.moderations.create({ input: \"I want to kill them.\" });\n\n  console.log(moderation);\n}\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"modr-XXXXX\",\n  \"model\": \"text-moderation-005\",\n  \"results\": [\n    {\n      \"flagged\": true,\n      \"categories\": {\n        \"sexual\": false,\n        \"hate\": false,\n        \"harassment\": false,\n        \"self-harm\": false,\n        \"sexual/minors\": false,\n        \"hate/threatening\": false,\n        \"violence/graphic\": false,\n        \"self-harm/intent\": false,\n        \"self-harm/instructions\": false,\n        \"harassment/threatening\": true,\n        \"violence\": true,\n      },\n      \"category_scores\": {\n        \"sexual\": 1.2282071e-06,\n        \"hate\": 0.010696256,\n        \"harassment\": 0.29842457,\n        \"self-harm\": 1.5236925e-08,\n        \"sexual/minors\": 5.7246268e-08,\n        \"hate/threatening\": 0.0060676364,\n        \"violence/graphic\": 4.435014e-06,\n        \"self-harm/intent\": 8.098441e-10,\n        \"self-harm/instructions\": 2.8498655e-11,\n        \"harassment/threatening\": 0.63055265,\n        \"violence\": 0.99011886,\n      }\n    }\n  ]\n}\n"
+          }
+        }
+      }
+    },
+    "/assistants": {
+      "get": {
+        "operationId": "listAssistants",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Returns a list of assistants.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAssistantsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List assistants",
+          "group": "assistants",
+          "beta": true,
+          "returns": "A list of [assistant](/docs/api-reference/assistants/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl \"https://api.openai.com/v1/assistants?order=desc&limit=20\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_assistants = client.beta.assistants.list(\n    order=\"desc\",\n    limit=\"20\",\n)\nprint(my_assistants.data)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistants = await openai.beta.assistants.list({\n    order: \"desc\",\n    limit: \"20\",\n  });\n\n  console.log(myAssistants.data);\n}\n\nmain();"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"asst_abc123\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982736,\n      \"name\": \"Coding Tutor\",\n      \"description\": null,\n      \"model\": \"gpt-4-turbo\",\n      \"instructions\": \"You are a helpful assistant designed to make me better at coding!\",\n      \"tools\": [],\n      \"tool_resources\": {},\n      \"metadata\": {},\n      \"top_p\": 1.0,\n      \"temperature\": 1.0,\n      \"response_format\": \"auto\"\n    },\n    {\n      \"id\": \"asst_abc456\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982718,\n      \"name\": \"My Assistant\",\n      \"description\": null,\n      \"model\": \"gpt-4-turbo\",\n      \"instructions\": \"You are a helpful assistant designed to make me better at coding!\",\n      \"tools\": [],\n      \"tool_resources\": {},\n      \"metadata\": {},\n      \"top_p\": 1.0,\n      \"temperature\": 1.0,\n      \"response_format\": \"auto\"\n    },\n    {\n      \"id\": \"asst_abc789\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982643,\n      \"name\": null,\n      \"description\": null,\n      \"model\": \"gpt-4-turbo\",\n      \"instructions\": null,\n      \"tools\": [],\n      \"tool_resources\": {},\n      \"metadata\": {},\n      \"top_p\": 1.0,\n      \"temperature\": 1.0,\n      \"response_format\": \"auto\"\n    }\n  ],\n  \"first_id\": \"asst_abc123\",\n  \"last_id\": \"asst_abc789\",\n  \"has_more\": false\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createAssistant",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Create an assistant with a model and instructions.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssistantRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create assistant",
+          "group": "assistants",
+          "beta": true,
+          "returns": "An [assistant](/docs/api-reference/assistants/object) object.",
+          "examples": [
+            {
+              "title": "Code Interpreter",
+              "request": {
+                "curl": "curl \"https://api.openai.com/v1/assistants\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"instructions\": \"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n    \"name\": \"Math Tutor\",\n    \"tools\": [{\"type\": \"code_interpreter\"}],\n    \"model\": \"gpt-4-turbo\"\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_assistant = client.beta.assistants.create(\n    instructions=\"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n    name=\"Math Tutor\",\n    tools=[{\"type\": \"code_interpreter\"}],\n    model=\"gpt-4-turbo\",\n)\nprint(my_assistant)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistant = await openai.beta.assistants.create({\n    instructions:\n      \"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n    name: \"Math Tutor\",\n    tools: [{ type: \"code_interpreter\" }],\n    model: \"gpt-4-turbo\",\n  });\n\n  console.log(myAssistant);\n}\n\nmain();"
+              },
+              "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1698984975,\n  \"name\": \"Math Tutor\",\n  \"description\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": \"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"metadata\": {},\n  \"top_p\": 1.0,\n  \"temperature\": 1.0,\n  \"response_format\": \"auto\"\n}\n"
+            },
+            {
+              "title": "Files",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/assistants \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n    \"tools\": [{\"type\": \"file_search\"}],\n    \"tool_resources\": {\"file_search\": {\"vector_store_ids\": [\"vs_123\"]}},\n    \"model\": \"gpt-4-turbo\"\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_assistant = client.beta.assistants.create(\n    instructions=\"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n    name=\"HR Helper\",\n    tools=[{\"type\": \"file_search\"}],\n    tool_resources={\"file_search\": {\"vector_store_ids\": [\"vs_123\"]}},\n    model=\"gpt-4-turbo\"\n)\nprint(my_assistant)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistant = await openai.beta.assistants.create({\n    instructions:\n      \"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n    name: \"HR Helper\",\n    tools: [{ type: \"file_search\" }],\n    tool_resources: {\n      file_search: {\n        vector_store_ids: [\"vs_123\"]\n      }\n    },\n    model: \"gpt-4-turbo\"\n  });\n\n  console.log(myAssistant);\n}\n\nmain();"
+              },
+              "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1699009403,\n  \"name\": \"HR Helper\",\n  \"description\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n  \"tools\": [\n    {\n      \"type\": \"file_search\"\n    }\n  ],\n  \"tool_resources\": {\n    \"file_search\": {\n      \"vector_store_ids\": [\"vs_123\"]\n    }\n  },\n  \"metadata\": {},\n  \"top_p\": 1.0,\n  \"temperature\": 1.0,\n  \"response_format\": \"auto\"\n}\n"
+            }
+          ]
+        }
+      }
+    },
+    "/assistants/{assistant_id}": {
+      "get": {
+        "operationId": "getAssistant",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Retrieves an assistant.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the assistant to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve assistant",
+          "group": "assistants",
+          "beta": true,
+          "returns": "The [assistant](/docs/api-reference/assistants/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_assistant = client.beta.assistants.retrieve(\"asst_abc123\")\nprint(my_assistant)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistant = await openai.beta.assistants.retrieve(\n    \"asst_abc123\"\n  );\n\n  console.log(myAssistant);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1699009709,\n  \"name\": \"HR Helper\",\n  \"description\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n  \"tools\": [\n    {\n      \"type\": \"file_search\"\n    }\n  ],\n  \"metadata\": {},\n  \"top_p\": 1.0,\n  \"temperature\": 1.0,\n  \"response_format\": \"auto\"\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "modifyAssistant",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Modifies an assistant.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the assistant to modify."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyAssistantRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Modify assistant",
+          "group": "assistants",
+          "beta": true,
+          "returns": "The modified [assistant](/docs/api-reference/assistants/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n      \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.\",\n      \"tools\": [{\"type\": \"file_search\"}],\n      \"model\": \"gpt-4-turbo\"\n    }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_updated_assistant = client.beta.assistants.update(\n  \"asst_abc123\",\n  instructions=\"You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.\",\n  name=\"HR Helper\",\n  tools=[{\"type\": \"file_search\"}],\n  model=\"gpt-4-turbo\"\n)\n\nprint(my_updated_assistant)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myUpdatedAssistant = await openai.beta.assistants.update(\n    \"asst_abc123\",\n    {\n      instructions:\n        \"You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.\",\n      name: \"HR Helper\",\n      tools: [{ type: \"file_search\" }],\n      model: \"gpt-4-turbo\"\n    }\n  );\n\n  console.log(myUpdatedAssistant);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"asst_123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1699009709,\n  \"name\": \"HR Helper\",\n  \"description\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.\",\n  \"tools\": [\n    {\n      \"type\": \"file_search\"\n    }\n  ],\n  \"tool_resources\": {\n    \"file_search\": {\n      \"vector_store_ids\": []\n    }\n  },\n  \"metadata\": {},\n  \"top_p\": 1.0,\n  \"temperature\": 1.0,\n  \"response_format\": \"auto\"\n}\n"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteAssistant",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Delete an assistant.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the assistant to delete."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteAssistantResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Delete assistant",
+          "group": "assistants",
+          "beta": true,
+          "returns": "Deletion status",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -X DELETE\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nresponse = client.beta.assistants.delete(\"asst_abc123\")\nprint(response)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const response = await openai.beta.assistants.del(\"asst_abc123\");\n\n  console.log(response);\n}\nmain();"
+            },
+            "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant.deleted\",\n  \"deleted\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/threads": {
+      "post": {
+        "operationId": "createThread",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Create a thread.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateThreadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create thread",
+          "group": "threads",
+          "beta": true,
+          "returns": "A [thread](/docs/api-reference/threads) object.",
+          "examples": [
+            {
+              "title": "Empty",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d ''\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nempty_thread = client.beta.threads.create()\nprint(empty_thread)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const emptyThread = await openai.beta.threads.create();\n\n  console.log(emptyThread);\n}\n\nmain();"
+              },
+              "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1699012949,\n  \"metadata\": {},\n  \"tool_resources\": {}\n}\n"
+            },
+            {
+              "title": "Messages",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads \\\n-H \"Content-Type: application/json\" \\\n-H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n-H \"OpenAI-Beta: assistants=v2\" \\\n-d '{\n    \"messages\": [{\n      \"role\": \"user\",\n      \"content\": \"Hello, what is AI?\"\n    }, {\n      \"role\": \"user\",\n      \"content\": \"How does AI work? Explain it in simple terms.\"\n    }]\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nmessage_thread = client.beta.threads.create(\n  messages=[\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello, what is AI?\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"How does AI work? Explain it in simple terms.\"\n    },\n  ]\n)\n\nprint(message_thread)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const messageThread = await openai.beta.threads.create({\n    messages: [\n      {\n        role: \"user\",\n        content: \"Hello, what is AI?\"\n      },\n      {\n        role: \"user\",\n        content: \"How does AI work? Explain it in simple terms.\",\n      },\n    ],\n  });\n\n  console.log(messageThread);\n}\n\nmain();"
+              },
+              "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1699014083,\n  \"metadata\": {},\n  \"tool_resources\": {}\n}\n"
+            }
+          ]
+        }
+      }
+    },
+    "/threads/{thread_id}": {
+      "get": {
+        "operationId": "getThread",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Retrieves a thread.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve thread",
+          "group": "threads",
+          "beta": true,
+          "returns": "The [thread](/docs/api-reference/threads/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_thread = client.beta.threads.retrieve(\"thread_abc123\")\nprint(my_thread)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myThread = await openai.beta.threads.retrieve(\n    \"thread_abc123\"\n  );\n\n  console.log(myThread);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1699014083,\n  \"metadata\": {},\n  \"tool_resources\": {\n    \"code_interpreter\": {\n      \"file_ids\": []\n    }\n  }\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "modifyThread",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Modifies a thread.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread to modify. Only the `metadata` can be modified."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyThreadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Modify thread",
+          "group": "threads",
+          "beta": true,
+          "returns": "The modified [thread](/docs/api-reference/threads/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n      \"metadata\": {\n        \"modified\": \"true\",\n        \"user\": \"abc123\"\n      }\n    }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_updated_thread = client.beta.threads.update(\n  \"thread_abc123\",\n  metadata={\n    \"modified\": \"true\",\n    \"user\": \"abc123\"\n  }\n)\nprint(my_updated_thread)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const updatedThread = await openai.beta.threads.update(\n    \"thread_abc123\",\n    {\n      metadata: { modified: \"true\", user: \"abc123\" },\n    }\n  );\n\n  console.log(updatedThread);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1699014083,\n  \"metadata\": {\n    \"modified\": \"true\",\n    \"user\": \"abc123\"\n  },\n  \"tool_resources\": {}\n}\n"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteThread",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Delete a thread.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread to delete."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteThreadResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Delete thread",
+          "group": "threads",
+          "beta": true,
+          "returns": "Deletion status",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -X DELETE\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nresponse = client.beta.threads.delete(\"thread_abc123\")\nprint(response)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const response = await openai.beta.threads.del(\"thread_abc123\");\n\n  console.log(response);\n}\nmain();"
+            },
+            "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread.deleted\",\n  \"deleted\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/threads/{thread_id}/messages": {
+      "get": {
+        "operationId": "listMessages",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Returns a list of messages for a given thread.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the [thread](/docs/api-reference/threads) the messages belong to."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "query",
+            "description": "Filter messages by the run ID that generated them.\n",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListMessagesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List messages",
+          "group": "threads",
+          "beta": true,
+          "returns": "A list of [message](/docs/api-reference/messages) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/messages \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nthread_messages = client.beta.threads.messages.list(\"thread_abc123\")\nprint(thread_messages.data)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const threadMessages = await openai.beta.threads.messages.list(\n    \"thread_abc123\"\n  );\n\n  console.log(threadMessages.data);\n}\n\nmain();"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"msg_abc123\",\n      \"object\": \"thread.message\",\n      \"created_at\": 1699016383,\n      \"assistant_id\": null,\n      \"thread_id\": \"thread_abc123\",\n      \"run_id\": null,\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": {\n            \"value\": \"How does AI work? Explain it in simple terms.\",\n            \"annotations\": []\n          }\n        }\n      ],\n      \"attachments\": [],\n      \"metadata\": {}\n    },\n    {\n      \"id\": \"msg_abc456\",\n      \"object\": \"thread.message\",\n      \"created_at\": 1699016383,\n      \"assistant_id\": null,\n      \"thread_id\": \"thread_abc123\",\n      \"run_id\": null,\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": {\n            \"value\": \"Hello, what is AI?\",\n            \"annotations\": []\n          }\n        }\n      ],\n      \"attachments\": [],\n      \"metadata\": {}\n    }\n  ],\n  \"first_id\": \"msg_abc123\",\n  \"last_id\": \"msg_abc456\",\n  \"has_more\": false\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createMessage",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Create a message.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the [thread](/docs/api-reference/threads) to create a message for."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create message",
+          "group": "threads",
+          "beta": true,
+          "returns": "A [message](/docs/api-reference/messages/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/messages \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n      \"role\": \"user\",\n      \"content\": \"How does AI work? Explain it in simple terms.\"\n    }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nthread_message = client.beta.threads.messages.create(\n  \"thread_abc123\",\n  role=\"user\",\n  content=\"How does AI work? Explain it in simple terms.\",\n)\nprint(thread_message)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const threadMessages = await openai.beta.threads.messages.create(\n    \"thread_abc123\",\n    { role: \"user\", content: \"How does AI work? Explain it in simple terms.\" }\n  );\n\n  console.log(threadMessages);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"msg_abc123\",\n  \"object\": \"thread.message\",\n  \"created_at\": 1713226573,\n  \"assistant_id\": null,\n  \"thread_id\": \"thread_abc123\",\n  \"run_id\": null,\n  \"role\": \"user\",\n  \"content\": [\n    {\n      \"type\": \"text\",\n      \"text\": {\n        \"value\": \"How does AI work? Explain it in simple terms.\",\n        \"annotations\": []\n      }\n    }\n  ],\n  \"attachments\": [],\n  \"metadata\": {}\n}\n"
+          }
+        }
+      }
+    },
+    "/threads/{thread_id}/messages/{message_id}": {
+      "get": {
+        "operationId": "getMessage",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Retrieve a message.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the [thread](/docs/api-reference/threads) to which this message belongs."
+          },
+          {
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the message to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve message",
+          "group": "threads",
+          "beta": true,
+          "returns": "The [message](/docs/api-reference/messages/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmessage = client.beta.threads.messages.retrieve(\n  message_id=\"msg_abc123\",\n  thread_id=\"thread_abc123\",\n)\nprint(message)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const message = await openai.beta.threads.messages.retrieve(\n    \"thread_abc123\",\n    \"msg_abc123\"\n  );\n\n  console.log(message);\n}\n\nmain();"
+            },
+            "response": "{\n  \"id\": \"msg_abc123\",\n  \"object\": \"thread.message\",\n  \"created_at\": 1699017614,\n  \"assistant_id\": null,\n  \"thread_id\": \"thread_abc123\",\n  \"run_id\": null,\n  \"role\": \"user\",\n  \"content\": [\n    {\n      \"type\": \"text\",\n      \"text\": {\n        \"value\": \"How does AI work? Explain it in simple terms.\",\n        \"annotations\": []\n      }\n    }\n  ],\n  \"attachments\": [],\n  \"metadata\": {}\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "modifyMessage",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Modifies a message.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread to which this message belongs."
+          },
+          {
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the message to modify."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Modify message",
+          "group": "threads",
+          "beta": true,
+          "returns": "The modified [message](/docs/api-reference/messages/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n      \"metadata\": {\n        \"modified\": \"true\",\n        \"user\": \"abc123\"\n      }\n    }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmessage = client.beta.threads.messages.update(\n  message_id=\"msg_abc12\",\n  thread_id=\"thread_abc123\",\n  metadata={\n    \"modified\": \"true\",\n    \"user\": \"abc123\",\n  },\n)\nprint(message)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const message = await openai.beta.threads.messages.update(\n    \"thread_abc123\",\n    \"msg_abc123\",\n    {\n      metadata: {\n        modified: \"true\",\n        user: \"abc123\",\n      },\n    }\n  }'"
+            },
+            "response": "{\n  \"id\": \"msg_abc123\",\n  \"object\": \"thread.message\",\n  \"created_at\": 1699017614,\n  \"assistant_id\": null,\n  \"thread_id\": \"thread_abc123\",\n  \"run_id\": null,\n  \"role\": \"user\",\n  \"content\": [\n    {\n      \"type\": \"text\",\n      \"text\": {\n        \"value\": \"How does AI work? Explain it in simple terms.\",\n        \"annotations\": []\n      }\n    }\n  ],\n  \"file_ids\": [],\n  \"metadata\": {\n    \"modified\": \"true\",\n    \"user\": \"abc123\"\n  }\n}\n"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteMessage",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Deletes a message.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread to which this message belongs."
+          },
+          {
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the message to delete."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteMessageResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Delete message",
+          "group": "threads",
+          "beta": true,
+          "returns": "Deletion status",
+          "examples": {
+            "request": {
+              "curl": "curl -X DELETE https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\ndeleted_message = client.beta.threads.messages.delete(\n  message_id=\"msg_abc12\",\n  thread_id=\"thread_abc123\",\n)\nprint(deleted_message)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const deletedMessage = await openai.beta.threads.messages.del(\n    \"thread_abc123\",\n    \"msg_abc123\"\n  );\n\n  console.log(deletedMessage);\n}"
+            },
+            "response": "{\n  \"id\": \"msg_abc123\",\n  \"object\": \"thread.message.deleted\",\n  \"deleted\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/threads/runs": {
+      "post": {
+        "operationId": "createThreadAndRun",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Create a thread and run it in one request.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateThreadAndRunRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create thread and run",
+          "group": "threads",
+          "beta": true,
+          "returns": "A [run](/docs/api-reference/runs/object) object.",
+          "examples": [
+            {
+              "title": "Default",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads/runs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n      \"assistant_id\": \"asst_abc123\",\n      \"thread\": {\n        \"messages\": [\n          {\"role\": \"user\", \"content\": \"Explain deep learning to a 5 year old.\"}\n        ]\n      }\n    }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.create_and_run(\n  assistant_id=\"asst_abc123\",\n  thread={\n    \"messages\": [\n      {\"role\": \"user\", \"content\": \"Explain deep learning to a 5 year old.\"}\n    ]\n  }\n)\n\nprint(run)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.createAndRun({\n    assistant_id: \"asst_abc123\",\n    thread: {\n      messages: [\n        { role: \"user\", content: \"Explain deep learning to a 5 year old.\" },\n      ],\n    },\n  });\n\n  console.log(run);\n}\n\nmain();\n"
+              },
+              "response": "{\n  \"id\": \"run_abc123\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699076792,\n  \"assistant_id\": \"asst_abc123\",\n  \"thread_id\": \"thread_abc123\",\n  \"status\": \"queued\",\n  \"started_at\": null,\n  \"expires_at\": 1699077392,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": null,\n  \"required_action\": null,\n  \"last_error\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": \"You are a helpful assistant.\",\n  \"tools\": [],\n  \"tool_resources\": {},\n  \"metadata\": {},\n  \"temperature\": 1.0,\n  \"top_p\": 1.0,\n  \"max_completion_tokens\": null,\n  \"max_prompt_tokens\": null,\n  \"truncation_strategy\": {\n    \"type\": \"auto\",\n    \"last_messages\": null\n  },\n  \"incomplete_details\": null,\n  \"usage\": null,\n  \"response_format\": \"auto\",\n  \"tool_choice\": \"auto\",\n  \"parallel_tool_calls\": true\n}\n"
+            },
+            {
+              "title": "Streaming",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads/runs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"assistant_id\": \"asst_123\",\n    \"thread\": {\n      \"messages\": [\n        {\"role\": \"user\", \"content\": \"Hello\"}\n      ]\n    },\n    \"stream\": true\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nstream = client.beta.threads.create_and_run(\n  assistant_id=\"asst_123\",\n  thread={\n    \"messages\": [\n      {\"role\": \"user\", \"content\": \"Hello\"}\n    ]\n  },\n  stream=True\n)\n\nfor event in stream:\n  print(event)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const stream = await openai.beta.threads.createAndRun({\n      assistant_id: \"asst_123\",\n      thread: {\n        messages: [\n          { role: \"user\", content: \"Hello\" },\n        ],\n      },\n      stream: true\n  });\n\n  for await (const event of stream) {\n    console.log(event);\n  }\n}\n\nmain();\n"
+              },
+              "response": "event: thread.created\ndata: {\"id\":\"thread_123\",\"object\":\"thread\",\"created_at\":1710348075,\"metadata\":{}}\n\nevent: thread.run.created\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710348075,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":null,\"expires_at\":1710348675,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"tool_resources\":{},\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}\n\nevent: thread.run.queued\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710348075,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":null,\"expires_at\":1710348675,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"tool_resources\":{},\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}\n\nevent: thread.run.in_progress\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710348075,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"in_progress\",\"started_at\":null,\"expires_at\":1710348675,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"tool_resources\":{},\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}\n\nevent: thread.run.step.created\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710348076,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710348675,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":null}\n\nevent: thread.run.step.in_progress\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710348076,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710348675,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":null}\n\nevent: thread.message.created\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710348076,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"in_progress\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":null,\"role\":\"assistant\",\"content\":[], \"metadata\":{}}\n\nevent: thread.message.in_progress\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710348076,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"in_progress\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":null,\"role\":\"assistant\",\"content\":[], \"metadata\":{}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\"Hello\",\"annotations\":[]}}]}}\n\n...\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\" today\"}}]}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\"?\"}}]}}\n\nevent: thread.message.completed\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710348076,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"completed\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":1710348077,\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":{\"value\":\"Hello! How can I assist you today?\",\"annotations\":[]}}], \"metadata\":{}}\n\nevent: thread.run.step.completed\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710348076,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"completed\",\"cancelled_at\":null,\"completed_at\":1710348077,\"expires_at\":1710348675,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":11,\"total_tokens\":31}}\n\nevent: thread.run.completed\n{\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710348076,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"completed\",\"started_at\":1713226836,\"expires_at\":null,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":1713226837,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":{\"prompt_tokens\":345,\"completion_tokens\":11,\"total_tokens\":356},\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}\n\nevent: done\ndata: [DONE]\n"
+            },
+            {
+              "title": "Streaming with Functions",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads/runs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"assistant_id\": \"asst_abc123\",\n    \"thread\": {\n      \"messages\": [\n        {\"role\": \"user\", \"content\": \"What is the weather like in San Francisco?\"}\n      ]\n    },\n    \"tools\": [\n      {\n        \"type\": \"function\",\n        \"function\": {\n          \"name\": \"get_current_weather\",\n          \"description\": \"Get the current weather in a given location\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"location\": {\n                \"type\": \"string\",\n                \"description\": \"The city and state, e.g. San Francisco, CA\"\n              },\n              \"unit\": {\n                \"type\": \"string\",\n                \"enum\": [\"celsius\", \"fahrenheit\"]\n              }\n            },\n            \"required\": [\"location\"]\n          }\n        }\n      }\n    ],\n    \"stream\": true\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ntools = [\n  {\n    \"type\": \"function\",\n    \"function\": {\n      \"name\": \"get_current_weather\",\n      \"description\": \"Get the current weather in a given location\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\",\n            \"description\": \"The city and state, e.g. San Francisco, CA\",\n          },\n          \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n        },\n        \"required\": [\"location\"],\n      },\n    }\n  }\n]\n\nstream = client.beta.threads.create_and_run(\n  thread={\n      \"messages\": [\n        {\"role\": \"user\", \"content\": \"What is the weather like in San Francisco?\"}\n      ]\n  },\n  assistant_id=\"asst_abc123\",\n  tools=tools,\n  stream=True\n)\n\nfor event in stream:\n  print(event)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nconst tools = [\n    {\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_current_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state, e.g. San Francisco, CA\",\n            },\n            \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n          },\n          \"required\": [\"location\"],\n        },\n      }\n    }\n];\n\nasync function main() {\n  const stream = await openai.beta.threads.createAndRun({\n    assistant_id: \"asst_123\",\n    thread: {\n      messages: [\n        { role: \"user\", content: \"What is the weather like in San Francisco?\" },\n      ],\n    },\n    tools: tools,\n    stream: true\n  });\n\n  for await (const event of stream) {\n    console.log(event);\n  }\n}\n\nmain();\n"
+              },
+              "response": "event: thread.created\ndata: {\"id\":\"thread_123\",\"object\":\"thread\",\"created_at\":1710351818,\"metadata\":{}}\n\nevent: thread.run.created\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710351818,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":null,\"expires_at\":1710352418,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"description\":\"Get the current weather in a given location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The city and state, e.g. San Francisco, CA\"},\"unit\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"]}},\"required\":[\"location\"]}}}],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.queued\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710351818,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":null,\"expires_at\":1710352418,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"description\":\"Get the current weather in a given location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The city and state, e.g. San Francisco, CA\"},\"unit\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"]}},\"required\":[\"location\"]}}}],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.in_progress\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710351818,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"in_progress\",\"started_at\":1710351818,\"expires_at\":1710352418,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"description\":\"Get the current weather in a given location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The city and state, e.g. San Francisco, CA\"},\"unit\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"]}},\"required\":[\"location\"]}}}],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.step.created\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710351819,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"tool_calls\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710352418,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"tool_calls\",\"tool_calls\":[]},\"usage\":null}\n\nevent: thread.run.step.in_progress\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710351819,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"tool_calls\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710352418,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"tool_calls\",\"tool_calls\":[]},\"usage\":null}\n\nevent: thread.run.step.delta\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step.delta\",\"delta\":{\"step_details\":{\"type\":\"tool_calls\",\"tool_calls\":[{\"index\":0,\"id\":\"call_XXNp8YGaFrjrSjgqxtC8JJ1B\",\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"arguments\":\"\",\"output\":null}}]}}}\n\nevent: thread.run.step.delta\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step.delta\",\"delta\":{\"step_details\":{\"type\":\"tool_calls\",\"tool_calls\":[{\"index\":0,\"type\":\"function\",\"function\":{\"arguments\":\"{\\\"\"}}]}}}\n\nevent: thread.run.step.delta\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step.delta\",\"delta\":{\"step_details\":{\"type\":\"tool_calls\",\"tool_calls\":[{\"index\":0,\"type\":\"function\",\"function\":{\"arguments\":\"location\"}}]}}}\n\n...\n\nevent: thread.run.step.delta\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step.delta\",\"delta\":{\"step_details\":{\"type\":\"tool_calls\",\"tool_calls\":[{\"index\":0,\"type\":\"function\",\"function\":{\"arguments\":\"ahrenheit\"}}]}}}\n\nevent: thread.run.step.delta\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step.delta\",\"delta\":{\"step_details\":{\"type\":\"tool_calls\",\"tool_calls\":[{\"index\":0,\"type\":\"function\",\"function\":{\"arguments\":\"\\\"}\"}}]}}}\n\nevent: thread.run.requires_action\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710351818,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"requires_action\",\"started_at\":1710351818,\"expires_at\":1710352418,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":{\"type\":\"submit_tool_outputs\",\"submit_tool_outputs\":{\"tool_calls\":[{\"id\":\"call_XXNp8YGaFrjrSjgqxtC8JJ1B\",\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"arguments\":\"{\\\"location\\\":\\\"San Francisco, CA\\\",\\\"unit\\\":\\\"fahrenheit\\\"}\"}}]}},\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"description\":\"Get the current weather in a given location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The city and state, e.g. San Francisco, CA\"},\"unit\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"]}},\"required\":[\"location\"]}}}],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":{\"prompt_tokens\":345,\"completion_tokens\":11,\"total_tokens\":356},\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: done\ndata: [DONE]\n"
+            }
+          ]
+        }
+      }
+    },
+    "/threads/{thread_id}/runs": {
+      "get": {
+        "operationId": "listRuns",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Returns a list of runs belonging to a thread.",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread the run belongs to."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListRunsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List runs",
+          "group": "threads",
+          "beta": true,
+          "returns": "A list of [run](/docs/api-reference/runs/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/runs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nruns = client.beta.threads.runs.list(\n  \"thread_abc123\"\n)\n\nprint(runs)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const runs = await openai.beta.threads.runs.list(\n    \"thread_abc123\"\n  );\n\n  console.log(runs);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"run_abc123\",\n      \"object\": \"thread.run\",\n      \"created_at\": 1699075072,\n      \"assistant_id\": \"asst_abc123\",\n      \"thread_id\": \"thread_abc123\",\n      \"status\": \"completed\",\n      \"started_at\": 1699075072,\n      \"expires_at\": null,\n      \"cancelled_at\": null,\n      \"failed_at\": null,\n      \"completed_at\": 1699075073,\n      \"last_error\": null,\n      \"model\": \"gpt-4-turbo\",\n      \"instructions\": null,\n      \"incomplete_details\": null,\n      \"tools\": [\n        {\n          \"type\": \"code_interpreter\"\n        }\n      ],\n      \"tool_resources\": {\n        \"code_interpreter\": {\n          \"file_ids\": [\n            \"file-abc123\",\n            \"file-abc456\"\n          ]\n        }\n      },\n      \"metadata\": {},\n      \"usage\": {\n        \"prompt_tokens\": 123,\n        \"completion_tokens\": 456,\n        \"total_tokens\": 579\n      },\n      \"temperature\": 1.0,\n      \"top_p\": 1.0,\n      \"max_prompt_tokens\": 1000,\n      \"max_completion_tokens\": 1000,\n      \"truncation_strategy\": {\n        \"type\": \"auto\",\n        \"last_messages\": null\n      },\n      \"response_format\": \"auto\",\n      \"tool_choice\": \"auto\",\n      \"parallel_tool_calls\": true\n    },\n    {\n      \"id\": \"run_abc456\",\n      \"object\": \"thread.run\",\n      \"created_at\": 1699063290,\n      \"assistant_id\": \"asst_abc123\",\n      \"thread_id\": \"thread_abc123\",\n      \"status\": \"completed\",\n      \"started_at\": 1699063290,\n      \"expires_at\": null,\n      \"cancelled_at\": null,\n      \"failed_at\": null,\n      \"completed_at\": 1699063291,\n      \"last_error\": null,\n      \"model\": \"gpt-4-turbo\",\n      \"instructions\": null,\n      \"incomplete_details\": null,\n      \"tools\": [\n        {\n          \"type\": \"code_interpreter\"\n        }\n      ],\n      \"tool_resources\": {\n        \"code_interpreter\": {\n          \"file_ids\": [\n            \"file-abc123\",\n            \"file-abc456\"\n          ]\n        }\n      },\n      \"metadata\": {},\n      \"usage\": {\n        \"prompt_tokens\": 123,\n        \"completion_tokens\": 456,\n        \"total_tokens\": 579\n      },\n      \"temperature\": 1.0,\n      \"top_p\": 1.0,\n      \"max_prompt_tokens\": 1000,\n      \"max_completion_tokens\": 1000,\n      \"truncation_strategy\": {\n        \"type\": \"auto\",\n        \"last_messages\": null\n      },\n      \"response_format\": \"auto\",\n      \"tool_choice\": \"auto\",\n      \"parallel_tool_calls\": true\n    }\n  ],\n  \"first_id\": \"run_abc123\",\n  \"last_id\": \"run_abc456\",\n  \"has_more\": false\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createRun",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Create a run.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread to run."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRunRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create run",
+          "group": "threads",
+          "beta": true,
+          "returns": "A [run](/docs/api-reference/runs/object) object.",
+          "examples": [
+            {
+              "title": "Default",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads/thread_abc123/runs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"assistant_id\": \"asst_abc123\"\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.create(\n  thread_id=\"thread_abc123\",\n  assistant_id=\"asst_abc123\"\n)\n\nprint(run)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.create(\n    \"thread_abc123\",\n    { assistant_id: \"asst_abc123\" }\n  );\n\n  console.log(run);\n}\n\nmain();\n"
+              },
+              "response": "{\n  \"id\": \"run_abc123\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699063290,\n  \"assistant_id\": \"asst_abc123\",\n  \"thread_id\": \"thread_abc123\",\n  \"status\": \"queued\",\n  \"started_at\": 1699063290,\n  \"expires_at\": null,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": 1699063291,\n  \"last_error\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": null,\n  \"incomplete_details\": null,\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"metadata\": {},\n  \"usage\": null,\n  \"temperature\": 1.0,\n  \"top_p\": 1.0,\n  \"max_prompt_tokens\": 1000,\n  \"max_completion_tokens\": 1000,\n  \"truncation_strategy\": {\n    \"type\": \"auto\",\n    \"last_messages\": null\n  },\n  \"response_format\": \"auto\",\n  \"tool_choice\": \"auto\",\n  \"parallel_tool_calls\": true\n}\n"
+            },
+            {
+              "title": "Streaming",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads/thread_123/runs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"assistant_id\": \"asst_123\",\n    \"stream\": true\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nstream = client.beta.threads.runs.create(\n  thread_id=\"thread_123\",\n  assistant_id=\"asst_123\",\n  stream=True\n)\n\nfor event in stream:\n  print(event)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const stream = await openai.beta.threads.runs.create(\n    \"thread_123\",\n    { assistant_id: \"asst_123\", stream: true }\n  );\n\n  for await (const event of stream) {\n    console.log(event);\n  }\n}\n\nmain();\n"
+              },
+              "response": "event: thread.run.created\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710330640,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":null,\"expires_at\":1710331240,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.queued\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710330640,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":null,\"expires_at\":1710331240,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.in_progress\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710330640,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"in_progress\",\"started_at\":1710330641,\"expires_at\":1710331240,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.step.created\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710330641,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710331240,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":null}\n\nevent: thread.run.step.in_progress\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710330641,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710331240,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":null}\n\nevent: thread.message.created\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710330641,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"in_progress\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":null,\"role\":\"assistant\",\"content\":[],\"metadata\":{}}\n\nevent: thread.message.in_progress\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710330641,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"in_progress\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":null,\"role\":\"assistant\",\"content\":[],\"metadata\":{}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\"Hello\",\"annotations\":[]}}]}}\n\n...\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\" today\"}}]}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\"?\"}}]}}\n\nevent: thread.message.completed\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710330641,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"completed\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":1710330642,\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":{\"value\":\"Hello! How can I assist you today?\",\"annotations\":[]}}],\"metadata\":{}}\n\nevent: thread.run.step.completed\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710330641,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"completed\",\"cancelled_at\":null,\"completed_at\":1710330642,\"expires_at\":1710331240,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":11,\"total_tokens\":31}}\n\nevent: thread.run.completed\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710330640,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"completed\",\"started_at\":1710330641,\"expires_at\":null,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":1710330642,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":11,\"total_tokens\":31},\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: done\ndata: [DONE]\n"
+            },
+            {
+              "title": "Streaming with Functions",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads/thread_abc123/runs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"assistant_id\": \"asst_abc123\",\n    \"tools\": [\n      {\n        \"type\": \"function\",\n        \"function\": {\n          \"name\": \"get_current_weather\",\n          \"description\": \"Get the current weather in a given location\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"location\": {\n                \"type\": \"string\",\n                \"description\": \"The city and state, e.g. San Francisco, CA\"\n              },\n              \"unit\": {\n                \"type\": \"string\",\n                \"enum\": [\"celsius\", \"fahrenheit\"]\n              }\n            },\n            \"required\": [\"location\"]\n          }\n        }\n      }\n    ],\n    \"stream\": true\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ntools = [\n  {\n    \"type\": \"function\",\n    \"function\": {\n      \"name\": \"get_current_weather\",\n      \"description\": \"Get the current weather in a given location\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\",\n            \"description\": \"The city and state, e.g. San Francisco, CA\",\n          },\n          \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n        },\n        \"required\": [\"location\"],\n      },\n    }\n  }\n]\n\nstream = client.beta.threads.runs.create(\n  thread_id=\"thread_abc123\",\n  assistant_id=\"asst_abc123\",\n  tools=tools,\n  stream=True\n)\n\nfor event in stream:\n  print(event)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nconst tools = [\n    {\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_current_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state, e.g. San Francisco, CA\",\n            },\n            \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n          },\n          \"required\": [\"location\"],\n        },\n      }\n    }\n];\n\nasync function main() {\n  const stream = await openai.beta.threads.runs.create(\n    \"thread_abc123\",\n    {\n      assistant_id: \"asst_abc123\",\n      tools: tools,\n      stream: true\n    }\n  );\n\n  for await (const event of stream) {\n    console.log(event);\n  }\n}\n\nmain();\n"
+              },
+              "response": "event: thread.run.created\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710348075,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":null,\"expires_at\":1710348675,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.queued\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710348075,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":null,\"expires_at\":1710348675,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.in_progress\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710348075,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"in_progress\",\"started_at\":1710348075,\"expires_at\":1710348675,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.step.created\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710348076,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710348675,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":null}\n\nevent: thread.run.step.in_progress\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710348076,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710348675,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":null}\n\nevent: thread.message.created\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710348076,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"in_progress\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":null,\"role\":\"assistant\",\"content\":[],\"metadata\":{}}\n\nevent: thread.message.in_progress\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710348076,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"in_progress\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":null,\"role\":\"assistant\",\"content\":[],\"metadata\":{}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\"Hello\",\"annotations\":[]}}]}}\n\n...\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\" today\"}}]}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\"?\"}}]}}\n\nevent: thread.message.completed\ndata: {\"id\":\"msg_001\",\"object\":\"thread.message\",\"created_at\":1710348076,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"completed\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":1710348077,\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":{\"value\":\"Hello! How can I assist you today?\",\"annotations\":[]}}],\"metadata\":{}}\n\nevent: thread.run.step.completed\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710348076,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"completed\",\"cancelled_at\":null,\"completed_at\":1710348077,\"expires_at\":1710348675,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_001\"}},\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":11,\"total_tokens\":31}}\n\nevent: thread.run.completed\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710348075,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"completed\",\"started_at\":1710348075,\"expires_at\":null,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":1710348077,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":11,\"total_tokens\":31},\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: done\ndata: [DONE]\n"
+            }
+          ]
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}": {
+      "get": {
+        "operationId": "getRun",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Retrieves a run.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the [thread](/docs/api-reference/threads) that was run."
+          },
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the run to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve run",
+          "group": "threads",
+          "beta": true,
+          "returns": "The [run](/docs/api-reference/runs/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.retrieve(\n  thread_id=\"thread_abc123\",\n  run_id=\"run_abc123\"\n)\n\nprint(run)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.retrieve(\n    \"thread_abc123\",\n    \"run_abc123\"\n  );\n\n  console.log(run);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"run_abc123\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699075072,\n  \"assistant_id\": \"asst_abc123\",\n  \"thread_id\": \"thread_abc123\",\n  \"status\": \"completed\",\n  \"started_at\": 1699075072,\n  \"expires_at\": null,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": 1699075073,\n  \"last_error\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": null,\n  \"incomplete_details\": null,\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"metadata\": {},\n  \"usage\": {\n    \"prompt_tokens\": 123,\n    \"completion_tokens\": 456,\n    \"total_tokens\": 579\n  },\n  \"temperature\": 1.0,\n  \"top_p\": 1.0,\n  \"max_prompt_tokens\": 1000,\n  \"max_completion_tokens\": 1000,\n  \"truncation_strategy\": {\n    \"type\": \"auto\",\n    \"last_messages\": null\n  },\n  \"response_format\": \"auto\",\n  \"tool_choice\": \"auto\",\n  \"parallel_tool_calls\": true\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "modifyRun",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Modifies a run.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the [thread](/docs/api-reference/threads) that was run."
+          },
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the run to modify."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyRunRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Modify run",
+          "group": "threads",
+          "beta": true,
+          "returns": "The modified [run](/docs/api-reference/runs/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"metadata\": {\n      \"user_id\": \"user_abc123\"\n    }\n  }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.update(\n  thread_id=\"thread_abc123\",\n  run_id=\"run_abc123\",\n  metadata={\"user_id\": \"user_abc123\"},\n)\n\nprint(run)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.update(\n    \"thread_abc123\",\n    \"run_abc123\",\n    {\n      metadata: {\n        user_id: \"user_abc123\",\n      },\n    }\n  );\n\n  console.log(run);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"run_abc123\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699075072,\n  \"assistant_id\": \"asst_abc123\",\n  \"thread_id\": \"thread_abc123\",\n  \"status\": \"completed\",\n  \"started_at\": 1699075072,\n  \"expires_at\": null,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": 1699075073,\n  \"last_error\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": null,\n  \"incomplete_details\": null,\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"tool_resources\": {\n    \"code_interpreter\": {\n      \"file_ids\": [\n        \"file-abc123\",\n        \"file-abc456\"\n      ]\n    }\n  },\n  \"metadata\": {\n    \"user_id\": \"user_abc123\"\n  },\n  \"usage\": {\n    \"prompt_tokens\": 123,\n    \"completion_tokens\": 456,\n    \"total_tokens\": 579\n  },\n  \"temperature\": 1.0,\n  \"top_p\": 1.0,\n  \"max_prompt_tokens\": 1000,\n  \"max_completion_tokens\": 1000,\n  \"truncation_strategy\": {\n    \"type\": \"auto\",\n    \"last_messages\": null\n  },\n  \"response_format\": \"auto\",\n  \"tool_choice\": \"auto\",\n  \"parallel_tool_calls\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}/submit_tool_outputs": {
+      "post": {
+        "operationId": "submitToolOuputsToRun",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "When a run has the `status: \"requires_action\"` and `required_action.type` is `submit_tool_outputs`, this endpoint can be used to submit the outputs from the tool calls once they're all completed. All outputs must be submitted in a single request.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the [thread](/docs/api-reference/threads) to which this run belongs."
+          },
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the run that requires the tool output submission."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitToolOutputsRunRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Submit tool outputs to run",
+          "group": "threads",
+          "beta": true,
+          "returns": "The modified [run](/docs/api-reference/runs/object) object matching the specified ID.",
+          "examples": [
+            {
+              "title": "Default",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"tool_outputs\": [\n      {\n        \"tool_call_id\": \"call_001\",\n        \"output\": \"70 degrees and sunny.\"\n      }\n    ]\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.submit_tool_outputs(\n  thread_id=\"thread_123\",\n  run_id=\"run_123\",\n  tool_outputs=[\n    {\n      \"tool_call_id\": \"call_001\",\n      \"output\": \"70 degrees and sunny.\"\n    }\n  ]\n)\n\nprint(run)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.submitToolOutputs(\n    \"thread_123\",\n    \"run_123\",\n    {\n      tool_outputs: [\n        {\n          tool_call_id: \"call_001\",\n          output: \"70 degrees and sunny.\",\n        },\n      ],\n    }\n  );\n\n  console.log(run);\n}\n\nmain();\n"
+              },
+              "response": "{\n  \"id\": \"run_123\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699075592,\n  \"assistant_id\": \"asst_123\",\n  \"thread_id\": \"thread_123\",\n  \"status\": \"queued\",\n  \"started_at\": 1699075592,\n  \"expires_at\": 1699076192,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": null,\n  \"last_error\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": null,\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_current_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state, e.g. San Francisco, CA\"\n            },\n            \"unit\": {\n              \"type\": \"string\",\n              \"enum\": [\"celsius\", \"fahrenheit\"]\n            }\n          },\n          \"required\": [\"location\"]\n        }\n      }\n    }\n  ],\n  \"metadata\": {},\n  \"usage\": null,\n  \"temperature\": 1.0,\n  \"top_p\": 1.0,\n  \"max_prompt_tokens\": 1000,\n  \"max_completion_tokens\": 1000,\n  \"truncation_strategy\": {\n    \"type\": \"auto\",\n    \"last_messages\": null\n  },\n  \"response_format\": \"auto\",\n  \"tool_choice\": \"auto\",\n  \"parallel_tool_calls\": true\n}\n"
+            },
+            {
+              "title": "Streaming",
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -d '{\n    \"tool_outputs\": [\n      {\n        \"tool_call_id\": \"call_001\",\n        \"output\": \"70 degrees and sunny.\"\n      }\n    ],\n    \"stream\": true\n  }'\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nstream = client.beta.threads.runs.submit_tool_outputs(\n  thread_id=\"thread_123\",\n  run_id=\"run_123\",\n  tool_outputs=[\n    {\n      \"tool_call_id\": \"call_001\",\n      \"output\": \"70 degrees and sunny.\"\n    }\n  ],\n  stream=True\n)\n\nfor event in stream:\n  print(event)\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const stream = await openai.beta.threads.runs.submitToolOutputs(\n    \"thread_123\",\n    \"run_123\",\n    {\n      tool_outputs: [\n        {\n          tool_call_id: \"call_001\",\n          output: \"70 degrees and sunny.\",\n        },\n      ],\n    }\n  );\n\n  for await (const event of stream) {\n    console.log(event);\n  }\n}\n\nmain();\n"
+              },
+              "response": "event: thread.run.step.completed\ndata: {\"id\":\"step_001\",\"object\":\"thread.run.step\",\"created_at\":1710352449,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"tool_calls\",\"status\":\"completed\",\"cancelled_at\":null,\"completed_at\":1710352475,\"expires_at\":1710353047,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"tool_calls\",\"tool_calls\":[{\"id\":\"call_iWr0kQ2EaYMaxNdl0v3KYkx7\",\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"arguments\":\"{\\\"location\\\":\\\"San Francisco, CA\\\",\\\"unit\\\":\\\"fahrenheit\\\"}\",\"output\":\"70 degrees and sunny.\"}}]},\"usage\":{\"prompt_tokens\":291,\"completion_tokens\":24,\"total_tokens\":315}}\n\nevent: thread.run.queued\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710352447,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"queued\",\"started_at\":1710352448,\"expires_at\":1710353047,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"description\":\"Get the current weather in a given location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The city and state, e.g. San Francisco, CA\"},\"unit\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"]}},\"required\":[\"location\"]}}}],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.in_progress\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710352447,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"in_progress\",\"started_at\":1710352475,\"expires_at\":1710353047,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":null,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"description\":\"Get the current weather in a given location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The city and state, e.g. San Francisco, CA\"},\"unit\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"]}},\"required\":[\"location\"]}}}],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":null,\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: thread.run.step.created\ndata: {\"id\":\"step_002\",\"object\":\"thread.run.step\",\"created_at\":1710352476,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710353047,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_002\"}},\"usage\":null}\n\nevent: thread.run.step.in_progress\ndata: {\"id\":\"step_002\",\"object\":\"thread.run.step\",\"created_at\":1710352476,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"in_progress\",\"cancelled_at\":null,\"completed_at\":null,\"expires_at\":1710353047,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_002\"}},\"usage\":null}\n\nevent: thread.message.created\ndata: {\"id\":\"msg_002\",\"object\":\"thread.message\",\"created_at\":1710352476,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"in_progress\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":null,\"role\":\"assistant\",\"content\":[],\"metadata\":{}}\n\nevent: thread.message.in_progress\ndata: {\"id\":\"msg_002\",\"object\":\"thread.message\",\"created_at\":1710352476,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"in_progress\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":null,\"role\":\"assistant\",\"content\":[],\"metadata\":{}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_002\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\"The\",\"annotations\":[]}}]}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_002\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\" current\"}}]}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_002\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\" weather\"}}]}}\n\n...\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_002\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\" sunny\"}}]}}\n\nevent: thread.message.delta\ndata: {\"id\":\"msg_002\",\"object\":\"thread.message.delta\",\"delta\":{\"content\":[{\"index\":0,\"type\":\"text\",\"text\":{\"value\":\".\"}}]}}\n\nevent: thread.message.completed\ndata: {\"id\":\"msg_002\",\"object\":\"thread.message\",\"created_at\":1710352476,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"run_id\":\"run_123\",\"status\":\"completed\",\"incomplete_details\":null,\"incomplete_at\":null,\"completed_at\":1710352477,\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":{\"value\":\"The current weather in San Francisco, CA is 70 degrees Fahrenheit and sunny.\",\"annotations\":[]}}],\"metadata\":{}}\n\nevent: thread.run.step.completed\ndata: {\"id\":\"step_002\",\"object\":\"thread.run.step\",\"created_at\":1710352476,\"run_id\":\"run_123\",\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"type\":\"message_creation\",\"status\":\"completed\",\"cancelled_at\":null,\"completed_at\":1710352477,\"expires_at\":1710353047,\"failed_at\":null,\"last_error\":null,\"step_details\":{\"type\":\"message_creation\",\"message_creation\":{\"message_id\":\"msg_002\"}},\"usage\":{\"prompt_tokens\":329,\"completion_tokens\":18,\"total_tokens\":347}}\n\nevent: thread.run.completed\ndata: {\"id\":\"run_123\",\"object\":\"thread.run\",\"created_at\":1710352447,\"assistant_id\":\"asst_123\",\"thread_id\":\"thread_123\",\"status\":\"completed\",\"started_at\":1710352475,\"expires_at\":null,\"cancelled_at\":null,\"failed_at\":null,\"completed_at\":1710352477,\"required_action\":null,\"last_error\":null,\"model\":\"gpt-4-turbo\",\"instructions\":null,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"description\":\"Get the current weather in a given location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The city and state, e.g. San Francisco, CA\"},\"unit\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"]}},\"required\":[\"location\"]}}}],\"metadata\":{},\"temperature\":1.0,\"top_p\":1.0,\"max_completion_tokens\":null,\"max_prompt_tokens\":null,\"truncation_strategy\":{\"type\":\"auto\",\"last_messages\":null},\"incomplete_details\":null,\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":11,\"total_tokens\":31},\"response_format\":\"auto\",\"tool_choice\":\"auto\",\"parallel_tool_calls\":true}}\n\nevent: done\ndata: [DONE]\n"
+            }
+          ]
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}/cancel": {
+      "post": {
+        "operationId": "cancelRun",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Cancels a run that is `in_progress`.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread to which this run belongs."
+          },
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the run to cancel."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Cancel a run",
+          "group": "threads",
+          "beta": true,
+          "returns": "The modified [run](/docs/api-reference/runs/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/cancel \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -X POST\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.cancel(\n  thread_id=\"thread_abc123\",\n  run_id=\"run_abc123\"\n)\n\nprint(run)\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.cancel(\n    \"thread_abc123\",\n    \"run_abc123\"\n  );\n\n  console.log(run);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"run_abc123\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699076126,\n  \"assistant_id\": \"asst_abc123\",\n  \"thread_id\": \"thread_abc123\",\n  \"status\": \"cancelling\",\n  \"started_at\": 1699076126,\n  \"expires_at\": 1699076726,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": null,\n  \"last_error\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": \"You summarize books.\",\n  \"tools\": [\n    {\n      \"type\": \"file_search\"\n    }\n  ],\n  \"tool_resources\": {\n    \"file_search\": {\n      \"vector_store_ids\": [\"vs_123\"]\n    }\n  },\n  \"metadata\": {},\n  \"usage\": null,\n  \"temperature\": 1.0,\n  \"top_p\": 1.0,\n  \"response_format\": \"auto\",\n  \"tool_choice\": \"auto\",\n  \"parallel_tool_calls\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}/steps": {
+      "get": {
+        "operationId": "listRunSteps",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Returns a list of run steps belonging to a run.",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread the run and run steps belong to."
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the run the run steps belong to."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListRunStepsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List run steps",
+          "group": "threads",
+          "beta": true,
+          "returns": "A list of [run step](/docs/api-reference/runs/step-object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun_steps = client.beta.threads.runs.steps.list(\n    thread_id=\"thread_abc123\",\n    run_id=\"run_abc123\"\n)\n\nprint(run_steps)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const runStep = await openai.beta.threads.runs.steps.list(\n    \"thread_abc123\",\n    \"run_abc123\"\n  );\n  console.log(runStep);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"step_abc123\",\n      \"object\": \"thread.run.step\",\n      \"created_at\": 1699063291,\n      \"run_id\": \"run_abc123\",\n      \"assistant_id\": \"asst_abc123\",\n      \"thread_id\": \"thread_abc123\",\n      \"type\": \"message_creation\",\n      \"status\": \"completed\",\n      \"cancelled_at\": null,\n      \"completed_at\": 1699063291,\n      \"expired_at\": null,\n      \"failed_at\": null,\n      \"last_error\": null,\n      \"step_details\": {\n        \"type\": \"message_creation\",\n        \"message_creation\": {\n          \"message_id\": \"msg_abc123\"\n        }\n      },\n      \"usage\": {\n        \"prompt_tokens\": 123,\n        \"completion_tokens\": 456,\n        \"total_tokens\": 579\n      }\n    }\n  ],\n  \"first_id\": \"step_abc123\",\n  \"last_id\": \"step_abc456\",\n  \"has_more\": false\n}\n"
+          }
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}/steps/{step_id}": {
+      "get": {
+        "operationId": "getRunStep",
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Retrieves a run step.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the thread to which the run and run step belongs."
+          },
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the run to which the run step belongs."
+          },
+          {
+            "in": "path",
+            "name": "step_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the run step to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunStepObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve run step",
+          "group": "threads",
+          "beta": true,
+          "returns": "The [run step](/docs/api-reference/runs/step-object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun_step = client.beta.threads.runs.steps.retrieve(\n    thread_id=\"thread_abc123\",\n    run_id=\"run_abc123\",\n    step_id=\"step_abc123\"\n)\n\nprint(run_step)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const runStep = await openai.beta.threads.runs.steps.retrieve(\n    \"thread_abc123\",\n    \"run_abc123\",\n    \"step_abc123\"\n  );\n  console.log(runStep);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"step_abc123\",\n  \"object\": \"thread.run.step\",\n  \"created_at\": 1699063291,\n  \"run_id\": \"run_abc123\",\n  \"assistant_id\": \"asst_abc123\",\n  \"thread_id\": \"thread_abc123\",\n  \"type\": \"message_creation\",\n  \"status\": \"completed\",\n  \"cancelled_at\": null,\n  \"completed_at\": 1699063291,\n  \"expired_at\": null,\n  \"failed_at\": null,\n  \"last_error\": null,\n  \"step_details\": {\n    \"type\": \"message_creation\",\n    \"message_creation\": {\n      \"message_id\": \"msg_abc123\"\n    }\n  },\n  \"usage\": {\n    \"prompt_tokens\": 123,\n    \"completion_tokens\": 456,\n    \"total_tokens\": 579\n  }\n}\n"
+          }
+        }
+      }
+    },
+    "/vector_stores": {
+      "get": {
+        "operationId": "listVectorStores",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Returns a list of vector stores.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListVectorStoresResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List vector stores",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "A list of [vector store](/docs/api-reference/vector-stores/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_stores = client.beta.vector_stores.list()\nprint(vector_stores)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const vectorStores = await openai.beta.vectorStores.list();\n  console.log(vectorStores);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"vs_abc123\",\n      \"object\": \"vector_store\",\n      \"created_at\": 1699061776,\n      \"name\": \"Support FAQ\",\n      \"bytes\": 139920,\n      \"file_counts\": {\n        \"in_progress\": 0,\n        \"completed\": 3,\n        \"failed\": 0,\n        \"cancelled\": 0,\n        \"total\": 3\n      }\n    },\n    {\n      \"id\": \"vs_abc456\",\n      \"object\": \"vector_store\",\n      \"created_at\": 1699061776,\n      \"name\": \"Support FAQ v2\",\n      \"bytes\": 139920,\n      \"file_counts\": {\n        \"in_progress\": 0,\n        \"completed\": 3,\n        \"failed\": 0,\n        \"cancelled\": 0,\n        \"total\": 3\n      }\n    }\n  ],\n  \"first_id\": \"vs_abc123\",\n  \"last_id\": \"vs_abc456\",\n  \"has_more\": false\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createVectorStore",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Create a vector store.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVectorStoreRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create vector store",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "A [vector store](/docs/api-reference/vector-stores/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n  -d '{\n    \"name\": \"Support FAQ\"\n  }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store = client.beta.vector_stores.create(\n  name=\"Support FAQ\"\n)\nprint(vector_store)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const vectorStore = await openai.beta.vectorStores.create({\n    name: \"Support FAQ\"\n  });\n  console.log(vectorStore);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"vs_abc123\",\n  \"object\": \"vector_store\",\n  \"created_at\": 1699061776,\n  \"name\": \"Support FAQ\",\n  \"bytes\": 139920,\n  \"file_counts\": {\n    \"in_progress\": 0,\n    \"completed\": 3,\n    \"failed\": 0,\n    \"cancelled\": 0,\n    \"total\": 3\n  }\n}\n"
+          }
+        }
+      }
+    },
+    "/vector_stores/{vector_store_id}": {
+      "get": {
+        "operationId": "getVectorStore",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Retrieves a vector store.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the vector store to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve vector store",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "The [vector store](/docs/api-reference/vector-stores/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store = client.beta.vector_stores.retrieve(\n  vector_store_id=\"vs_abc123\"\n)\nprint(vector_store)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const vectorStore = await openai.beta.vectorStores.retrieve(\n    \"vs_abc123\"\n  );\n  console.log(vectorStore);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"vs_abc123\",\n  \"object\": \"vector_store\",\n  \"created_at\": 1699061776\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "modifyVectorStore",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Modifies a vector store.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the vector store to modify."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateVectorStoreRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Modify vector store",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "The modified [vector store](/docs/api-reference/vector-stores/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n  -d '{\n    \"name\": \"Support FAQ\"\n  }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store = client.beta.vector_stores.update(\n  vector_store_id=\"vs_abc123\",\n  name=\"Support FAQ\"\n)\nprint(vector_store)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const vectorStore = await openai.beta.vectorStores.update(\n    \"vs_abc123\",\n    {\n      name: \"Support FAQ\"\n    }\n  );\n  console.log(vectorStore);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"vs_abc123\",\n  \"object\": \"vector_store\",\n  \"created_at\": 1699061776,\n  \"name\": \"Support FAQ\",\n  \"bytes\": 139920,\n  \"file_counts\": {\n    \"in_progress\": 0,\n    \"completed\": 3,\n    \"failed\": 0,\n    \"cancelled\": 0,\n    \"total\": 3\n  }\n}\n"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVectorStore",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Delete a vector store.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the vector store to delete."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteVectorStoreResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Delete vector store",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "Deletion status",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -X DELETE\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\ndeleted_vector_store = client.beta.vector_stores.delete(\n  vector_store_id=\"vs_abc123\"\n)\nprint(deleted_vector_store)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const deletedVectorStore = await openai.beta.vectorStores.del(\n    \"vs_abc123\"\n  );\n  console.log(deletedVectorStore);\n}\n\nmain();\n"
+            },
+            "response": "{\n  id: \"vs_abc123\",\n  object: \"vector_store.deleted\",\n  deleted: true\n}\n"
+          }
+        }
+      }
+    },
+    "/vector_stores/{vector_store_id}/files": {
+      "get": {
+        "operationId": "listVectorStoreFiles",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Returns a list of vector store files.",
+        "parameters": [
+          {
+            "name": "vector_store_id",
+            "in": "path",
+            "description": "The ID of the vector store that the files belong to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Filter by file status. One of `in_progress`, `completed`, `failed`, `cancelled`.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListVectorStoreFilesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List vector store files",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store_files = client.beta.vector_stores.files.list(\n  vector_store_id=\"vs_abc123\"\n)\nprint(vector_store_files)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const vectorStoreFiles = await openai.beta.vectorStores.files.list(\n    \"vs_abc123\"\n  );\n  console.log(vectorStoreFiles);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"vector_store.file\",\n      \"created_at\": 1699061776,\n      \"vector_store_id\": \"vs_abc123\"\n    },\n    {\n      \"id\": \"file-abc456\",\n      \"object\": \"vector_store.file\",\n      \"created_at\": 1699061776,\n      \"vector_store_id\": \"vs_abc123\"\n    }\n  ],\n  \"first_id\": \"file-abc123\",\n  \"last_id\": \"file-abc456\",\n  \"has_more\": false\n}\n"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createVectorStoreFile",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Create a vector store file by attaching a [File](/docs/api-reference/files) to a [vector store](/docs/api-reference/vector-stores/object).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "vs_abc123"
+            },
+            "description": "The ID of the vector store for which to create a File.\n"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVectorStoreFileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreFileObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create vector store file",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "A [vector store file](/docs/api-reference/vector-stores-files/file-object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123/files \\\n    -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n    -H \"Content-Type: application/json\" \\\n    -H \"OpenAI-Beta: assistants=v2\" \\\n    -d '{\n      \"file_id\": \"file-abc123\"\n    }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store_file = client.beta.vector_stores.files.create(\n  vector_store_id=\"vs_abc123\",\n  file_id=\"file-abc123\"\n)\nprint(vector_store_file)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const myVectorStoreFile = await openai.beta.vectorStores.files.create(\n    \"vs_abc123\",\n    {\n      file_id: \"file-abc123\"\n    }\n  );\n  console.log(myVectorStoreFile);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"file-abc123\",\n  \"object\": \"vector_store.file\",\n  \"created_at\": 1699061776,\n  \"usage_bytes\": 1234,\n  \"vector_store_id\": \"vs_abcd\",\n  \"status\": \"completed\",\n  \"last_error\": null\n}\n"
+          }
+        }
+      }
+    },
+    "/vector_stores/{vector_store_id}/files/{file_id}": {
+      "get": {
+        "operationId": "getVectorStoreFile",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Retrieves a vector store file.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "vs_abc123"
+            },
+            "description": "The ID of the vector store that the file belongs to."
+          },
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "file-abc123"
+            },
+            "description": "The ID of the file being retrieved."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreFileObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve vector store file",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "The [vector store file](/docs/api-reference/vector-stores-files/file-object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store_file = client.beta.vector_stores.files.retrieve(\n  vector_store_id=\"vs_abc123\",\n  file_id=\"file-abc123\"\n)\nprint(vector_store_file)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const vectorStoreFile = await openai.beta.vectorStores.files.retrieve(\n    \"vs_abc123\",\n    \"file-abc123\"\n  );\n  console.log(vectorStoreFile);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"file-abc123\",\n  \"object\": \"vector_store.file\",\n  \"created_at\": 1699061776,\n  \"vector_store_id\": \"vs_abcd\",\n  \"status\": \"completed\",\n  \"last_error\": null\n}\n"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVectorStoreFile",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Delete a vector store file. This will remove the file from the vector store but the file itself will not be deleted. To delete the file, use the [delete file](/docs/api-reference/files/delete) endpoint.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the vector store that the file belongs to."
+          },
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the file to delete."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteVectorStoreFileResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Delete vector store file",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "Deletion status",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -X DELETE\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\ndeleted_vector_store_file = client.beta.vector_stores.files.delete(\n    vector_store_id=\"vs_abc123\",\n    file_id=\"file-abc123\"\n)\nprint(deleted_vector_store_file)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const deletedVectorStoreFile = await openai.beta.vectorStores.files.del(\n    \"vs_abc123\",\n    \"file-abc123\"\n  );\n  console.log(deletedVectorStoreFile);\n}\n\nmain();\n"
+            },
+            "response": "{\n  id: \"file-abc123\",\n  object: \"vector_store.file.deleted\",\n  deleted: true\n}\n"
+          }
+        }
+      }
+    },
+    "/vector_stores/{vector_store_id}/file_batches": {
+      "post": {
+        "operationId": "createVectorStoreFileBatch",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Create a vector store file batch.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "vs_abc123"
+            },
+            "description": "The ID of the vector store for which to create a File Batch.\n"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVectorStoreFileBatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreFileBatchObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create vector store file batch",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "A [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123/file_batches \\\n    -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n    -H \"Content-Type: application/json \\\n    -H \"OpenAI-Beta: assistants=v2\" \\\n    -d '{\n      \"file_ids\": [\"file-abc123\", \"file-abc456\"]\n    }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store_file_batch = client.beta.vector_stores.file_batches.create(\n  vector_store_id=\"vs_abc123\",\n  file_ids=[\"file-abc123\", \"file-abc456\"]\n)\nprint(vector_store_file_batch)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const myVectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.create(\n    \"vs_abc123\",\n    {\n      file_ids: [\"file-abc123\", \"file-abc456\"]\n    }\n  );\n  console.log(myVectorStoreFileBatch);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"vsfb_abc123\",\n  \"object\": \"vector_store.file_batch\",\n  \"created_at\": 1699061776,\n  \"vector_store_id\": \"vs_abc123\",\n  \"status\": \"in_progress\",\n  \"file_counts\": {\n    \"in_progress\": 1,\n    \"completed\": 1,\n    \"failed\": 0,\n    \"cancelled\": 0,\n    \"total\": 0,\n  }\n}\n"
+          }
+        }
+      }
+    },
+    "/vector_stores/{vector_store_id}/file_batches/{batch_id}": {
+      "get": {
+        "operationId": "getVectorStoreFileBatch",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Retrieves a vector store file batch.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "vs_abc123"
+            },
+            "description": "The ID of the vector store that the file batch belongs to."
+          },
+          {
+            "in": "path",
+            "name": "batch_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "vsfb_abc123"
+            },
+            "description": "The ID of the file batch being retrieved."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreFileBatchObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve vector store file batch",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "The [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store_file_batch = client.beta.vector_stores.file_batches.retrieve(\n  vector_store_id=\"vs_abc123\",\n  batch_id=\"vsfb_abc123\"\n)\nprint(vector_store_file_batch)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const vectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.retrieve(\n    \"vs_abc123\",\n    \"vsfb_abc123\"\n  );\n  console.log(vectorStoreFileBatch);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"vsfb_abc123\",\n  \"object\": \"vector_store.file_batch\",\n  \"created_at\": 1699061776,\n  \"vector_store_id\": \"vs_abc123\",\n  \"status\": \"in_progress\",\n  \"file_counts\": {\n    \"in_progress\": 1,\n    \"completed\": 1,\n    \"failed\": 0,\n    \"cancelled\": 0,\n    \"total\": 0,\n  }\n}\n"
+          }
+        }
+      }
+    },
+    "/vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel": {
+      "post": {
+        "operationId": "cancelVectorStoreFileBatch",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Cancel a vector store file batch. This attempts to cancel the processing of files in this batch as soon as possible.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vector_store_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the vector store that the file batch belongs to."
+          },
+          {
+            "in": "path",
+            "name": "batch_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the file batch to cancel."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreFileBatchObject"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Cancel vector store file batch",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "The modified vector store file batch object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/cancel \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\" \\\n  -X POST\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\ndeleted_vector_store_file_batch = client.beta.vector_stores.file_batches.cancel(\n    vector_store_id=\"vs_abc123\",\n    file_batch_id=\"vsfb_abc123\"\n)\nprint(deleted_vector_store_file_batch)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const deletedVectorStoreFileBatch = await openai.vector_stores.fileBatches.cancel(\n    \"vs_abc123\",\n    \"vsfb_abc123\"\n  );\n  console.log(deletedVectorStoreFileBatch);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"vsfb_abc123\",\n  \"object\": \"vector_store.file_batch\",\n  \"created_at\": 1699061776,\n  \"vector_store_id\": \"vs_abc123\",\n  \"status\": \"cancelling\",\n  \"file_counts\": {\n    \"in_progress\": 12,\n    \"completed\": 3,\n    \"failed\": 0,\n    \"cancelled\": 0,\n    \"total\": 15,\n  }\n}\n"
+          }
+        }
+      }
+    },
+    "/vector_stores/{vector_store_id}/file_batches/{batch_id}/files": {
+      "get": {
+        "operationId": "listFilesInVectorStoreBatch",
+        "tags": [
+          "Vector Stores"
+        ],
+        "summary": "Returns a list of vector store files in a batch.",
+        "parameters": [
+          {
+            "name": "vector_store_id",
+            "in": "path",
+            "description": "The ID of the vector store that the files belong to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "batch_id",
+            "in": "path",
+            "description": "The ID of the file batch that the files belong to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Filter by file status. One of `in_progress`, `completed`, `failed`, `cancelled`.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListVectorStoreFilesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List vector store files in a batch",
+          "group": "vector_stores",
+          "beta": true,
+          "returns": "A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"OpenAI-Beta: assistants=v2\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nvector_store_files = client.beta.vector_stores.file_batches.list_files(\n  vector_store_id=\"vs_abc123\",\n  batch_id=\"vsfb_abc123\"\n)\nprint(vector_store_files)\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const vectorStoreFiles = await openai.beta.vectorStores.fileBatches.listFiles(\n    \"vs_abc123\",\n    \"vsfb_abc123\"\n  );\n  console.log(vectorStoreFiles);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"vector_store.file\",\n      \"created_at\": 1699061776,\n      \"vector_store_id\": \"vs_abc123\"\n    },\n    {\n      \"id\": \"file-abc456\",\n      \"object\": \"vector_store.file\",\n      \"created_at\": 1699061776,\n      \"vector_store_id\": \"vs_abc123\"\n    }\n  ],\n  \"first_id\": \"file-abc123\",\n  \"last_id\": \"file-abc456\",\n  \"has_more\": false\n}\n"
+          }
+        }
+      }
+    },
+    "/batches": {
+      "post": {
+        "summary": "Creates and executes a batch from an uploaded file of requests",
+        "operationId": "createBatch",
+        "tags": [
+          "Batch"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "input_file_id",
+                  "endpoint",
+                  "completion_window"
+                ],
+                "properties": {
+                  "input_file_id": {
+                    "type": "string",
+                    "description": "The ID of an uploaded file that contains requests for the new batch.\n\nSee [upload file](/docs/api-reference/files/create) for how to upload a file.\n\nYour input file must be formatted as a [JSONL file](/docs/api-reference/batch/request-input), and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests, and can be up to 100 MB in size.\n"
+                  },
+                  "endpoint": {
+                    "type": "string",
+                    "enum": [
+                      "/v1/chat/completions",
+                      "/v1/embeddings",
+                      "/v1/completions"
+                    ],
+                    "description": "The endpoint to be used for all requests in the batch. Currently `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are supported. Note that `/v1/embeddings` batches are also restricted to a maximum of 50,000 embedding inputs across all requests in the batch."
+                  },
+                  "completion_window": {
+                    "type": "string",
+                    "enum": [
+                      "24h"
+                    ],
+                    "description": "The time frame within which the batch should be processed. Currently only `24h` is supported."
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Optional custom metadata for the batch.",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Batch"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Create batch",
+          "group": "batch",
+          "returns": "The created [Batch](/docs/api-reference/batch/object) object.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/batches \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"input_file_id\": \"file-abc123\",\n    \"endpoint\": \"/v1/chat/completions\",\n    \"completion_window\": \"24h\"\n  }'\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.batches.create(\n  input_file_id=\"file-abc123\",\n  endpoint=\"/v1/chat/completions\",\n  completion_window=\"24h\"\n)\n",
+              "node": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const batch = await openai.batches.create({\n    input_file_id: \"file-abc123\",\n    endpoint: \"/v1/chat/completions\",\n    completion_window: \"24h\"\n  });\n\n  console.log(batch);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"batch_abc123\",\n  \"object\": \"batch\",\n  \"endpoint\": \"/v1/chat/completions\",\n  \"errors\": null,\n  \"input_file_id\": \"file-abc123\",\n  \"completion_window\": \"24h\",\n  \"status\": \"validating\",\n  \"output_file_id\": null,\n  \"error_file_id\": null,\n  \"created_at\": 1711471533,\n  \"in_progress_at\": null,\n  \"expires_at\": null,\n  \"finalizing_at\": null,\n  \"completed_at\": null,\n  \"failed_at\": null,\n  \"expired_at\": null,\n  \"cancelling_at\": null,\n  \"cancelled_at\": null,\n  \"request_counts\": {\n    \"total\": 0,\n    \"completed\": 0,\n    \"failed\": 0\n  },\n  \"metadata\": {\n    \"customer_id\": \"user_123456789\",\n    \"batch_description\": \"Nightly eval job\",\n  }\n}\n"
+          }
+        }
+      },
+      "get": {
+        "operationId": "listBatches",
+        "tags": [
+          "Batch"
+        ],
+        "summary": "List your organization's batches.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "after",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Batch listed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListBatchesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "List batch",
+          "group": "batch",
+          "returns": "A list of paginated [Batch](/docs/api-reference/batch/object) objects.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/batches?limit=2 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\"\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.batches.list()\n",
+              "node": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.batches.list();\n\n  for await (const batch of list) {\n    console.log(batch);\n  }\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"batch_abc123\",\n      \"object\": \"batch\",\n      \"endpoint\": \"/v1/chat/completions\",\n      \"errors\": null,\n      \"input_file_id\": \"file-abc123\",\n      \"completion_window\": \"24h\",\n      \"status\": \"completed\",\n      \"output_file_id\": \"file-cvaTdG\",\n      \"error_file_id\": \"file-HOWS94\",\n      \"created_at\": 1711471533,\n      \"in_progress_at\": 1711471538,\n      \"expires_at\": 1711557933,\n      \"finalizing_at\": 1711493133,\n      \"completed_at\": 1711493163,\n      \"failed_at\": null,\n      \"expired_at\": null,\n      \"cancelling_at\": null,\n      \"cancelled_at\": null,\n      \"request_counts\": {\n        \"total\": 100,\n        \"completed\": 95,\n        \"failed\": 5\n      },\n      \"metadata\": {\n        \"customer_id\": \"user_123456789\",\n        \"batch_description\": \"Nightly job\",\n      }\n    },\n    { ... },\n  ],\n  \"first_id\": \"batch_abc123\",\n  \"last_id\": \"batch_abc456\",\n  \"has_more\": true\n}\n"
+          }
+        }
+      }
+    },
+    "/batches/{batch_id}": {
+      "get": {
+        "operationId": "retrieveBatch",
+        "tags": [
+          "Batch"
+        ],
+        "summary": "Retrieves a batch.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "batch_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the batch to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Batch retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Batch"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Retrieve batch",
+          "group": "batch",
+          "returns": "The [Batch](/docs/api-reference/batch/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/batches/batch_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.batches.retrieve(\"batch_abc123\")\n",
+              "node": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const batch = await openai.batches.retrieve(\"batch_abc123\");\n\n  console.log(batch);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"batch_abc123\",\n  \"object\": \"batch\",\n  \"endpoint\": \"/v1/completions\",\n  \"errors\": null,\n  \"input_file_id\": \"file-abc123\",\n  \"completion_window\": \"24h\",\n  \"status\": \"completed\",\n  \"output_file_id\": \"file-cvaTdG\",\n  \"error_file_id\": \"file-HOWS94\",\n  \"created_at\": 1711471533,\n  \"in_progress_at\": 1711471538,\n  \"expires_at\": 1711557933,\n  \"finalizing_at\": 1711493133,\n  \"completed_at\": 1711493163,\n  \"failed_at\": null,\n  \"expired_at\": null,\n  \"cancelling_at\": null,\n  \"cancelled_at\": null,\n  \"request_counts\": {\n    \"total\": 100,\n    \"completed\": 95,\n    \"failed\": 5\n  },\n  \"metadata\": {\n    \"customer_id\": \"user_123456789\",\n    \"batch_description\": \"Nightly eval job\",\n  }\n}\n"
+          }
+        }
+      }
+    },
+    "/batches/{batch_id}/cancel": {
+      "post": {
+        "operationId": "cancelBatch",
+        "tags": [
+          "Batch"
+        ],
+        "summary": "Cancels an in-progress batch. The batch will be in status `cancelling` for up to 10 minutes, before changing to `cancelled`, where it will have partial results (if any) available in the output file.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "batch_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the batch to cancel."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Batch is cancelling. Returns the cancelling batch's details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Batch"
+                }
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Cancel batch",
+          "group": "batch",
+          "returns": "The [Batch](/docs/api-reference/batch/object) object matching the specified ID.",
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/batches/batch_abc123/cancel \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -X POST\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.batches.cancel(\"batch_abc123\")\n",
+              "node": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const batch = await openai.batches.cancel(\"batch_abc123\");\n\n  console.log(batch);\n}\n\nmain();\n"
+            },
+            "response": "{\n  \"id\": \"batch_abc123\",\n  \"object\": \"batch\",\n  \"endpoint\": \"/v1/chat/completions\",\n  \"errors\": null,\n  \"input_file_id\": \"file-abc123\",\n  \"completion_window\": \"24h\",\n  \"status\": \"cancelling\",\n  \"output_file_id\": null,\n  \"error_file_id\": null,\n  \"created_at\": 1711471533,\n  \"in_progress_at\": 1711471538,\n  \"expires_at\": 1711557933,\n  \"finalizing_at\": null,\n  \"completed_at\": null,\n  \"failed_at\": null,\n  \"expired_at\": null,\n  \"cancelling_at\": 1711475133,\n  \"cancelled_at\": null,\n  \"request_counts\": {\n    \"total\": 100,\n    \"completed\": 23,\n    \"failed\": 1\n  },\n  \"metadata\": {\n    \"customer_id\": \"user_123456789\",\n    \"batch_description\": \"Nightly eval job\",\n  }\n}\n"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": false
+          },
+          "param": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": false
+          }
+        },
+        "required": [
+          "type",
+          "message",
+          "param",
+          "code"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Error"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "ListModelsResponse": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ]
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Model"
+            }
+          }
+        },
+        "required": [
+          "object",
+          "data"
+        ]
+      },
+      "DeleteModelResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ]
+      },
+      "CreateCompletionRequest": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "gpt-3.5-turbo-instruct",
+                  "davinci-002",
+                  "babbage-002"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          },
+          "prompt": {
+            "description": "The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.\n\nNote that <|endoftext|> is the document separator that the model sees during training, so if a prompt is not specified the model will generate as if from the beginning of a new document.\n",
+            "default": "<|endoftext|>",
+            "nullable": true,
+            "oneOf": [
+              {
+                "type": "string",
+                "default": "",
+                "example": "This is a test."
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "default": "",
+                  "example": "This is a test."
+                }
+              },
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "integer"
+                },
+                "example": "[1212, 318, 257, 1332, 13]"
+              },
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "example": "[[1212, 318, 257, 1332, 13]]"
+              }
+            ]
+          },
+          "best_of": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 0,
+            "maximum": 20,
+            "nullable": true,
+            "description": "Generates `best_of` completions server-side and returns the \"best\" (the one with the highest log probability per token). Results cannot be streamed.\n\nWhen used with `n`, `best_of` controls the number of candidate completions and `n` specifies how many to return – `best_of` must be greater than `n`.\n\n**Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.\n"
+          },
+          "echo": {
+            "type": "boolean",
+            "default": false,
+            "nullable": true,
+            "description": "Echo back the prompt in addition to the completion\n"
+          },
+          "frequency_penalty": {
+            "type": "number",
+            "default": 0,
+            "minimum": -2,
+            "maximum": 2,
+            "nullable": true,
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.\n\n[See more information about frequency and presence penalties.](/docs/guides/text-generation/parameter-details)\n"
+          },
+          "logit_bias": {
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "default": null,
+            "nullable": true,
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Modify the likelihood of specified tokens appearing in the completion.\n\nAccepts a JSON object that maps tokens (specified by their token ID in the GPT tokenizer) to an associated bias value from -100 to 100. You can use this [tokenizer tool](/tokenizer?view=bpe) to convert text to token IDs. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.\n\nAs an example, you can pass `{\"50256\": -100}` to prevent the <|endoftext|> token from being generated.\n"
+          },
+          "logprobs": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 5,
+            "default": null,
+            "nullable": true,
+            "description": "Include the log probabilities on the `logprobs` most likely output tokens, as well the chosen tokens. For example, if `logprobs` is 5, the API will return a list of the 5 most likely tokens. The API will always return the `logprob` of the sampled token, so there may be up to `logprobs+1` elements in the response.\n\nThe maximum value for `logprobs` is 5.\n"
+          },
+          "max_tokens": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 16,
+            "example": 16,
+            "nullable": true,
+            "description": "The maximum number of [tokens](/tokenizer) that can be generated in the completion.\n\nThe token count of your prompt plus `max_tokens` cannot exceed the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.\n"
+          },
+          "n": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 128,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "How many completions to generate for each prompt.\n\n**Note:** Because this parameter generates many completions, it can quickly consume your token quota. Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.\n"
+          },
+          "presence_penalty": {
+            "type": "number",
+            "default": 0,
+            "minimum": -2,
+            "maximum": 2,
+            "nullable": true,
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.\n\n[See more information about frequency and presence penalties.](/docs/guides/text-generation/parameter-details)\n"
+          },
+          "seed": {
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000,
+            "nullable": true,
+            "description": "If specified, our system will make a best effort to sample deterministically, such that repeated requests with the same `seed` and parameters should return the same result.\n\nDeterminism is not guaranteed, and you should refer to the `system_fingerprint` response parameter to monitor changes in the backend.\n"
+          },
+          "stop": {
+            "description": "Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.\n",
+            "default": null,
+            "nullable": true,
+            "oneOf": [
+              {
+                "type": "string",
+                "default": "<|endoftext|>",
+                "example": "\n",
+                "nullable": true
+              },
+              {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 4,
+                "items": {
+                  "type": "string",
+                  "example": "[\"\\n\"]"
+                }
+              }
+            ]
+          },
+          "stream": {
+            "description": "Whether to stream back partial progress. If set, tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).\n",
+            "type": "boolean",
+            "nullable": true,
+            "default": false
+          },
+          "stream_options": {
+            "$ref": "#/components/schemas/ChatCompletionStreamOptions"
+          },
+          "suffix": {
+            "description": "The suffix that comes after a completion of inserted text.\n\nThis parameter is only supported for `gpt-3.5-turbo-instruct`.\n",
+            "default": null,
+            "nullable": true,
+            "type": "string",
+            "example": "test."
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\n\nWe generally recommend altering this or `top_p` but not both.\n"
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or `temperature` but not both.\n"
+          },
+          "user": {
+            "type": "string",
+            "example": "user-1234",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n"
+          }
+        },
+        "required": [
+          "model",
+          "prompt"
+        ]
+      },
+      "CreateCompletionResponse": {
+        "type": "object",
+        "description": "Represents a completion response from the API. Note: both the streamed and non-streamed response objects share the same shape (unlike the chat endpoint).\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique identifier for the completion."
+          },
+          "choices": {
+            "type": "array",
+            "description": "The list of completion choices the model generated for the input prompt.",
+            "items": {
+              "type": "object",
+              "required": [
+                "finish_reason",
+                "index",
+                "logprobs",
+                "text"
+              ],
+              "properties": {
+                "finish_reason": {
+                  "type": "string",
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\nor `content_filter` if content was omitted due to a flag from our content filters.\n",
+                  "enum": [
+                    "stop",
+                    "length",
+                    "content_filter"
+                  ]
+                },
+                "index": {
+                  "type": "integer"
+                },
+                "logprobs": {
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "text_offset": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      }
+                    },
+                    "token_logprobs": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "tokens": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "top_logprobs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                },
+                "text": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "created": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) of when the completion was created."
+          },
+          "model": {
+            "type": "string",
+            "description": "The model used for completion."
+          },
+          "system_fingerprint": {
+            "type": "string",
+            "description": "This fingerprint represents the backend configuration that the model runs with.\n\nCan be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.\n"
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always \"text_completion\"",
+            "enum": [
+              "text_completion"
+            ]
+          },
+          "usage": {
+            "$ref": "#/components/schemas/CompletionUsage"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created",
+          "model",
+          "choices"
+        ],
+        "x-oaiMeta": {
+          "name": "The completion object",
+          "legacy": true,
+          "example": "{\n  \"id\": \"cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7\",\n  \"object\": \"text_completion\",\n  \"created\": 1589478378,\n  \"model\": \"gpt-4-turbo\",\n  \"choices\": [\n    {\n      \"text\": \"\\n\\nThis is indeed a test\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": \"length\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 5,\n    \"completion_tokens\": 7,\n    \"total_tokens\": 12\n  }\n}\n"
+        }
+      },
+      "ChatCompletionRequestMessageContentPart": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartImage"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "ChatCompletionRequestMessageContentPartImage": {
+        "type": "object",
+        "title": "Image content part",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "image_url"
+            ],
+            "description": "The type of the content part."
+          },
+          "image_url": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Either a URL of the image or the base64 encoded image data.",
+                "format": "uri"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Specifies the detail level of the image. Learn more in the [Vision guide](/docs/guides/vision/low-or-high-fidelity-image-understanding).",
+                "enum": [
+                  "auto",
+                  "low",
+                  "high"
+                ],
+                "default": "auto"
+              }
+            },
+            "required": [
+              "url"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "image_url"
+        ]
+      },
+      "ChatCompletionRequestMessageContentPartText": {
+        "type": "object",
+        "title": "Text content part",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "text"
+            ],
+            "description": "The type of the content part."
+          },
+          "text": {
+            "type": "string",
+            "description": "The text content."
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ]
+      },
+      "ChatCompletionRequestMessage": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestSystemMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestUserMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestAssistantMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestToolMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestFunctionMessage"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "ChatCompletionRequestSystemMessage": {
+        "type": "object",
+        "title": "System message",
+        "properties": {
+          "content": {
+            "description": "The contents of the system message.",
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "system"
+            ],
+            "description": "The role of the messages author, in this case `system`."
+          },
+          "name": {
+            "type": "string",
+            "description": "An optional name for the participant. Provides the model information to differentiate between participants of the same role."
+          }
+        },
+        "required": [
+          "content",
+          "role"
+        ]
+      },
+      "ChatCompletionRequestUserMessage": {
+        "type": "object",
+        "title": "User message",
+        "properties": {
+          "content": {
+            "description": "The contents of the user message.\n",
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "The text contents of the message.",
+                "title": "Text content"
+              },
+              {
+                "type": "array",
+                "description": "An array of content parts with a defined type, each can be of type `text` or `image_url` when passing in images. You can pass multiple images by adding multiple `image_url` content parts. Image input is only supported when using the `gpt-4o` model.",
+                "title": "Array of content parts",
+                "items": {
+                  "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPart"
+                },
+                "minItems": 1
+              }
+            ],
+            "x-oaiExpandable": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user"
+            ],
+            "description": "The role of the messages author, in this case `user`."
+          },
+          "name": {
+            "type": "string",
+            "description": "An optional name for the participant. Provides the model information to differentiate between participants of the same role."
+          }
+        },
+        "required": [
+          "content",
+          "role"
+        ]
+      },
+      "ChatCompletionRequestAssistantMessage": {
+        "type": "object",
+        "title": "Assistant message",
+        "properties": {
+          "content": {
+            "nullable": true,
+            "type": "string",
+            "description": "The contents of the assistant message. Required unless `tool_calls` or `function_call` is specified.\n"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "assistant"
+            ],
+            "description": "The role of the messages author, in this case `assistant`."
+          },
+          "name": {
+            "type": "string",
+            "description": "An optional name for the participant. Provides the model information to differentiate between participants of the same role."
+          },
+          "tool_calls": {
+            "$ref": "#/components/schemas/ChatCompletionMessageToolCalls"
+          },
+          "function_call": {
+            "type": "object",
+            "deprecated": true,
+            "description": "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model.",
+            "nullable": true,
+            "properties": {
+              "arguments": {
+                "type": "string",
+                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function."
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the function to call."
+              }
+            },
+            "required": [
+              "arguments",
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "role"
+        ]
+      },
+      "FineTuneChatCompletionRequestAssistantMessage": {
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Assistant message",
+            "deprecated": false,
+            "properties": {
+              "weight": {
+                "type": "integer",
+                "enum": [
+                  0,
+                  1
+                ],
+                "description": "Controls whether the assistant message is trained against (0 or 1)"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestAssistantMessage"
+          }
+        ],
+        "required": [
+          "role"
+        ]
+      },
+      "ChatCompletionRequestToolMessage": {
+        "type": "object",
+        "title": "Tool message",
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "tool"
+            ],
+            "description": "The role of the messages author, in this case `tool`."
+          },
+          "content": {
+            "type": "string",
+            "description": "The contents of the tool message."
+          },
+          "tool_call_id": {
+            "type": "string",
+            "description": "Tool call that this message is responding to."
+          }
+        },
+        "required": [
+          "role",
+          "content",
+          "tool_call_id"
+        ]
+      },
+      "ChatCompletionRequestFunctionMessage": {
+        "type": "object",
+        "title": "Function message",
+        "deprecated": true,
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "function"
+            ],
+            "description": "The role of the messages author, in this case `function`."
+          },
+          "content": {
+            "nullable": true,
+            "type": "string",
+            "description": "The contents of the function message."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to call."
+          }
+        },
+        "required": [
+          "role",
+          "content",
+          "name"
+        ]
+      },
+      "FunctionParameters": {
+        "type": "object",
+        "description": "The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format. \n\nOmitting `parameters` defines a function with an empty parameter list.",
+        "additionalProperties": true
+      },
+      "ChatCompletionFunctions": {
+        "type": "object",
+        "deprecated": true,
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A description of what the function does, used by the model to choose when and how to call the function."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64."
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/FunctionParameters"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "ChatCompletionFunctionCallOption": {
+        "type": "object",
+        "description": "Specifying a particular function via `{\"name\": \"my_function\"}` forces the model to call that function.\n",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the function to call."
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "ChatCompletionTool": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "function"
+            ],
+            "description": "The type of the tool. Currently, only `function` is supported."
+          },
+          "function": {
+            "$ref": "#/components/schemas/FunctionObject"
+          }
+        },
+        "required": [
+          "type",
+          "function"
+        ]
+      },
+      "FunctionObject": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A description of what the function does, used by the model to choose when and how to call the function."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64."
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/FunctionParameters"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "ChatCompletionToolChoiceOption": {
+        "description": "Controls which (if any) tool is called by the model.\n`none` means the model will not call any tool and instead generates a message.\n`auto` means the model can pick between generating a message or calling one or more tools.\n`required` means the model must call one or more tools.\nSpecifying a particular tool via `{\"type\": \"function\", \"function\": {\"name\": \"my_function\"}}` forces the model to call that tool.\n\n`none` is the default when no tools are present. `auto` is the default if tools are present.\n",
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "`none` means the model will not call any tool and instead generates a message. `auto` means the model can pick between generating a message or calling one or more tools. `required` means the model must call one or more tools.\n",
+            "enum": [
+              "none",
+              "auto",
+              "required"
+            ]
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionNamedToolChoice"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "ChatCompletionNamedToolChoice": {
+        "type": "object",
+        "description": "Specifies a tool the model should use. Use to force the model to call a specific function.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "function"
+            ],
+            "description": "The type of the tool. Currently, only `function` is supported."
+          },
+          "function": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the function to call."
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "function"
+        ]
+      },
+      "ParallelToolCalls": {
+        "description": "Whether to enable [parallel function calling](/docs/guides/function-calling/parallel-function-calling) during tool use.",
+        "type": "boolean",
+        "default": true
+      },
+      "ChatCompletionMessageToolCalls": {
+        "type": "array",
+        "description": "The tool calls generated by the model, such as function calls.",
+        "items": {
+          "$ref": "#/components/schemas/ChatCompletionMessageToolCall"
+        }
+      },
+      "ChatCompletionMessageToolCall": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function"
+            ],
+            "description": "The type of the tool. Currently, only `function` is supported."
+          },
+          "function": {
+            "type": "object",
+            "description": "The function that the model called.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the function to call."
+              },
+              "arguments": {
+                "type": "string",
+                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function."
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "function"
+        ]
+      },
+      "ChatCompletionMessageToolCallChunk": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function"
+            ],
+            "description": "The type of the tool. Currently, only `function` is supported."
+          },
+          "function": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the function to call."
+              },
+              "arguments": {
+                "type": "string",
+                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function."
+              }
+            }
+          }
+        },
+        "required": [
+          "index"
+        ]
+      },
+      "ChatCompletionRole": {
+        "type": "string",
+        "description": "The role of the author of a message",
+        "enum": [
+          "system",
+          "user",
+          "assistant",
+          "tool",
+          "function"
+        ]
+      },
+      "ChatCompletionStreamOptions": {
+        "description": "Options for streaming response. Only set this when you set `stream: true`.\n",
+        "type": "object",
+        "nullable": true,
+        "default": null,
+        "properties": {
+          "include_usage": {
+            "type": "boolean",
+            "description": "If set, an additional chunk will be streamed before the `data: [DONE]` message. The `usage` field on this chunk shows the token usage statistics for the entire request, and the `choices` field will always be an empty array. All other chunks will also include a `usage` field, but with a null value.\n"
+          }
+        }
+      },
+      "ChatCompletionResponseMessage": {
+        "type": "object",
+        "description": "A chat completion message generated by the model.",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "The contents of the message.",
+            "nullable": true
+          },
+          "tool_calls": {
+            "$ref": "#/components/schemas/ChatCompletionMessageToolCalls"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "assistant"
+            ],
+            "description": "The role of the author of this message."
+          },
+          "function_call": {
+            "type": "object",
+            "deprecated": true,
+            "description": "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model.",
+            "properties": {
+              "arguments": {
+                "type": "string",
+                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function."
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the function to call."
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ]
+      },
+      "ChatCompletionStreamResponseDelta": {
+        "type": "object",
+        "description": "A chat completion delta generated by streamed model responses.",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "The contents of the chunk message.",
+            "nullable": true
+          },
+          "function_call": {
+            "deprecated": true,
+            "type": "object",
+            "description": "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model.",
+            "properties": {
+              "arguments": {
+                "type": "string",
+                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function."
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the function to call."
+              }
+            }
+          },
+          "tool_calls": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionMessageToolCallChunk"
+            }
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "system",
+              "user",
+              "assistant",
+              "tool"
+            ],
+            "description": "The role of the author of this message."
+          }
+        }
+      },
+      "CreateChatCompletionRequest": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "description": "A list of messages comprising the conversation so far. [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionRequestMessage"
+            }
+          },
+          "model": {
+            "description": "ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.",
+            "example": "gpt-4-turbo",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "gpt-4o",
+                  "gpt-4o-2024-05-13",
+                  "gpt-4o-mini",
+                  "gpt-4o-mini-2024-07-18",
+                  "gpt-4-turbo",
+                  "gpt-4-turbo-2024-04-09",
+                  "gpt-4-0125-preview",
+                  "gpt-4-turbo-preview",
+                  "gpt-4-1106-preview",
+                  "gpt-4-vision-preview",
+                  "gpt-4",
+                  "gpt-4-0314",
+                  "gpt-4-0613",
+                  "gpt-4-32k",
+                  "gpt-4-32k-0314",
+                  "gpt-4-32k-0613",
+                  "gpt-3.5-turbo",
+                  "gpt-3.5-turbo-16k",
+                  "gpt-3.5-turbo-0301",
+                  "gpt-3.5-turbo-0613",
+                  "gpt-3.5-turbo-1106",
+                  "gpt-3.5-turbo-0125",
+                  "gpt-3.5-turbo-16k-0613"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          },
+          "frequency_penalty": {
+            "type": "number",
+            "default": 0,
+            "minimum": -2,
+            "maximum": 2,
+            "nullable": true,
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.\n\n[See more information about frequency and presence penalties.](/docs/guides/text-generation/parameter-details)\n"
+          },
+          "logit_bias": {
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "default": null,
+            "nullable": true,
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Modify the likelihood of specified tokens appearing in the completion.\n\nAccepts a JSON object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.\n"
+          },
+          "logprobs": {
+            "description": "Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the `content` of `message`.",
+            "type": "boolean",
+            "default": false,
+            "nullable": true
+          },
+          "top_logprobs": {
+            "description": "An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. `logprobs` must be set to `true` if this parameter is used.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 20,
+            "nullable": true
+          },
+          "max_tokens": {
+            "description": "The maximum number of [tokens](/tokenizer) that can be generated in the chat completion.\n\nThe total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.\n",
+            "type": "integer",
+            "nullable": true
+          },
+          "n": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 128,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep `n` as `1` to minimize costs."
+          },
+          "presence_penalty": {
+            "type": "number",
+            "default": 0,
+            "minimum": -2,
+            "maximum": 2,
+            "nullable": true,
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.\n\n[See more information about frequency and presence penalties.](/docs/guides/text-generation/parameter-details)\n"
+          },
+          "response_format": {
+            "type": "object",
+            "description": "An object specifying the format that the model must output. Compatible with [GPT-4 Turbo](/docs/models/gpt-4-and-gpt-4-turbo) and all GPT-3.5 Turbo models newer than `gpt-3.5-turbo-1106`.\n\nSetting to `{ \"type\": \"json_object\" }` enables JSON mode, which guarantees the message the model generates is valid JSON.\n\n**Important:** when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly \"stuck\" request. Also note that the message content may be partially cut off if `finish_reason=\"length\"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length.\n",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "json_object"
+                ],
+                "example": "json_object",
+                "default": "text",
+                "description": "Must be one of `text` or `json_object`."
+              }
+            }
+          },
+          "seed": {
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000,
+            "nullable": true,
+            "description": "This feature is in Beta.\nIf specified, our system will make a best effort to sample deterministically, such that repeated requests with the same `seed` and parameters should return the same result.\nDeterminism is not guaranteed, and you should refer to the `system_fingerprint` response parameter to monitor changes in the backend.\n",
+            "x-oaiMeta": {
+              "beta": true
+            }
+          },
+          "service_tier": {
+            "description": "Specifies the latency tier to use for processing the request. This parameter is relevant for customers subscribed to the scale tier service:\n  - If set to 'auto', the system will utilize scale tier credits until they are exhausted.\n  - If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.\n  - When not set, the default behavior is 'auto'.\n\n  When this parameter is set, the response body will include the `service_tier` utilized.\n",
+            "type": "string",
+            "enum": [
+              "auto",
+              "default"
+            ],
+            "nullable": true,
+            "default": null
+          },
+          "stop": {
+            "description": "Up to 4 sequences where the API will stop generating further tokens.\n",
+            "default": null,
+            "oneOf": [
+              {
+                "type": "string",
+                "nullable": true
+              },
+              {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 4,
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "stream": {
+            "description": "If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).\n",
+            "type": "boolean",
+            "nullable": true,
+            "default": false
+          },
+          "stream_options": {
+            "$ref": "#/components/schemas/ChatCompletionStreamOptions"
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\n\nWe generally recommend altering this or `top_p` but not both.\n"
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or `temperature` but not both.\n"
+          },
+          "tools": {
+            "type": "array",
+            "description": "A list of tools the model may call. Currently, only functions are supported as a tool. Use this to provide a list of functions the model may generate JSON inputs for. A max of 128 functions are supported.\n",
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionTool"
+            }
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/ChatCompletionToolChoiceOption"
+          },
+          "parallel_tool_calls": {
+            "$ref": "#/components/schemas/ParallelToolCalls"
+          },
+          "user": {
+            "type": "string",
+            "example": "user-1234",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n"
+          },
+          "function_call": {
+            "deprecated": true,
+            "description": "Deprecated in favor of `tool_choice`.\n\nControls which (if any) function is called by the model.\n`none` means the model will not call a function and instead generates a message.\n`auto` means the model can pick between generating a message or calling a function.\nSpecifying a particular function via `{\"name\": \"my_function\"}` forces the model to call that function.\n\n`none` is the default when no functions are present. `auto` is the default if functions are present.\n",
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "`none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function.\n",
+                "enum": [
+                  "none",
+                  "auto"
+                ]
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionFunctionCallOption"
+              }
+            ],
+            "x-oaiExpandable": true
+          },
+          "functions": {
+            "deprecated": true,
+            "description": "Deprecated in favor of `tools`.\n\nA list of functions the model may generate JSON inputs for.\n",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 128,
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionFunctions"
+            }
+          }
+        },
+        "required": [
+          "model",
+          "messages"
+        ]
+      },
+      "CreateChatCompletionResponse": {
+        "type": "object",
+        "description": "Represents a chat completion response returned by model, based on the provided input.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique identifier for the chat completion."
+          },
+          "choices": {
+            "type": "array",
+            "description": "A list of chat completion choices. Can be more than one if `n` is greater than 1.",
+            "items": {
+              "type": "object",
+              "required": [
+                "finish_reason",
+                "index",
+                "message",
+                "logprobs"
+              ],
+              "properties": {
+                "finish_reason": {
+                  "type": "string",
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\n",
+                  "enum": [
+                    "stop",
+                    "length",
+                    "tool_calls",
+                    "content_filter",
+                    "function_call"
+                  ]
+                },
+                "index": {
+                  "type": "integer",
+                  "description": "The index of the choice in the list of choices."
+                },
+                "message": {
+                  "$ref": "#/components/schemas/ChatCompletionResponseMessage"
+                },
+                "logprobs": {
+                  "description": "Log probability information for the choice.",
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "content": {
+                      "description": "A list of message content tokens with log probability information.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ChatCompletionTokenLogprob"
+                      },
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "content"
+                  ]
+                }
+              }
+            }
+          },
+          "created": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) of when the chat completion was created."
+          },
+          "model": {
+            "type": "string",
+            "description": "The model used for the chat completion."
+          },
+          "service_tier": {
+            "description": "The service tier used for processing the request. This field is only included if the `service_tier` parameter is specified in the request.",
+            "type": "string",
+            "enum": [
+              "scale",
+              "default"
+            ],
+            "example": "scale",
+            "nullable": true
+          },
+          "system_fingerprint": {
+            "type": "string",
+            "description": "This fingerprint represents the backend configuration that the model runs with.\n\nCan be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.\n"
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always `chat.completion`.",
+            "enum": [
+              "chat.completion"
+            ]
+          },
+          "usage": {
+            "$ref": "#/components/schemas/CompletionUsage"
+          }
+        },
+        "required": [
+          "choices",
+          "created",
+          "id",
+          "model",
+          "object"
+        ],
+        "x-oaiMeta": {
+          "name": "The chat completion object",
+          "group": "chat",
+          "example": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"model\": \"gpt-4o-mini\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nHello there, how may I assist you today?\",\n    },\n    \"logprobs\": null,\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n"
+        }
+      },
+      "CreateChatCompletionFunctionResponse": {
+        "type": "object",
+        "description": "Represents a chat completion response returned by model, based on the provided input.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique identifier for the chat completion."
+          },
+          "choices": {
+            "type": "array",
+            "description": "A list of chat completion choices. Can be more than one if `n` is greater than 1.",
+            "items": {
+              "type": "object",
+              "required": [
+                "finish_reason",
+                "index",
+                "message",
+                "logprobs"
+              ],
+              "properties": {
+                "finish_reason": {
+                  "type": "string",
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence, `length` if the maximum number of tokens specified in the request was reached, `content_filter` if content was omitted due to a flag from our content filters, or `function_call` if the model called a function.\n",
+                  "enum": [
+                    "stop",
+                    "length",
+                    "function_call",
+                    "content_filter"
+                  ]
+                },
+                "index": {
+                  "type": "integer",
+                  "description": "The index of the choice in the list of choices."
+                },
+                "message": {
+                  "$ref": "#/components/schemas/ChatCompletionResponseMessage"
+                }
+              }
+            }
+          },
+          "created": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) of when the chat completion was created."
+          },
+          "model": {
+            "type": "string",
+            "description": "The model used for the chat completion."
+          },
+          "system_fingerprint": {
+            "type": "string",
+            "description": "This fingerprint represents the backend configuration that the model runs with.\n\nCan be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.\n"
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always `chat.completion`.",
+            "enum": [
+              "chat.completion"
+            ]
+          },
+          "usage": {
+            "$ref": "#/components/schemas/CompletionUsage"
+          }
+        },
+        "required": [
+          "choices",
+          "created",
+          "id",
+          "model",
+          "object"
+        ],
+        "x-oaiMeta": {
+          "name": "The chat completion object",
+          "group": "chat",
+          "example": "{\n  \"id\": \"chatcmpl-abc123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1699896916,\n  \"model\": \"gpt-4o-mini\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n            \"id\": \"call_abc123\",\n            \"type\": \"function\",\n            \"function\": {\n              \"name\": \"get_current_weather\",\n              \"arguments\": \"{\\n\\\"location\\\": \\\"Boston, MA\\\"\\n}\"\n            }\n          }\n        ]\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 82,\n    \"completion_tokens\": 17,\n    \"total_tokens\": 99\n  }\n}\n"
+        }
+      },
+      "ChatCompletionTokenLogprob": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "description": "The token.",
+            "type": "string"
+          },
+          "logprob": {
+            "description": "The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely.",
+            "type": "number"
+          },
+          "bytes": {
+            "description": "A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token.",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true
+          },
+          "top_logprobs": {
+            "description": "List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "description": "The token.",
+                  "type": "string"
+                },
+                "logprob": {
+                  "description": "The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely.",
+                  "type": "number"
+                },
+                "bytes": {
+                  "description": "A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "nullable": true
+                }
+              },
+              "required": [
+                "token",
+                "logprob",
+                "bytes"
+              ]
+            }
+          }
+        },
+        "required": [
+          "token",
+          "logprob",
+          "bytes",
+          "top_logprobs"
+        ]
+      },
+      "ListPaginatedFineTuningJobsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FineTuningJob"
+            }
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ]
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ]
+      },
+      "CreateChatCompletionStreamResponse": {
+        "type": "object",
+        "description": "Represents a streamed chunk of a chat completion response returned by model, based on the provided input.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique identifier for the chat completion. Each chunk has the same ID."
+          },
+          "choices": {
+            "type": "array",
+            "description": "A list of chat completion choices. Can contain more than one elements if `n` is greater than 1. Can also be empty for the\nlast chunk if you set `stream_options: {\"include_usage\": true}`.\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "delta",
+                "finish_reason",
+                "index"
+              ],
+              "properties": {
+                "delta": {
+                  "$ref": "#/components/schemas/ChatCompletionStreamResponseDelta"
+                },
+                "logprobs": {
+                  "description": "Log probability information for the choice.",
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "content": {
+                      "description": "A list of message content tokens with log probability information.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ChatCompletionTokenLogprob"
+                      },
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "content"
+                  ]
+                },
+                "finish_reason": {
+                  "type": "string",
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\n",
+                  "enum": [
+                    "stop",
+                    "length",
+                    "tool_calls",
+                    "content_filter",
+                    "function_call"
+                  ],
+                  "nullable": true
+                },
+                "index": {
+                  "type": "integer",
+                  "description": "The index of the choice in the list of choices."
+                }
+              }
+            }
+          },
+          "created": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp."
+          },
+          "model": {
+            "type": "string",
+            "description": "The model to generate the completion."
+          },
+          "service_tier": {
+            "description": "The service tier used for processing the request. This field is only included if the `service_tier` parameter is specified in the request.",
+            "type": "string",
+            "enum": [
+              "scale",
+              "default"
+            ],
+            "example": "scale",
+            "nullable": true
+          },
+          "system_fingerprint": {
+            "type": "string",
+            "description": "This fingerprint represents the backend configuration that the model runs with.\nCan be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.\n"
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always `chat.completion.chunk`.",
+            "enum": [
+              "chat.completion.chunk"
+            ]
+          },
+          "usage": {
+            "type": "object",
+            "description": "An optional field that will only be present when you set `stream_options: {\"include_usage\": true}` in your request.\nWhen present, it contains a null value except for the last chunk which contains the token usage statistics for the entire request.\n",
+            "properties": {
+              "completion_tokens": {
+                "type": "integer",
+                "description": "Number of tokens in the generated completion."
+              },
+              "prompt_tokens": {
+                "type": "integer",
+                "description": "Number of tokens in the prompt."
+              },
+              "total_tokens": {
+                "type": "integer",
+                "description": "Total number of tokens used in the request (prompt + completion)."
+              }
+            },
+            "required": [
+              "prompt_tokens",
+              "completion_tokens",
+              "total_tokens"
+            ]
+          }
+        },
+        "required": [
+          "choices",
+          "created",
+          "id",
+          "model",
+          "object"
+        ],
+        "x-oaiMeta": {
+          "name": "The chat completion chunk object",
+          "group": "chat",
+          "example": "{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-4o-mini\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"logprobs\":null,\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-4o-mini\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"logprobs\":null,\"finish_reason\":null}]}\n\n....\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-4o-mini\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}]}\n"
+        }
+      },
+      "CreateChatCompletionImageResponse": {
+        "type": "object",
+        "description": "Represents a streamed chunk of a chat completion response returned by model, based on the provided input.",
+        "x-oaiMeta": {
+          "name": "The chat completion chunk object",
+          "group": "chat",
+          "example": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"model\": \"gpt-4o-mini\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nThis image shows a wooden boardwalk extending through a lush green marshland.\",\n    },\n    \"logprobs\": null,\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n"
+        }
+      },
+      "CreateImageRequest": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "description": "A text description of the desired image(s). The maximum length is 1000 characters for `dall-e-2` and 4000 characters for `dall-e-3`.",
+            "type": "string",
+            "example": "A cute baby sea otter"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "dall-e-2",
+                  "dall-e-3"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string",
+            "default": "dall-e-2",
+            "example": "dall-e-3",
+            "nullable": true,
+            "description": "The model to use for image generation."
+          },
+          "n": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "The number of images to generate. Must be between 1 and 10. For `dall-e-3`, only `n=1` is supported."
+          },
+          "quality": {
+            "type": "string",
+            "enum": [
+              "standard",
+              "hd"
+            ],
+            "default": "standard",
+            "example": "standard",
+            "description": "The quality of the image that will be generated. `hd` creates images with finer details and greater consistency across the image. This param is only supported for `dall-e-3`."
+          },
+          "response_format": {
+            "type": "string",
+            "enum": [
+              "url",
+              "b64_json"
+            ],
+            "default": "url",
+            "example": "url",
+            "nullable": true,
+            "description": "The format in which the generated images are returned. Must be one of `url` or `b64_json`. URLs are only valid for 60 minutes after the image has been generated."
+          },
+          "size": {
+            "type": "string",
+            "enum": [
+              "256x256",
+              "512x512",
+              "1024x1024",
+              "1792x1024",
+              "1024x1792"
+            ],
+            "default": "1024x1024",
+            "example": "1024x1024",
+            "nullable": true,
+            "description": "The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024` for `dall-e-2`. Must be one of `1024x1024`, `1792x1024`, or `1024x1792` for `dall-e-3` models."
+          },
+          "style": {
+            "type": "string",
+            "enum": [
+              "vivid",
+              "natural"
+            ],
+            "default": "vivid",
+            "example": "vivid",
+            "nullable": true,
+            "description": "The style of the generated images. Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images. This param is only supported for `dall-e-3`."
+          },
+          "user": {
+            "type": "string",
+            "example": "user-1234",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n"
+          }
+        },
+        "required": [
+          "prompt"
+        ]
+      },
+      "ImagesResponse": {
+        "properties": {
+          "created": {
+            "type": "integer"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Image"
+            }
+          }
+        },
+        "required": [
+          "created",
+          "data"
+        ]
+      },
+      "Image": {
+        "type": "object",
+        "description": "Represents the url or the content of an image generated by the OpenAI API.",
+        "properties": {
+          "b64_json": {
+            "type": "string",
+            "description": "The base64-encoded JSON of the generated image, if `response_format` is `b64_json`."
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL of the generated image, if `response_format` is `url` (default)."
+          },
+          "revised_prompt": {
+            "type": "string",
+            "description": "The prompt that was used to generate the image, if there was any revision to the prompt."
+          }
+        },
+        "x-oaiMeta": {
+          "name": "The image object",
+          "example": "{\n  \"url\": \"...\",\n  \"revised_prompt\": \"...\"\n}\n"
+        }
+      },
+      "CreateImageEditRequest": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "description": "The image to edit. Must be a valid PNG file, less than 4MB, and square. If mask is not provided, image must have transparency, which will be used as the mask.",
+            "type": "string",
+            "format": "binary"
+          },
+          "prompt": {
+            "description": "A text description of the desired image(s). The maximum length is 1000 characters.",
+            "type": "string",
+            "example": "A cute baby sea otter wearing a beret"
+          },
+          "mask": {
+            "description": "An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. Must be a valid PNG file, less than 4MB, and have the same dimensions as `image`.",
+            "type": "string",
+            "format": "binary"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "dall-e-2"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string",
+            "default": "dall-e-2",
+            "example": "dall-e-2",
+            "nullable": true,
+            "description": "The model to use for image generation. Only `dall-e-2` is supported at this time."
+          },
+          "n": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "The number of images to generate. Must be between 1 and 10."
+          },
+          "size": {
+            "type": "string",
+            "enum": [
+              "256x256",
+              "512x512",
+              "1024x1024"
+            ],
+            "default": "1024x1024",
+            "example": "1024x1024",
+            "nullable": true,
+            "description": "The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`."
+          },
+          "response_format": {
+            "type": "string",
+            "enum": [
+              "url",
+              "b64_json"
+            ],
+            "default": "url",
+            "example": "url",
+            "nullable": true,
+            "description": "The format in which the generated images are returned. Must be one of `url` or `b64_json`. URLs are only valid for 60 minutes after the image has been generated."
+          },
+          "user": {
+            "type": "string",
+            "example": "user-1234",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n"
+          }
+        },
+        "required": [
+          "prompt",
+          "image"
+        ]
+      },
+      "CreateImageVariationRequest": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "description": "The image to use as the basis for the variation(s). Must be a valid PNG file, less than 4MB, and square.",
+            "type": "string",
+            "format": "binary"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "dall-e-2"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string",
+            "default": "dall-e-2",
+            "example": "dall-e-2",
+            "nullable": true,
+            "description": "The model to use for image generation. Only `dall-e-2` is supported at this time."
+          },
+          "n": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "The number of images to generate. Must be between 1 and 10. For `dall-e-3`, only `n=1` is supported."
+          },
+          "response_format": {
+            "type": "string",
+            "enum": [
+              "url",
+              "b64_json"
+            ],
+            "default": "url",
+            "example": "url",
+            "nullable": true,
+            "description": "The format in which the generated images are returned. Must be one of `url` or `b64_json`. URLs are only valid for 60 minutes after the image has been generated."
+          },
+          "size": {
+            "type": "string",
+            "enum": [
+              "256x256",
+              "512x512",
+              "1024x1024"
+            ],
+            "default": "1024x1024",
+            "example": "1024x1024",
+            "nullable": true,
+            "description": "The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`."
+          },
+          "user": {
+            "type": "string",
+            "example": "user-1234",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n"
+          }
+        },
+        "required": [
+          "image"
+        ]
+      },
+      "CreateModerationRequest": {
+        "type": "object",
+        "properties": {
+          "input": {
+            "description": "The input text to classify",
+            "oneOf": [
+              {
+                "type": "string",
+                "default": "",
+                "example": "I want to kill them."
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "default": "",
+                  "example": "I want to kill them."
+                }
+              }
+            ]
+          },
+          "model": {
+            "description": "Two content moderations models are available: `text-moderation-stable` and `text-moderation-latest`.\n\nThe default is `text-moderation-latest` which will be automatically upgraded over time. This ensures you are always using our most accurate model. If you use `text-moderation-stable`, we will provide advanced notice before updating the model. Accuracy of `text-moderation-stable` may be slightly lower than for `text-moderation-latest`.\n",
+            "nullable": false,
+            "default": "text-moderation-latest",
+            "example": "text-moderation-stable",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "text-moderation-latest",
+                  "text-moderation-stable"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          }
+        },
+        "required": [
+          "input"
+        ]
+      },
+      "CreateModerationResponse": {
+        "type": "object",
+        "description": "Represents if a given text input is potentially harmful.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier for the moderation request."
+          },
+          "model": {
+            "type": "string",
+            "description": "The model used to generate the moderation results."
+          },
+          "results": {
+            "type": "array",
+            "description": "A list of moderation objects.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "flagged": {
+                  "type": "boolean",
+                  "description": "Whether any of the below categories are flagged."
+                },
+                "categories": {
+                  "type": "object",
+                  "description": "A list of the categories, and whether they are flagged or not.",
+                  "properties": {
+                    "hate": {
+                      "type": "boolean",
+                      "description": "Content that expresses, incites, or promotes hate based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste. Hateful content aimed at non-protected groups (e.g., chess players) is harassment."
+                    },
+                    "hate/threatening": {
+                      "type": "boolean",
+                      "description": "Hateful content that also includes violence or serious harm towards the targeted group based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste."
+                    },
+                    "harassment": {
+                      "type": "boolean",
+                      "description": "Content that expresses, incites, or promotes harassing language towards any target."
+                    },
+                    "harassment/threatening": {
+                      "type": "boolean",
+                      "description": "Harassment content that also includes violence or serious harm towards any target."
+                    },
+                    "self-harm": {
+                      "type": "boolean",
+                      "description": "Content that promotes, encourages, or depicts acts of self-harm, such as suicide, cutting, and eating disorders."
+                    },
+                    "self-harm/intent": {
+                      "type": "boolean",
+                      "description": "Content where the speaker expresses that they are engaging or intend to engage in acts of self-harm, such as suicide, cutting, and eating disorders."
+                    },
+                    "self-harm/instructions": {
+                      "type": "boolean",
+                      "description": "Content that encourages performing acts of self-harm, such as suicide, cutting, and eating disorders, or that gives instructions or advice on how to commit such acts."
+                    },
+                    "sexual": {
+                      "type": "boolean",
+                      "description": "Content meant to arouse sexual excitement, such as the description of sexual activity, or that promotes sexual services (excluding sex education and wellness)."
+                    },
+                    "sexual/minors": {
+                      "type": "boolean",
+                      "description": "Sexual content that includes an individual who is under 18 years old."
+                    },
+                    "violence": {
+                      "type": "boolean",
+                      "description": "Content that depicts death, violence, or physical injury."
+                    },
+                    "violence/graphic": {
+                      "type": "boolean",
+                      "description": "Content that depicts death, violence, or physical injury in graphic detail."
+                    }
+                  },
+                  "required": [
+                    "hate",
+                    "hate/threatening",
+                    "harassment",
+                    "harassment/threatening",
+                    "self-harm",
+                    "self-harm/intent",
+                    "self-harm/instructions",
+                    "sexual",
+                    "sexual/minors",
+                    "violence",
+                    "violence/graphic"
+                  ]
+                },
+                "category_scores": {
+                  "type": "object",
+                  "description": "A list of the categories along with their scores as predicted by model.",
+                  "properties": {
+                    "hate": {
+                      "type": "number",
+                      "description": "The score for the category 'hate'."
+                    },
+                    "hate/threatening": {
+                      "type": "number",
+                      "description": "The score for the category 'hate/threatening'."
+                    },
+                    "harassment": {
+                      "type": "number",
+                      "description": "The score for the category 'harassment'."
+                    },
+                    "harassment/threatening": {
+                      "type": "number",
+                      "description": "The score for the category 'harassment/threatening'."
+                    },
+                    "self-harm": {
+                      "type": "number",
+                      "description": "The score for the category 'self-harm'."
+                    },
+                    "self-harm/intent": {
+                      "type": "number",
+                      "description": "The score for the category 'self-harm/intent'."
+                    },
+                    "self-harm/instructions": {
+                      "type": "number",
+                      "description": "The score for the category 'self-harm/instructions'."
+                    },
+                    "sexual": {
+                      "type": "number",
+                      "description": "The score for the category 'sexual'."
+                    },
+                    "sexual/minors": {
+                      "type": "number",
+                      "description": "The score for the category 'sexual/minors'."
+                    },
+                    "violence": {
+                      "type": "number",
+                      "description": "The score for the category 'violence'."
+                    },
+                    "violence/graphic": {
+                      "type": "number",
+                      "description": "The score for the category 'violence/graphic'."
+                    }
+                  },
+                  "required": [
+                    "hate",
+                    "hate/threatening",
+                    "harassment",
+                    "harassment/threatening",
+                    "self-harm",
+                    "self-harm/intent",
+                    "self-harm/instructions",
+                    "sexual",
+                    "sexual/minors",
+                    "violence",
+                    "violence/graphic"
+                  ]
+                }
+              },
+              "required": [
+                "flagged",
+                "categories",
+                "category_scores"
+              ]
+            }
+          }
+        },
+        "required": [
+          "id",
+          "model",
+          "results"
+        ],
+        "x-oaiMeta": {
+          "name": "The moderation object",
+          "example": "{\n  \"id\": \"modr-XXXXX\",\n  \"model\": \"text-moderation-005\",\n  \"results\": [\n    {\n      \"flagged\": true,\n      \"categories\": {\n        \"sexual\": false,\n        \"hate\": false,\n        \"harassment\": false,\n        \"self-harm\": false,\n        \"sexual/minors\": false,\n        \"hate/threatening\": false,\n        \"violence/graphic\": false,\n        \"self-harm/intent\": false,\n        \"self-harm/instructions\": false,\n        \"harassment/threatening\": true,\n        \"violence\": true,\n      },\n      \"category_scores\": {\n        \"sexual\": 1.2282071e-06,\n        \"hate\": 0.010696256,\n        \"harassment\": 0.29842457,\n        \"self-harm\": 1.5236925e-08,\n        \"sexual/minors\": 5.7246268e-08,\n        \"hate/threatening\": 0.0060676364,\n        \"violence/graphic\": 4.435014e-06,\n        \"self-harm/intent\": 8.098441e-10,\n        \"self-harm/instructions\": 2.8498655e-11,\n        \"harassment/threatening\": 0.63055265,\n        \"violence\": 0.99011886,\n      }\n    }\n  ]\n}\n"
+        }
+      },
+      "ListFilesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAIFile"
+            }
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ]
+          }
+        },
+        "required": [
+          "object",
+          "data"
+        ]
+      },
+      "CreateFileRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "file": {
+            "description": "The File object (not file name) to be uploaded.\n",
+            "type": "string",
+            "format": "binary"
+          },
+          "purpose": {
+            "description": "The intended purpose of the uploaded file.\n\nUse \"assistants\" for [Assistants](/docs/api-reference/assistants) and [Message](/docs/api-reference/messages) files, \"vision\" for Assistants image file inputs, \"batch\" for [Batch API](/docs/guides/batch), and \"fine-tune\" for [Fine-tuning](/docs/api-reference/fine-tuning).\n",
+            "type": "string",
+            "enum": [
+              "assistants",
+              "batch",
+              "fine-tune",
+              "vision"
+            ]
+          }
+        },
+        "required": [
+          "file",
+          "purpose"
+        ]
+      },
+      "DeleteFileResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "file"
+            ]
+          },
+          "deleted": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ]
+      },
+      "CreateUploadRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "filename": {
+            "description": "The name of the file to upload.\n",
+            "type": "string"
+          },
+          "purpose": {
+            "description": "The intended purpose of the uploaded file.\n\nSee the [documentation on File purposes](/docs/api-reference/files/create#files-create-purpose).\n",
+            "type": "string",
+            "enum": [
+              "assistants",
+              "batch",
+              "fine-tune",
+              "vision"
+            ]
+          },
+          "bytes": {
+            "description": "The number of bytes in the file you are uploading.\n",
+            "type": "integer"
+          },
+          "mime_type": {
+            "description": "The MIME type of the file.\n\nThis must fall within the supported MIME types for your file purpose. See the supported MIME types for assistants and vision.\n",
+            "type": "string"
+          }
+        },
+        "required": [
+          "filename",
+          "purpose",
+          "bytes",
+          "mime_type"
+        ]
+      },
+      "AddUploadPartRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "description": "The chunk of bytes for this Part.\n",
+            "type": "string",
+            "format": "binary"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CompleteUploadRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "part_ids": {
+            "type": "array",
+            "description": "The ordered list of Part IDs.\n",
+            "items": {
+              "type": "string"
+            }
+          },
+          "md5": {
+            "description": "The optional md5 checksum for the file contents to verify if the bytes uploaded matches what you expect.\n",
+            "type": "string"
+          }
+        },
+        "required": [
+          "part_ids"
+        ]
+      },
+      "CancelUploadRequest": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CreateFineTuningJobRequest": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "description": "The name of the model to fine-tune. You can select one of the\n[supported models](/docs/guides/fine-tuning/what-models-can-be-fine-tuned).\n",
+            "example": "gpt-3.5-turbo",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "babbage-002",
+                  "davinci-002",
+                  "gpt-3.5-turbo"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          },
+          "training_file": {
+            "description": "The ID of an uploaded file that contains training data.\n\nSee [upload file](/docs/api-reference/files/create) for how to upload a file.\n\nYour dataset must be formatted as a JSONL file. Additionally, you must upload your file with the purpose `fine-tune`.\n\nThe contents of the file should differ depending on if the model uses the [chat](/docs/api-reference/fine-tuning/chat-input) or [completions](/docs/api-reference/fine-tuning/completions-input) format.\n\nSee the [fine-tuning guide](/docs/guides/fine-tuning) for more details.\n",
+            "type": "string",
+            "example": "file-abc123"
+          },
+          "hyperparameters": {
+            "type": "object",
+            "description": "The hyperparameters used for the fine-tuning job.",
+            "properties": {
+              "batch_size": {
+                "description": "Number of examples in each batch. A larger batch size means that model parameters\nare updated less frequently, but with lower variance.\n",
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "auto"
+                    ]
+                  },
+                  {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 256
+                  }
+                ],
+                "default": "auto"
+              },
+              "learning_rate_multiplier": {
+                "description": "Scaling factor for the learning rate. A smaller learning rate may be useful to avoid\noverfitting.\n",
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "auto"
+                    ]
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  }
+                ],
+                "default": "auto"
+              },
+              "n_epochs": {
+                "description": "The number of epochs to train the model for. An epoch refers to one full cycle\nthrough the training dataset.\n",
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "auto"
+                    ]
+                  },
+                  {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50
+                  }
+                ],
+                "default": "auto"
+              }
+            }
+          },
+          "suffix": {
+            "description": "A string of up to 18 characters that will be added to your fine-tuned model name.\n\nFor example, a `suffix` of \"custom-model-name\" would produce a model name like `ft:gpt-3.5-turbo:openai:custom-model-name:7p4lURel`.\n",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 40,
+            "default": null,
+            "nullable": true
+          },
+          "validation_file": {
+            "description": "The ID of an uploaded file that contains validation data.\n\nIf you provide this file, the data is used to generate validation\nmetrics periodically during fine-tuning. These metrics can be viewed in\nthe fine-tuning results file.\nThe same data should not be present in both train and validation files.\n\nYour dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.\n\nSee the [fine-tuning guide](/docs/guides/fine-tuning) for more details.\n",
+            "type": "string",
+            "nullable": true,
+            "example": "file-abc123"
+          },
+          "integrations": {
+            "type": "array",
+            "description": "A list of integrations to enable for your fine-tuning job.",
+            "nullable": true,
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "wandb"
+              ],
+              "properties": {
+                "type": {
+                  "description": "The type of integration to enable. Currently, only \"wandb\" (Weights and Biases) is supported.\n",
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "wandb"
+                      ]
+                    }
+                  ]
+                },
+                "wandb": {
+                  "type": "object",
+                  "description": "The settings for your integration with Weights and Biases. This payload specifies the project that\nmetrics will be sent to. Optionally, you can set an explicit display name for your run, add tags\nto your run, and set a default entity (team, username, etc) to be associated with your run.\n",
+                  "required": [
+                    "project"
+                  ],
+                  "properties": {
+                    "project": {
+                      "description": "The name of the project that the new run will be created under.\n",
+                      "type": "string",
+                      "example": "my-wandb-project"
+                    },
+                    "name": {
+                      "description": "A display name to set for the run. If not set, we will use the Job ID as the name.\n",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "entity": {
+                      "description": "The entity to use for the run. This allows you to set the team or username of the WandB user that you would\nlike associated with the run. If not set, the default entity for the registered WandB API key is used.\n",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "tags": {
+                      "description": "A list of tags to be attached to the newly created run. These tags are passed through directly to WandB. Some\ndefault tags are generated by OpenAI: \"openai/finetune\", \"openai/{base-model}\", \"openai/{ftjob-abcdef}\".\n",
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "custom-tag"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "seed": {
+            "description": "The seed controls the reproducibility of the job. Passing in the same seed and job parameters should produce the same results, but may differ in rare cases.\nIf a seed is not specified, one will be generated for you.\n",
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 42
+          }
+        },
+        "required": [
+          "model",
+          "training_file"
+        ]
+      },
+      "ListFineTuningJobEventsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FineTuningJobEvent"
+            }
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ]
+          }
+        },
+        "required": [
+          "object",
+          "data"
+        ]
+      },
+      "ListFineTuningJobCheckpointsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FineTuningJobCheckpoint"
+            }
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ]
+          },
+          "first_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "last_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "has_more": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ]
+      },
+      "CreateEmbeddingRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "input": {
+            "description": "Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `text-embedding-ada-002`), cannot be an empty string, and any array must be 2048 dimensions or less. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.\n",
+            "example": "The quick brown fox jumped over the lazy dog",
+            "oneOf": [
+              {
+                "type": "string",
+                "title": "string",
+                "description": "The string that will be turned into an embedding.",
+                "default": "",
+                "example": "This is a test."
+              },
+              {
+                "type": "array",
+                "title": "array",
+                "description": "The array of strings that will be turned into an embedding.",
+                "minItems": 1,
+                "maxItems": 2048,
+                "items": {
+                  "type": "string",
+                  "default": "",
+                  "example": "['This is a test.']"
+                }
+              },
+              {
+                "type": "array",
+                "title": "array",
+                "description": "The array of integers that will be turned into an embedding.",
+                "minItems": 1,
+                "maxItems": 2048,
+                "items": {
+                  "type": "integer"
+                },
+                "example": "[1212, 318, 257, 1332, 13]"
+              },
+              {
+                "type": "array",
+                "title": "array",
+                "description": "The array of arrays containing integers that will be turned into an embedding.",
+                "minItems": 1,
+                "maxItems": 2048,
+                "items": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "example": "[[1212, 318, 257, 1332, 13]]"
+              }
+            ],
+            "x-oaiExpandable": true
+          },
+          "model": {
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n",
+            "example": "text-embedding-3-small",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "text-embedding-ada-002",
+                  "text-embedding-3-small",
+                  "text-embedding-3-large"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          },
+          "encoding_format": {
+            "description": "The format to return the embeddings in. Can be either `float` or [`base64`](https://pypi.org/project/pybase64/).",
+            "example": "float",
+            "default": "float",
+            "type": "string",
+            "enum": [
+              "float",
+              "base64"
+            ]
+          },
+          "dimensions": {
+            "description": "The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` and later models.\n",
+            "type": "integer",
+            "minimum": 1
+          },
+          "user": {
+            "type": "string",
+            "example": "user-1234",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n"
+          }
+        },
+        "required": [
+          "model",
+          "input"
+        ]
+      },
+      "CreateEmbeddingResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "The list of embeddings generated by the model.",
+            "items": {
+              "$ref": "#/components/schemas/Embedding"
+            }
+          },
+          "model": {
+            "type": "string",
+            "description": "The name of the model used to generate the embedding."
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always \"list\".",
+            "enum": [
+              "list"
+            ]
+          },
+          "usage": {
+            "type": "object",
+            "description": "The usage information for the request.",
+            "properties": {
+              "prompt_tokens": {
+                "type": "integer",
+                "description": "The number of tokens used by the prompt."
+              },
+              "total_tokens": {
+                "type": "integer",
+                "description": "The total number of tokens used by the request."
+              }
+            },
+            "required": [
+              "prompt_tokens",
+              "total_tokens"
+            ]
+          }
+        },
+        "required": [
+          "object",
+          "model",
+          "data",
+          "usage"
+        ]
+      },
+      "CreateTranscriptionRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "file": {
+            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n",
+            "type": "string",
+            "x-oaiTypeLabel": "file",
+            "format": "binary"
+          },
+          "model": {
+            "description": "ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.\n",
+            "example": "whisper-1",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "whisper-1"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          },
+          "language": {
+            "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.\n",
+            "type": "string"
+          },
+          "prompt": {
+            "description": "An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should match the audio language.\n",
+            "type": "string"
+          },
+          "response_format": {
+            "description": "The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.\n",
+            "type": "string",
+            "enum": [
+              "json",
+              "text",
+              "srt",
+              "verbose_json",
+              "vtt"
+            ],
+            "default": "json"
+          },
+          "temperature": {
+            "description": "The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.\n",
+            "type": "number",
+            "default": 0
+          },
+          "timestamp_granularities[]": {
+            "description": "The timestamp granularities to populate for this transcription. `response_format` must be set `verbose_json` to use timestamp granularities. Either or both of these options are supported: `word`, or `segment`. Note: There is no additional latency for segment timestamps, but generating word timestamps incurs additional latency.\n",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "word",
+                "segment"
+              ]
+            },
+            "default": [
+              "segment"
+            ]
+          }
+        },
+        "required": [
+          "file",
+          "model"
+        ]
+      },
+      "CreateTranscriptionResponseJson": {
+        "type": "object",
+        "description": "Represents a transcription response returned by model, based on the provided input.",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The transcribed text."
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "x-oaiMeta": {
+          "name": "The transcription object (JSON)",
+          "group": "audio",
+          "example": "{\n  \"text\": \"Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that.\"\n}\n"
+        }
+      },
+      "TranscriptionSegment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier of the segment."
+          },
+          "seek": {
+            "type": "integer",
+            "description": "Seek offset of the segment."
+          },
+          "start": {
+            "type": "number",
+            "format": "float",
+            "description": "Start time of the segment in seconds."
+          },
+          "end": {
+            "type": "number",
+            "format": "float",
+            "description": "End time of the segment in seconds."
+          },
+          "text": {
+            "type": "string",
+            "description": "Text content of the segment."
+          },
+          "tokens": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Array of token IDs for the text content."
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "description": "Temperature parameter used for generating the segment."
+          },
+          "avg_logprob": {
+            "type": "number",
+            "format": "float",
+            "description": "Average logprob of the segment. If the value is lower than -1, consider the logprobs failed."
+          },
+          "compression_ratio": {
+            "type": "number",
+            "format": "float",
+            "description": "Compression ratio of the segment. If the value is greater than 2.4, consider the compression failed."
+          },
+          "no_speech_prob": {
+            "type": "number",
+            "format": "float",
+            "description": "Probability of no speech in the segment. If the value is higher than 1.0 and the `avg_logprob` is below -1, consider this segment silent."
+          }
+        },
+        "required": [
+          "id",
+          "seek",
+          "start",
+          "end",
+          "text",
+          "tokens",
+          "temperature",
+          "avg_logprob",
+          "compression_ratio",
+          "no_speech_prob"
+        ]
+      },
+      "TranscriptionWord": {
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string",
+            "description": "The text content of the word."
+          },
+          "start": {
+            "type": "number",
+            "format": "float",
+            "description": "Start time of the word in seconds."
+          },
+          "end": {
+            "type": "number",
+            "format": "float",
+            "description": "End time of the word in seconds."
+          }
+        },
+        "required": [
+          "word",
+          "start",
+          "end"
+        ]
+      },
+      "CreateTranscriptionResponseVerboseJson": {
+        "type": "object",
+        "description": "Represents a verbose json transcription response returned by model, based on the provided input.",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "The language of the input audio."
+          },
+          "duration": {
+            "type": "string",
+            "description": "The duration of the input audio."
+          },
+          "text": {
+            "type": "string",
+            "description": "The transcribed text."
+          },
+          "words": {
+            "type": "array",
+            "description": "Extracted words and their corresponding timestamps.",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionWord"
+            }
+          },
+          "segments": {
+            "type": "array",
+            "description": "Segments of the transcribed text and their corresponding details.",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionSegment"
+            }
+          }
+        },
+        "required": [
+          "language",
+          "duration",
+          "text"
+        ],
+        "x-oaiMeta": {
+          "name": "The transcription object (Verbose JSON)",
+          "group": "audio",
+          "example": "{\n  \"task\": \"transcribe\",\n  \"language\": \"english\",\n  \"duration\": 8.470000267028809,\n  \"text\": \"The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.\",\n  \"segments\": [\n    {\n      \"id\": 0,\n      \"seek\": 0,\n      \"start\": 0.0,\n      \"end\": 3.319999933242798,\n      \"text\": \" The beach was a popular spot on a hot summer day.\",\n      \"tokens\": [\n        50364, 440, 7534, 390, 257, 3743, 4008, 322, 257, 2368, 4266, 786, 13, 50530\n      ],\n      \"temperature\": 0.0,\n      \"avg_logprob\": -0.2860786020755768,\n      \"compression_ratio\": 1.2363636493682861,\n      \"no_speech_prob\": 0.00985979475080967\n    },\n    ...\n  ]\n}\n"
+        }
+      },
+      "CreateTranslationRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "file": {
+            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n",
+            "type": "string",
+            "x-oaiTypeLabel": "file",
+            "format": "binary"
+          },
+          "model": {
+            "description": "ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.\n",
+            "example": "whisper-1",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "whisper-1"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          },
+          "prompt": {
+            "description": "An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should be in English.\n",
+            "type": "string"
+          },
+          "response_format": {
+            "description": "The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.\n",
+            "type": "string",
+            "default": "json"
+          },
+          "temperature": {
+            "description": "The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.\n",
+            "type": "number",
+            "default": 0
+          }
+        },
+        "required": [
+          "file",
+          "model"
+        ]
+      },
+      "CreateTranslationResponseJson": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ]
+      },
+      "CreateTranslationResponseVerboseJson": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "The language of the output translation (always `english`)."
+          },
+          "duration": {
+            "type": "string",
+            "description": "The duration of the input audio."
+          },
+          "text": {
+            "type": "string",
+            "description": "The translated text."
+          },
+          "segments": {
+            "type": "array",
+            "description": "Segments of the translated text and their corresponding details.",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionSegment"
+            }
+          }
+        },
+        "required": [
+          "language",
+          "duration",
+          "text"
+        ]
+      },
+      "CreateSpeechRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "model": {
+            "description": "One of the available [TTS models](/docs/models/tts): `tts-1` or `tts-1-hd`\n",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "tts-1",
+                  "tts-1-hd"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          },
+          "input": {
+            "type": "string",
+            "description": "The text to generate audio for. The maximum length is 4096 characters.",
+            "maxLength": 4096
+          },
+          "voice": {
+            "description": "The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`. Previews of the voices are available in the [Text to speech guide](/docs/guides/text-to-speech/voice-options).",
+            "type": "string",
+            "enum": [
+              "alloy",
+              "echo",
+              "fable",
+              "onyx",
+              "nova",
+              "shimmer"
+            ]
+          },
+          "response_format": {
+            "description": "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`.",
+            "default": "mp3",
+            "type": "string",
+            "enum": [
+              "mp3",
+              "opus",
+              "aac",
+              "flac",
+              "wav",
+              "pcm"
+            ]
+          },
+          "speed": {
+            "description": "The speed of the generated audio. Select a value from `0.25` to `4.0`. `1.0` is the default.",
+            "type": "number",
+            "default": 1,
+            "minimum": 0.25,
+            "maximum": 4
+          }
+        },
+        "required": [
+          "model",
+          "input",
+          "voice"
+        ]
+      },
+      "Model": {
+        "title": "Model",
+        "description": "Describes an OpenAI model offering that can be used with the API.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The model identifier, which can be referenced in the API endpoints."
+          },
+          "created": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) when the model was created."
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always \"model\".",
+            "enum": [
+              "model"
+            ]
+          },
+          "owned_by": {
+            "type": "string",
+            "description": "The organization that owns the model."
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created",
+          "owned_by"
+        ],
+        "x-oaiMeta": {
+          "name": "The model object",
+          "example": "{\n  \"id\": \"VAR_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
+        }
+      },
+      "OpenAIFile": {
+        "title": "OpenAIFile",
+        "description": "The `File` object represents a document that has been uploaded to OpenAI.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The file identifier, which can be referenced in the API endpoints."
+          },
+          "bytes": {
+            "type": "integer",
+            "description": "The size of the file, in bytes."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the file was created."
+          },
+          "filename": {
+            "type": "string",
+            "description": "The name of the file."
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always `file`.",
+            "enum": [
+              "file"
+            ]
+          },
+          "purpose": {
+            "type": "string",
+            "description": "The intended purpose of the file. Supported values are `assistants`, `assistants_output`, `batch`, `batch_output`, `fine-tune`, `fine-tune-results` and `vision`.",
+            "enum": [
+              "assistants",
+              "assistants_output",
+              "batch",
+              "batch_output",
+              "fine-tune",
+              "fine-tune-results",
+              "vision"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "deprecated": true,
+            "description": "Deprecated. The current status of the file, which can be either `uploaded`, `processed`, or `error`.",
+            "enum": [
+              "uploaded",
+              "processed",
+              "error"
+            ]
+          },
+          "status_details": {
+            "type": "string",
+            "deprecated": true,
+            "description": "Deprecated. For details on why a fine-tuning training file failed validation, see the `error` field on `fine_tuning.job`."
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "bytes",
+          "created_at",
+          "filename",
+          "purpose",
+          "status"
+        ],
+        "x-oaiMeta": {
+          "name": "The file object",
+          "example": "{\n  \"id\": \"file-abc123\",\n  \"object\": \"file\",\n  \"bytes\": 120000,\n  \"created_at\": 1677610602,\n  \"filename\": \"salesOverview.pdf\",\n  \"purpose\": \"assistants\",\n}\n"
+        }
+      },
+      "Upload": {
+        "type": "object",
+        "title": "Upload",
+        "description": "The Upload object can accept byte chunks in the form of Parts.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The Upload unique identifier, which can be referenced in API endpoints."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the Upload was created."
+          },
+          "filename": {
+            "type": "string",
+            "description": "The name of the file to be uploaded."
+          },
+          "bytes": {
+            "type": "integer",
+            "description": "The intended number of bytes to be uploaded."
+          },
+          "purpose": {
+            "type": "string",
+            "description": "The intended purpose of the file. [Please refer here](/docs/api-reference/files/object#files/object-purpose) for acceptable values."
+          },
+          "status": {
+            "type": "string",
+            "description": "The status of the Upload.",
+            "enum": [
+              "pending",
+              "completed",
+              "cancelled",
+              "expired"
+            ]
+          },
+          "expires_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the Upload was created."
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always \"upload\".",
+            "enum": [
+              "upload"
+            ]
+          },
+          "file": {
+            "$ref": "#/components/schemas/OpenAIFile",
+            "nullable": true,
+            "description": "The ready File object after the Upload is completed."
+          }
+        },
+        "required": [
+          "bytes",
+          "created_at",
+          "expires_at",
+          "filename",
+          "id",
+          "purpose",
+          "status",
+          "step_number"
+        ],
+        "x-oaiMeta": {
+          "name": "The upload object",
+          "example": "{\n  \"id\": \"upload_abc123\",\n  \"object\": \"upload\",\n  \"bytes\": 2147483648,\n  \"created_at\": 1719184911,\n  \"filename\": \"training_examples.jsonl\",\n  \"purpose\": \"fine-tune\",\n  \"status\": \"completed\",\n  \"expires_at\": 1719127296,\n  \"file\": {\n    \"id\": \"file-xyz321\",\n    \"object\": \"file\",\n    \"bytes\": 2147483648,\n    \"created_at\": 1719186911,\n    \"filename\": \"training_examples.jsonl\",\n    \"purpose\": \"fine-tune\",\n  }\n}\n"
+        }
+      },
+      "UploadPart": {
+        "type": "object",
+        "title": "UploadPart",
+        "description": "The upload Part represents a chunk of bytes we can add to an Upload object.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The upload Part unique identifier, which can be referenced in API endpoints."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the Part was created."
+          },
+          "upload_id": {
+            "type": "string",
+            "description": "The ID of the Upload object that this Part was added to."
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always `upload.part`.",
+            "enum": [
+              "upload.part"
+            ]
+          }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "object",
+          "upload_id"
+        ],
+        "x-oaiMeta": {
+          "name": "The upload part object",
+          "example": "{\n    \"id\": \"part_def456\",\n    \"object\": \"upload.part\",\n    \"created_at\": 1719186911,\n    \"upload_id\": \"upload_abc123\"\n}\n"
+        }
+      },
+      "Embedding": {
+        "type": "object",
+        "description": "Represents an embedding vector returned by embedding endpoint.\n",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the embedding in the list of embeddings."
+          },
+          "embedding": {
+            "type": "array",
+            "description": "The embedding vector, which is a list of floats. The length of vector depends on the model as listed in the [embedding guide](/docs/guides/embeddings).\n",
+            "items": {
+              "type": "number"
+            }
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always \"embedding\".",
+            "enum": [
+              "embedding"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "object",
+          "embedding"
+        ],
+        "x-oaiMeta": {
+          "name": "The embedding object",
+          "example": "{\n  \"object\": \"embedding\",\n  \"embedding\": [\n    0.0023064255,\n    -0.009327292,\n    .... (1536 floats total for ada-002)\n    -0.0028842222,\n  ],\n  \"index\": 0\n}\n"
+        }
+      },
+      "FineTuningJob": {
+        "type": "object",
+        "title": "FineTuningJob",
+        "description": "The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The object identifier, which can be referenced in the API endpoints."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the fine-tuning job was created."
+          },
+          "error": {
+            "type": "object",
+            "nullable": true,
+            "description": "For fine-tuning jobs that have `failed`, this will contain more information on the cause of the failure.",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "A machine-readable error code."
+              },
+              "message": {
+                "type": "string",
+                "description": "A human-readable error message."
+              },
+              "param": {
+                "type": "string",
+                "description": "The parameter that was invalid, usually `training_file` or `validation_file`. This field will be null if the failure was not parameter-specific.",
+                "nullable": true
+              }
+            },
+            "required": [
+              "code",
+              "message",
+              "param"
+            ]
+          },
+          "fine_tuned_model": {
+            "type": "string",
+            "nullable": true,
+            "description": "The name of the fine-tuned model that is being created. The value will be null if the fine-tuning job is still running."
+          },
+          "finished_at": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The Unix timestamp (in seconds) for when the fine-tuning job was finished. The value will be null if the fine-tuning job is still running."
+          },
+          "hyperparameters": {
+            "type": "object",
+            "description": "The hyperparameters used for the fine-tuning job. See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.",
+            "properties": {
+              "n_epochs": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "auto"
+                    ]
+                  },
+                  {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50
+                  }
+                ],
+                "default": "auto",
+                "description": "The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset.\n\"auto\" decides the optimal number of epochs based on the size of the dataset. If setting the number manually, we support any number between 1 and 50 epochs."
+              }
+            },
+            "required": [
+              "n_epochs"
+            ]
+          },
+          "model": {
+            "type": "string",
+            "description": "The base model that is being fine-tuned."
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always \"fine_tuning.job\".",
+            "enum": [
+              "fine_tuning.job"
+            ]
+          },
+          "organization_id": {
+            "type": "string",
+            "description": "The organization that owns the fine-tuning job."
+          },
+          "result_files": {
+            "type": "array",
+            "description": "The compiled results file ID(s) for the fine-tuning job. You can retrieve the results with the [Files API](/docs/api-reference/files/retrieve-contents).",
+            "items": {
+              "type": "string",
+              "example": "file-abc123"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`.",
+            "enum": [
+              "validating_files",
+              "queued",
+              "running",
+              "succeeded",
+              "failed",
+              "cancelled"
+            ]
+          },
+          "trained_tokens": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The total number of billable tokens processed by this fine-tuning job. The value will be null if the fine-tuning job is still running."
+          },
+          "training_file": {
+            "type": "string",
+            "description": "The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents)."
+          },
+          "validation_file": {
+            "type": "string",
+            "nullable": true,
+            "description": "The file ID used for validation. You can retrieve the validation results with the [Files API](/docs/api-reference/files/retrieve-contents)."
+          },
+          "integrations": {
+            "type": "array",
+            "nullable": true,
+            "description": "A list of integrations to enable for this fine-tuning job.",
+            "maxItems": 5,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FineTuningIntegration"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          },
+          "seed": {
+            "type": "integer",
+            "description": "The seed used for the fine-tuning job."
+          },
+          "estimated_finish": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The Unix timestamp (in seconds) for when the fine-tuning job is estimated to finish. The value will be null if the fine-tuning job is not running."
+          }
+        },
+        "required": [
+          "created_at",
+          "error",
+          "finished_at",
+          "fine_tuned_model",
+          "hyperparameters",
+          "id",
+          "model",
+          "object",
+          "organization_id",
+          "result_files",
+          "status",
+          "trained_tokens",
+          "training_file",
+          "validation_file",
+          "seed"
+        ],
+        "x-oaiMeta": {
+          "name": "The fine-tuning job object",
+          "example": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"davinci-002\",\n  \"created_at\": 1692661014,\n  \"finished_at\": 1692661190,\n  \"fine_tuned_model\": \"ft:davinci-002:my-org:custom_suffix:7q8mpxmy\",\n  \"organization_id\": \"org-123\",\n  \"result_files\": [\n      \"file-abc123\"\n  ],\n  \"status\": \"succeeded\",\n  \"validation_file\": null,\n  \"training_file\": \"file-abc123\",\n  \"hyperparameters\": {\n      \"n_epochs\": 4,\n      \"batch_size\": 1,\n      \"learning_rate_multiplier\": 1.0\n  },\n  \"trained_tokens\": 5768,\n  \"integrations\": [],\n  \"seed\": 0,\n  \"estimated_finish\": 0\n}\n"
+        }
+      },
+      "FineTuningIntegration": {
+        "type": "object",
+        "title": "Fine-Tuning Job Integration",
+        "required": [
+          "type",
+          "wandb"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The type of the integration being enabled for the fine-tuning job",
+            "enum": [
+              "wandb"
+            ]
+          },
+          "wandb": {
+            "type": "object",
+            "description": "The settings for your integration with Weights and Biases. This payload specifies the project that\nmetrics will be sent to. Optionally, you can set an explicit display name for your run, add tags\nto your run, and set a default entity (team, username, etc) to be associated with your run.\n",
+            "required": [
+              "project"
+            ],
+            "properties": {
+              "project": {
+                "description": "The name of the project that the new run will be created under.\n",
+                "type": "string",
+                "example": "my-wandb-project"
+              },
+              "name": {
+                "description": "A display name to set for the run. If not set, we will use the Job ID as the name.\n",
+                "nullable": true,
+                "type": "string"
+              },
+              "entity": {
+                "description": "The entity to use for the run. This allows you to set the team or username of the WandB user that you would\nlike associated with the run. If not set, the default entity for the registered WandB API key is used.\n",
+                "nullable": true,
+                "type": "string"
+              },
+              "tags": {
+                "description": "A list of tags to be attached to the newly created run. These tags are passed through directly to WandB. Some\ndefault tags are generated by OpenAI: \"openai/finetune\", \"openai/{base-model}\", \"openai/{ftjob-abcdef}\".\n",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "custom-tag"
+                }
+              }
+            }
+          }
+        }
+      },
+      "FineTuningJobEvent": {
+        "type": "object",
+        "description": "Fine-tuning job event object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "integer"
+          },
+          "level": {
+            "type": "string",
+            "enum": [
+              "info",
+              "warn",
+              "error"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "fine_tuning.job.event"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "level",
+          "message"
+        ],
+        "x-oaiMeta": {
+          "name": "The fine-tuning job event object",
+          "example": "{\n  \"object\": \"fine_tuning.job.event\",\n  \"id\": \"ftevent-abc123\"\n  \"created_at\": 1677610602,\n  \"level\": \"info\",\n  \"message\": \"Created fine-tuning job\"\n}\n"
+        }
+      },
+      "FineTuningJobCheckpoint": {
+        "type": "object",
+        "title": "FineTuningJobCheckpoint",
+        "description": "The `fine_tuning.job.checkpoint` object represents a model checkpoint for a fine-tuning job that is ready to use.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The checkpoint identifier, which can be referenced in the API endpoints."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the checkpoint was created."
+          },
+          "fine_tuned_model_checkpoint": {
+            "type": "string",
+            "description": "The name of the fine-tuned checkpoint model that is created."
+          },
+          "step_number": {
+            "type": "integer",
+            "description": "The step number that the checkpoint was created at."
+          },
+          "metrics": {
+            "type": "object",
+            "description": "Metrics at the step number during the fine-tuning job.",
+            "properties": {
+              "step": {
+                "type": "number"
+              },
+              "train_loss": {
+                "type": "number"
+              },
+              "train_mean_token_accuracy": {
+                "type": "number"
+              },
+              "valid_loss": {
+                "type": "number"
+              },
+              "valid_mean_token_accuracy": {
+                "type": "number"
+              },
+              "full_valid_loss": {
+                "type": "number"
+              },
+              "full_valid_mean_token_accuracy": {
+                "type": "number"
+              }
+            }
+          },
+          "fine_tuning_job_id": {
+            "type": "string",
+            "description": "The name of the fine-tuning job that this checkpoint was created from."
+          },
+          "object": {
+            "type": "string",
+            "description": "The object type, which is always \"fine_tuning.job.checkpoint\".",
+            "enum": [
+              "fine_tuning.job.checkpoint"
+            ]
+          }
+        },
+        "required": [
+          "created_at",
+          "fine_tuning_job_id",
+          "fine_tuned_model_checkpoint",
+          "id",
+          "metrics",
+          "object",
+          "step_number"
+        ],
+        "x-oaiMeta": {
+          "name": "The fine-tuning job checkpoint object",
+          "example": "{\n  \"object\": \"fine_tuning.job.checkpoint\",\n  \"id\": \"ftckpt_qtZ5Gyk4BLq1SfLFWp3RtO3P\",\n  \"created_at\": 1712211699,\n  \"fine_tuned_model_checkpoint\": \"ft:gpt-3.5-turbo-0125:my-org:custom_suffix:9ABel2dg:ckpt-step-88\",\n  \"fine_tuning_job_id\": \"ftjob-fpbNQ3H1GrMehXRf8cO97xTN\",\n  \"metrics\": {\n    \"step\": 88,\n    \"train_loss\": 0.478,\n    \"train_mean_token_accuracy\": 0.924,\n    \"valid_loss\": 10.112,\n    \"valid_mean_token_accuracy\": 0.145,\n    \"full_valid_loss\": 0.567,\n    \"full_valid_mean_token_accuracy\": 0.944\n  },\n  \"step_number\": 88\n}\n"
+        }
+      },
+      "FinetuneChatRequestInput": {
+        "type": "object",
+        "description": "The per-line training example of a fine-tuning input file for chat models",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestSystemMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestUserMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/FineTuneChatCompletionRequestAssistantMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestToolMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestFunctionMessage"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          },
+          "tools": {
+            "type": "array",
+            "description": "A list of tools the model may generate JSON inputs for.",
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionTool"
+            }
+          },
+          "parallel_tool_calls": {
+            "$ref": "#/components/schemas/ParallelToolCalls"
+          },
+          "functions": {
+            "deprecated": true,
+            "description": "A list of functions the model may generate JSON inputs for.",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 128,
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionFunctions"
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Training format for chat models",
+          "example": "{\n  \"messages\": [\n    { \"role\": \"user\", \"content\": \"What is the weather in San Francisco?\" },\n    {\n      \"role\": \"assistant\",\n      \"tool_calls\": [\n        {\n          \"id\": \"call_id\",\n          \"type\": \"function\",\n          \"function\": {\n            \"name\": \"get_current_weather\",\n            \"arguments\": \"{\\\"location\\\": \\\"San Francisco, USA\\\", \\\"format\\\": \\\"celsius\\\"}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"parallel_tool_calls\": false,\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_current_weather\",\n        \"description\": \"Get the current weather\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n                \"type\": \"string\",\n                \"description\": \"The city and country, eg. San Francisco, USA\"\n            },\n            \"format\": { \"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"] }\n          },\n          \"required\": [\"location\", \"format\"]\n        }\n      }\n    }\n  ]\n}\n"
+        }
+      },
+      "FinetuneCompletionRequestInput": {
+        "type": "object",
+        "description": "The per-line training example of a fine-tuning input file for completions models",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "The input prompt for this training example."
+          },
+          "completion": {
+            "type": "string",
+            "description": "The desired completion for this training example."
+          }
+        },
+        "x-oaiMeta": {
+          "name": "Training format for completions models",
+          "example": "{\n  \"prompt\": \"What is the answer to 2+2\",\n  \"completion\": \"4\"\n}\n"
+        }
+      },
+      "CompletionUsage": {
+        "type": "object",
+        "description": "Usage statistics for the completion request.",
+        "properties": {
+          "completion_tokens": {
+            "type": "integer",
+            "description": "Number of tokens in the generated completion."
+          },
+          "prompt_tokens": {
+            "type": "integer",
+            "description": "Number of tokens in the prompt."
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total number of tokens used in the request (prompt + completion)."
+          }
+        },
+        "required": [
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens"
+        ]
+      },
+      "RunCompletionUsage": {
+        "type": "object",
+        "description": "Usage statistics related to the run. This value will be `null` if the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).",
+        "properties": {
+          "completion_tokens": {
+            "type": "integer",
+            "description": "Number of completion tokens used over the course of the run."
+          },
+          "prompt_tokens": {
+            "type": "integer",
+            "description": "Number of prompt tokens used over the course of the run."
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total number of tokens used (prompt + completion)."
+          }
+        },
+        "required": [
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens"
+        ],
+        "nullable": true
+      },
+      "RunStepCompletionUsage": {
+        "type": "object",
+        "description": "Usage statistics related to the run step. This value will be `null` while the run step's status is `in_progress`.",
+        "properties": {
+          "completion_tokens": {
+            "type": "integer",
+            "description": "Number of completion tokens used over the course of the run step."
+          },
+          "prompt_tokens": {
+            "type": "integer",
+            "description": "Number of prompt tokens used over the course of the run step."
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total number of tokens used (prompt + completion)."
+          }
+        },
+        "required": [
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens"
+        ],
+        "nullable": true
+      },
+      "AssistantsApiResponseFormatOption": {
+        "description": "Specifies the format that the model must output. Compatible with [GPT-4o](/docs/models/gpt-4o), [GPT-4 Turbo](/docs/models/gpt-4-turbo-and-gpt-4), and all GPT-3.5 Turbo models since `gpt-3.5-turbo-1106`.\n\nSetting to `{ \"type\": \"json_object\" }` enables JSON mode, which guarantees the message the model generates is valid JSON.\n\n**Important:** when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly \"stuck\" request. Also note that the message content may be partially cut off if `finish_reason=\"length\"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length.\n",
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "`auto` is the default value\n",
+            "enum": [
+              "none",
+              "auto"
+            ]
+          },
+          {
+            "$ref": "#/components/schemas/AssistantsApiResponseFormat"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "AssistantsApiResponseFormat": {
+        "type": "object",
+        "description": "An object describing the expected output of the model. If `json_object` only `function` type `tools` are allowed to be passed to the Run. If `text` the model can return text or any value needed.\n",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "text",
+              "json_object"
+            ],
+            "example": "json_object",
+            "default": "text",
+            "description": "Must be one of `text` or `json_object`."
+          }
+        }
+      },
+      "AssistantObject": {
+        "type": "object",
+        "title": "Assistant",
+        "description": "Represents an `assistant` that can call the model and use tools.",
+        "properties": {
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `assistant`.",
+            "type": "string",
+            "enum": [
+              "assistant"
+            ]
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the assistant was created.",
+            "type": "integer"
+          },
+          "name": {
+            "description": "The name of the assistant. The maximum length is 256 characters.\n",
+            "type": "string",
+            "maxLength": 256,
+            "nullable": true
+          },
+          "description": {
+            "description": "The description of the assistant. The maximum length is 512 characters.\n",
+            "type": "string",
+            "maxLength": 512,
+            "nullable": true
+          },
+          "model": {
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n",
+            "type": "string"
+          },
+          "instructions": {
+            "description": "The system instructions that the assistant uses. The maximum length is 256,000 characters.\n",
+            "type": "string",
+            "maxLength": 256000,
+            "nullable": true
+          },
+          "tools": {
+            "description": "A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`.\n",
+            "default": [],
+            "type": "array",
+            "maxItems": 128,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFileSearch"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          },
+          "tool_resources": {
+            "type": "object",
+            "description": "A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.\n",
+            "properties": {
+              "code_interpreter": {
+                "type": "object",
+                "properties": {
+                  "file_ids": {
+                    "type": "array",
+                    "description": "A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter`` tool. There can be a maximum of 20 files associated with the tool.\n",
+                    "default": [],
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "file_search": {
+                "type": "object",
+                "properties": {
+                  "vector_store_ids": {
+                    "type": "array",
+                    "description": "The ID of the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          },
+          "temperature": {
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\n",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 1,
+            "example": 1,
+            "nullable": true
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.\n"
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/AssistantsApiResponseFormatOption",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "name",
+          "description",
+          "model",
+          "instructions",
+          "tools",
+          "metadata"
+        ],
+        "x-oaiMeta": {
+          "name": "The assistant object",
+          "beta": true,
+          "example": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1698984975,\n  \"name\": \"Math Tutor\",\n  \"description\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": \"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"metadata\": {},\n  \"top_p\": 1.0,\n  \"temperature\": 1.0,\n  \"response_format\": \"auto\"\n}\n"
+        }
+      },
+      "CreateAssistantRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "model": {
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n",
+            "example": "gpt-4-turbo",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "gpt-4o",
+                  "gpt-4o-2024-05-13",
+                  "gpt-4o-mini",
+                  "gpt-4o-mini-2024-07-18",
+                  "gpt-4-turbo",
+                  "gpt-4-turbo-2024-04-09",
+                  "gpt-4-0125-preview",
+                  "gpt-4-turbo-preview",
+                  "gpt-4-1106-preview",
+                  "gpt-4-vision-preview",
+                  "gpt-4",
+                  "gpt-4-0314",
+                  "gpt-4-0613",
+                  "gpt-4-32k",
+                  "gpt-4-32k-0314",
+                  "gpt-4-32k-0613",
+                  "gpt-3.5-turbo",
+                  "gpt-3.5-turbo-16k",
+                  "gpt-3.5-turbo-0613",
+                  "gpt-3.5-turbo-1106",
+                  "gpt-3.5-turbo-0125",
+                  "gpt-3.5-turbo-16k-0613"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string"
+          },
+          "name": {
+            "description": "The name of the assistant. The maximum length is 256 characters.\n",
+            "type": "string",
+            "nullable": true,
+            "maxLength": 256
+          },
+          "description": {
+            "description": "The description of the assistant. The maximum length is 512 characters.\n",
+            "type": "string",
+            "nullable": true,
+            "maxLength": 512
+          },
+          "instructions": {
+            "description": "The system instructions that the assistant uses. The maximum length is 256,000 characters.\n",
+            "type": "string",
+            "nullable": true,
+            "maxLength": 256000
+          },
+          "tools": {
+            "description": "A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`.\n",
+            "default": [],
+            "type": "array",
+            "maxItems": 128,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFileSearch"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          },
+          "tool_resources": {
+            "type": "object",
+            "description": "A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.\n",
+            "properties": {
+              "code_interpreter": {
+                "type": "object",
+                "properties": {
+                  "file_ids": {
+                    "type": "array",
+                    "description": "A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.\n",
+                    "default": [],
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "file_search": {
+                "type": "object",
+                "properties": {
+                  "vector_store_ids": {
+                    "type": "array",
+                    "description": "The [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "vector_stores": {
+                    "type": "array",
+                    "description": "A helper to create a [vector store](/docs/api-reference/vector-stores/object) with file_ids and attach it to this assistant. There can be a maximum of 1 vector store attached to the assistant.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "file_ids": {
+                          "type": "array",
+                          "description": "A list of [file](/docs/api-reference/files) IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.\n",
+                          "maxItems": 10000,
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "chunking_strategy": {
+                          "type": "object",
+                          "description": "The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.",
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "title": "Auto Chunking Strategy",
+                              "description": "The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.",
+                              "additionalProperties": false,
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "Always `auto`.",
+                                  "enum": [
+                                    "auto"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "title": "Static Chunking Strategy",
+                              "additionalProperties": false,
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "Always `static`.",
+                                  "enum": [
+                                    "static"
+                                  ]
+                                },
+                                "static": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "max_chunk_size_tokens": {
+                                      "type": "integer",
+                                      "minimum": 100,
+                                      "maximum": 4096,
+                                      "description": "The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`."
+                                    },
+                                    "chunk_overlap_tokens": {
+                                      "type": "integer",
+                                      "description": "The number of tokens that overlap between chunks. The default value is `400`.\n\nNote that the overlap must not exceed half of `max_chunk_size_tokens`.\n"
+                                    }
+                                  },
+                                  "required": [
+                                    "max_chunk_size_tokens",
+                                    "chunk_overlap_tokens"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "static"
+                              ]
+                            }
+                          ],
+                          "x-oaiExpandable": true
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "description": "Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+                          "x-oaiTypeLabel": "map"
+                        }
+                      }
+                    }
+                  }
+                },
+                "oneOf": [
+                  {
+                    "required": [
+                      "vector_store_ids"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "vector_stores"
+                    ]
+                  }
+                ]
+              }
+            },
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          },
+          "temperature": {
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\n",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 1,
+            "example": 1,
+            "nullable": true
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.\n"
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/AssistantsApiResponseFormatOption",
+            "nullable": true
+          }
+        },
+        "required": [
+          "model"
+        ]
+      },
+      "ModifyAssistantRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "model": {
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n",
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "name": {
+            "description": "The name of the assistant. The maximum length is 256 characters.\n",
+            "type": "string",
+            "nullable": true,
+            "maxLength": 256
+          },
+          "description": {
+            "description": "The description of the assistant. The maximum length is 512 characters.\n",
+            "type": "string",
+            "nullable": true,
+            "maxLength": 512
+          },
+          "instructions": {
+            "description": "The system instructions that the assistant uses. The maximum length is 256,000 characters.\n",
+            "type": "string",
+            "nullable": true,
+            "maxLength": 256000
+          },
+          "tools": {
+            "description": "A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`.\n",
+            "default": [],
+            "type": "array",
+            "maxItems": 128,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFileSearch"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          },
+          "tool_resources": {
+            "type": "object",
+            "description": "A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.\n",
+            "properties": {
+              "code_interpreter": {
+                "type": "object",
+                "properties": {
+                  "file_ids": {
+                    "type": "array",
+                    "description": "Overrides the list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.\n",
+                    "default": [],
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "file_search": {
+                "type": "object",
+                "properties": {
+                  "vector_store_ids": {
+                    "type": "array",
+                    "description": "Overrides the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          },
+          "temperature": {
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\n",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 1,
+            "example": 1,
+            "nullable": true
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.\n"
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/AssistantsApiResponseFormatOption",
+            "nullable": true
+          }
+        }
+      },
+      "DeleteAssistantResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "assistant.deleted"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ]
+      },
+      "ListAssistantsResponse": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "example": "list"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssistantObject"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "example": "asst_abc123"
+          },
+          "last_id": {
+            "type": "string",
+            "example": "asst_abc456"
+          },
+          "has_more": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ],
+        "x-oaiMeta": {
+          "name": "List assistants response object",
+          "group": "chat",
+          "example": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"asst_abc123\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982736,\n      \"name\": \"Coding Tutor\",\n      \"description\": null,\n      \"model\": \"gpt-4-turbo\",\n      \"instructions\": \"You are a helpful assistant designed to make me better at coding!\",\n      \"tools\": [],\n      \"tool_resources\": {},\n      \"metadata\": {},\n      \"top_p\": 1.0,\n      \"temperature\": 1.0,\n      \"response_format\": \"auto\"\n    },\n    {\n      \"id\": \"asst_abc456\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982718,\n      \"name\": \"My Assistant\",\n      \"description\": null,\n      \"model\": \"gpt-4-turbo\",\n      \"instructions\": \"You are a helpful assistant designed to make me better at coding!\",\n      \"tools\": [],\n      \"tool_resources\": {},\n      \"metadata\": {},\n      \"top_p\": 1.0,\n      \"temperature\": 1.0,\n      \"response_format\": \"auto\"\n    },\n    {\n      \"id\": \"asst_abc789\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982643,\n      \"name\": null,\n      \"description\": null,\n      \"model\": \"gpt-4-turbo\",\n      \"instructions\": null,\n      \"tools\": [],\n      \"tool_resources\": {},\n      \"metadata\": {},\n      \"top_p\": 1.0,\n      \"temperature\": 1.0,\n      \"response_format\": \"auto\"\n    }\n  ],\n  \"first_id\": \"asst_abc123\",\n  \"last_id\": \"asst_abc789\",\n  \"has_more\": false\n}\n"
+        }
+      },
+      "AssistantToolsCode": {
+        "type": "object",
+        "title": "Code interpreter tool",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The type of tool being defined: `code_interpreter`",
+            "enum": [
+              "code_interpreter"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "AssistantToolsFileSearch": {
+        "type": "object",
+        "title": "FileSearch tool",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The type of tool being defined: `file_search`",
+            "enum": [
+              "file_search"
+            ]
+          },
+          "file_search": {
+            "type": "object",
+            "description": "Overrides for the file search tool.",
+            "properties": {
+              "max_num_results": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 50,
+                "description": "The maximum number of results the file search tool should output. The default is 20 for gpt-4* models and 5 for gpt-3.5-turbo. This number should be between 1 and 50 inclusive.\n\nNote that the file search tool may output fewer than `max_num_results` results. See the [file search tool documentation](/docs/assistants/tools/file-search/number-of-chunks-returned) for more information.\n"
+              }
+            }
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "AssistantToolsFileSearchTypeOnly": {
+        "type": "object",
+        "title": "FileSearch tool",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The type of tool being defined: `file_search`",
+            "enum": [
+              "file_search"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "AssistantToolsFunction": {
+        "type": "object",
+        "title": "Function tool",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The type of tool being defined: `function`",
+            "enum": [
+              "function"
+            ]
+          },
+          "function": {
+            "$ref": "#/components/schemas/FunctionObject"
+          }
+        },
+        "required": [
+          "type",
+          "function"
+        ]
+      },
+      "TruncationObject": {
+        "type": "object",
+        "title": "Thread Truncation Controls",
+        "description": "Controls for how a thread will be truncated prior to the run. Use this to control the intial context window of the run.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The truncation strategy to use for the thread. The default is `auto`. If set to `last_messages`, the thread will be truncated to the n most recent messages in the thread. When set to `auto`, messages in the middle of the thread will be dropped to fit the context length of the model, `max_prompt_tokens`.",
+            "enum": [
+              "auto",
+              "last_messages"
+            ]
+          },
+          "last_messages": {
+            "type": "integer",
+            "description": "The number of most recent messages from the thread when constructing the context for the run.",
+            "minimum": 1,
+            "nullable": true
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "AssistantsApiToolChoiceOption": {
+        "description": "Controls which (if any) tool is called by the model.\n`none` means the model will not call any tools and instead generates a message.\n`auto` is the default value and means the model can pick between generating a message or calling one or more tools.\n`required` means the model must call one or more tools before responding to the user.\nSpecifying a particular tool like `{\"type\": \"file_search\"}` or `{\"type\": \"function\", \"function\": {\"name\": \"my_function\"}}` forces the model to call that tool.\n",
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "`none` means the model will not call any tools and instead generates a message. `auto` means the model can pick between generating a message or calling one or more tools. `required` means the model must call one or more tools before responding to the user.\n",
+            "enum": [
+              "none",
+              "auto",
+              "required"
+            ]
+          },
+          {
+            "$ref": "#/components/schemas/AssistantsNamedToolChoice"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "AssistantsNamedToolChoice": {
+        "type": "object",
+        "description": "Specifies a tool the model should use. Use to force the model to call a specific tool.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "function",
+              "code_interpreter",
+              "file_search"
+            ],
+            "description": "The type of the tool. If type is `function`, the function name must be set"
+          },
+          "function": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the function to call."
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "RunObject": {
+        "type": "object",
+        "title": "A run on a thread",
+        "description": "Represents an execution run on a [thread](/docs/api-reference/threads).",
+        "properties": {
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `thread.run`.",
+            "type": "string",
+            "enum": [
+              "thread.run"
+            ]
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the run was created.",
+            "type": "integer"
+          },
+          "thread_id": {
+            "description": "The ID of the [thread](/docs/api-reference/threads) that was executed on as a part of this run.",
+            "type": "string"
+          },
+          "assistant_id": {
+            "description": "The ID of the [assistant](/docs/api-reference/assistants) used for execution of this run.",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the run, which can be either `queued`, `in_progress`, `requires_action`, `cancelling`, `cancelled`, `failed`, `completed`, `incomplete`, or `expired`.",
+            "type": "string",
+            "enum": [
+              "queued",
+              "in_progress",
+              "requires_action",
+              "cancelling",
+              "cancelled",
+              "failed",
+              "completed",
+              "incomplete",
+              "expired"
+            ]
+          },
+          "required_action": {
+            "type": "object",
+            "description": "Details on the action required to continue the run. Will be `null` if no action is required.",
+            "nullable": true,
+            "properties": {
+              "type": {
+                "description": "For now, this is always `submit_tool_outputs`.",
+                "type": "string",
+                "enum": [
+                  "submit_tool_outputs"
+                ]
+              },
+              "submit_tool_outputs": {
+                "type": "object",
+                "description": "Details on the tool outputs needed for this run to continue.",
+                "properties": {
+                  "tool_calls": {
+                    "type": "array",
+                    "description": "A list of the relevant tool calls.",
+                    "items": {
+                      "$ref": "#/components/schemas/RunToolCallObject"
+                    }
+                  }
+                },
+                "required": [
+                  "tool_calls"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "submit_tool_outputs"
+            ]
+          },
+          "last_error": {
+            "type": "object",
+            "description": "The last error associated with this run. Will be `null` if there are no errors.",
+            "nullable": true,
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "One of `server_error`, `rate_limit_exceeded`, or `invalid_prompt`.",
+                "enum": [
+                  "server_error",
+                  "rate_limit_exceeded",
+                  "invalid_prompt"
+                ]
+              },
+              "message": {
+                "type": "string",
+                "description": "A human-readable description of the error."
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          },
+          "expires_at": {
+            "description": "The Unix timestamp (in seconds) for when the run will expire.",
+            "type": "integer",
+            "nullable": true
+          },
+          "started_at": {
+            "description": "The Unix timestamp (in seconds) for when the run was started.",
+            "type": "integer",
+            "nullable": true
+          },
+          "cancelled_at": {
+            "description": "The Unix timestamp (in seconds) for when the run was cancelled.",
+            "type": "integer",
+            "nullable": true
+          },
+          "failed_at": {
+            "description": "The Unix timestamp (in seconds) for when the run failed.",
+            "type": "integer",
+            "nullable": true
+          },
+          "completed_at": {
+            "description": "The Unix timestamp (in seconds) for when the run was completed.",
+            "type": "integer",
+            "nullable": true
+          },
+          "incomplete_details": {
+            "description": "Details on why the run is incomplete. Will be `null` if the run is not incomplete.",
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "reason": {
+                "description": "The reason why the run is incomplete. This will point to which specific token limit was reached over the course of the run.",
+                "type": "string",
+                "enum": [
+                  "max_completion_tokens",
+                  "max_prompt_tokens"
+                ]
+              }
+            }
+          },
+          "model": {
+            "description": "The model that the [assistant](/docs/api-reference/assistants) used for this run.",
+            "type": "string"
+          },
+          "instructions": {
+            "description": "The instructions that the [assistant](/docs/api-reference/assistants) used for this run.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "The list of tools that the [assistant](/docs/api-reference/assistants) used for this run.",
+            "default": [],
+            "type": "array",
+            "maxItems": 20,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFileSearch"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          },
+          "usage": {
+            "$ref": "#/components/schemas/RunCompletionUsage"
+          },
+          "temperature": {
+            "description": "The sampling temperature used for this run. If not set, defaults to 1.",
+            "type": "number",
+            "nullable": true
+          },
+          "top_p": {
+            "description": "The nucleus sampling value used for this run. If not set, defaults to 1.",
+            "type": "number",
+            "nullable": true
+          },
+          "max_prompt_tokens": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The maximum number of prompt tokens specified to have been used over the course of the run.\n",
+            "minimum": 256
+          },
+          "max_completion_tokens": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The maximum number of completion tokens specified to have been used over the course of the run.\n",
+            "minimum": 256
+          },
+          "truncation_strategy": {
+            "$ref": "#/components/schemas/TruncationObject",
+            "nullable": true
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/AssistantsApiToolChoiceOption",
+            "nullable": true
+          },
+          "parallel_tool_calls": {
+            "$ref": "#/components/schemas/ParallelToolCalls"
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/AssistantsApiResponseFormatOption",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "thread_id",
+          "assistant_id",
+          "status",
+          "required_action",
+          "last_error",
+          "expires_at",
+          "started_at",
+          "cancelled_at",
+          "failed_at",
+          "completed_at",
+          "model",
+          "instructions",
+          "tools",
+          "metadata",
+          "usage",
+          "incomplete_details",
+          "max_prompt_tokens",
+          "max_completion_tokens",
+          "truncation_strategy",
+          "tool_choice",
+          "parallel_tool_calls",
+          "response_format"
+        ],
+        "x-oaiMeta": {
+          "name": "The run object",
+          "beta": true,
+          "example": "{\n  \"id\": \"run_abc123\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1698107661,\n  \"assistant_id\": \"asst_abc123\",\n  \"thread_id\": \"thread_abc123\",\n  \"status\": \"completed\",\n  \"started_at\": 1699073476,\n  \"expires_at\": null,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": 1699073498,\n  \"last_error\": null,\n  \"model\": \"gpt-4-turbo\",\n  \"instructions\": null,\n  \"tools\": [{\"type\": \"file_search\"}, {\"type\": \"code_interpreter\"}],\n  \"metadata\": {},\n  \"incomplete_details\": null,\n  \"usage\": {\n    \"prompt_tokens\": 123,\n    \"completion_tokens\": 456,\n    \"total_tokens\": 579\n  },\n  \"temperature\": 1.0,\n  \"top_p\": 1.0,\n  \"max_prompt_tokens\": 1000,\n  \"max_completion_tokens\": 1000,\n  \"truncation_strategy\": {\n    \"type\": \"auto\",\n    \"last_messages\": null\n  },\n  \"response_format\": \"auto\",\n  \"tool_choice\": \"auto\",\n  \"parallel_tool_calls\": true\n}\n"
+        }
+      },
+      "CreateRunRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "assistant_id": {
+            "description": "The ID of the [assistant](/docs/api-reference/assistants) to use to execute this run.",
+            "type": "string"
+          },
+          "model": {
+            "description": "The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.",
+            "example": "gpt-4-turbo",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "gpt-4o",
+                  "gpt-4o-2024-05-13",
+                  "gpt-4o-mini",
+                  "gpt-4o-mini-2024-07-18",
+                  "gpt-4-turbo",
+                  "gpt-4-turbo-2024-04-09",
+                  "gpt-4-0125-preview",
+                  "gpt-4-turbo-preview",
+                  "gpt-4-1106-preview",
+                  "gpt-4-vision-preview",
+                  "gpt-4",
+                  "gpt-4-0314",
+                  "gpt-4-0613",
+                  "gpt-4-32k",
+                  "gpt-4-32k-0314",
+                  "gpt-4-32k-0613",
+                  "gpt-3.5-turbo",
+                  "gpt-3.5-turbo-16k",
+                  "gpt-3.5-turbo-0613",
+                  "gpt-3.5-turbo-1106",
+                  "gpt-3.5-turbo-0125",
+                  "gpt-3.5-turbo-16k-0613"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string",
+            "nullable": true
+          },
+          "instructions": {
+            "description": "Overrides the [instructions](/docs/api-reference/assistants/createAssistant) of the assistant. This is useful for modifying the behavior on a per-run basis.",
+            "type": "string",
+            "nullable": true
+          },
+          "additional_instructions": {
+            "description": "Appends additional instructions at the end of the instructions for the run. This is useful for modifying the behavior on a per-run basis without overriding other instructions.",
+            "type": "string",
+            "nullable": true
+          },
+          "additional_messages": {
+            "description": "Adds additional messages to the thread before creating the run.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateMessageRequest"
+            },
+            "nullable": true
+          },
+          "tools": {
+            "description": "Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.",
+            "nullable": true,
+            "type": "array",
+            "maxItems": 20,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFileSearch"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\n"
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.\n"
+          },
+          "stream": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.\n"
+          },
+          "max_prompt_tokens": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.\n",
+            "minimum": 256
+          },
+          "max_completion_tokens": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.\n",
+            "minimum": 256
+          },
+          "truncation_strategy": {
+            "$ref": "#/components/schemas/TruncationObject",
+            "nullable": true
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/AssistantsApiToolChoiceOption",
+            "nullable": true
+          },
+          "parallel_tool_calls": {
+            "$ref": "#/components/schemas/ParallelToolCalls"
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/AssistantsApiResponseFormatOption",
+            "nullable": true
+          }
+        },
+        "required": [
+          "thread_id",
+          "assistant_id"
+        ]
+      },
+      "ListRunsResponse": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "example": "list"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RunObject"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "example": "run_abc123"
+          },
+          "last_id": {
+            "type": "string",
+            "example": "run_abc456"
+          },
+          "has_more": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "ModifyRunRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        }
+      },
+      "SubmitToolOutputsRunRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tool_outputs": {
+            "description": "A list of tools for which the outputs are being submitted.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tool_call_id": {
+                  "type": "string",
+                  "description": "The ID of the tool call in the `required_action` object within the run object the output is being submitted for."
+                },
+                "output": {
+                  "type": "string",
+                  "description": "The output of the tool call to be submitted to continue the run."
+                }
+              }
+            }
+          },
+          "stream": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.\n"
+          }
+        },
+        "required": [
+          "tool_outputs"
+        ]
+      },
+      "RunToolCallObject": {
+        "type": "object",
+        "description": "Tool call objects",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call. This ID must be referenced when you submit the tool outputs in using the [Submit tool outputs to run](/docs/api-reference/runs/submitToolOutputs) endpoint."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of tool call the output is required for. For now, this is always `function`.",
+            "enum": [
+              "function"
+            ]
+          },
+          "function": {
+            "type": "object",
+            "description": "The function definition.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the function."
+              },
+              "arguments": {
+                "type": "string",
+                "description": "The arguments that the model expects you to pass to the function."
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "function"
+        ]
+      },
+      "CreateThreadAndRunRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "assistant_id": {
+            "description": "The ID of the [assistant](/docs/api-reference/assistants) to use to execute this run.",
+            "type": "string"
+          },
+          "thread": {
+            "$ref": "#/components/schemas/CreateThreadRequest",
+            "description": "If no thread is provided, an empty thread will be created."
+          },
+          "model": {
+            "description": "The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.",
+            "example": "gpt-4-turbo",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "gpt-4o",
+                  "gpt-4o-2024-05-13",
+                  "gpt-4o-mini",
+                  "gpt-4o-mini-2024-07-18",
+                  "gpt-4-turbo",
+                  "gpt-4-turbo-2024-04-09",
+                  "gpt-4-0125-preview",
+                  "gpt-4-turbo-preview",
+                  "gpt-4-1106-preview",
+                  "gpt-4-vision-preview",
+                  "gpt-4",
+                  "gpt-4-0314",
+                  "gpt-4-0613",
+                  "gpt-4-32k",
+                  "gpt-4-32k-0314",
+                  "gpt-4-32k-0613",
+                  "gpt-3.5-turbo",
+                  "gpt-3.5-turbo-16k",
+                  "gpt-3.5-turbo-0613",
+                  "gpt-3.5-turbo-1106",
+                  "gpt-3.5-turbo-0125",
+                  "gpt-3.5-turbo-16k-0613"
+                ]
+              }
+            ],
+            "x-oaiTypeLabel": "string",
+            "nullable": true
+          },
+          "instructions": {
+            "description": "Override the default system message of the assistant. This is useful for modifying the behavior on a per-run basis.",
+            "type": "string",
+            "nullable": true
+          },
+          "tools": {
+            "description": "Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.",
+            "nullable": true,
+            "type": "array",
+            "maxItems": 20,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFileSearch"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ]
+            }
+          },
+          "tool_resources": {
+            "type": "object",
+            "description": "A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.\n",
+            "properties": {
+              "code_interpreter": {
+                "type": "object",
+                "properties": {
+                  "file_ids": {
+                    "type": "array",
+                    "description": "A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.\n",
+                    "default": [],
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "file_search": {
+                "type": "object",
+                "properties": {
+                  "vector_store_ids": {
+                    "type": "array",
+                    "description": "The ID of the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\n"
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 1,
+            "example": 1,
+            "nullable": true,
+            "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.\n"
+          },
+          "stream": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.\n"
+          },
+          "max_prompt_tokens": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.\n",
+            "minimum": 256
+          },
+          "max_completion_tokens": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.\n",
+            "minimum": 256
+          },
+          "truncation_strategy": {
+            "$ref": "#/components/schemas/TruncationObject",
+            "nullable": true
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/AssistantsApiToolChoiceOption",
+            "nullable": true
+          },
+          "parallel_tool_calls": {
+            "$ref": "#/components/schemas/ParallelToolCalls"
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/AssistantsApiResponseFormatOption",
+            "nullable": true
+          }
+        },
+        "required": [
+          "thread_id",
+          "assistant_id"
+        ]
+      },
+      "ThreadObject": {
+        "type": "object",
+        "title": "Thread",
+        "description": "Represents a thread that contains [messages](/docs/api-reference/messages).",
+        "properties": {
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `thread`.",
+            "type": "string",
+            "enum": [
+              "thread"
+            ]
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the thread was created.",
+            "type": "integer"
+          },
+          "tool_resources": {
+            "type": "object",
+            "description": "A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.\n",
+            "properties": {
+              "code_interpreter": {
+                "type": "object",
+                "properties": {
+                  "file_ids": {
+                    "type": "array",
+                    "description": "A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.\n",
+                    "default": [],
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "file_search": {
+                "type": "object",
+                "properties": {
+                  "vector_store_ids": {
+                    "type": "array",
+                    "description": "The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "tool_resources",
+          "metadata"
+        ],
+        "x-oaiMeta": {
+          "name": "The thread object",
+          "beta": true,
+          "example": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1698107661,\n  \"metadata\": {}\n}\n"
+        }
+      },
+      "CreateThreadRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "messages": {
+            "description": "A list of [messages](/docs/api-reference/messages) to start the thread with.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateMessageRequest"
+            }
+          },
+          "tool_resources": {
+            "type": "object",
+            "description": "A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.\n",
+            "properties": {
+              "code_interpreter": {
+                "type": "object",
+                "properties": {
+                  "file_ids": {
+                    "type": "array",
+                    "description": "A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.\n",
+                    "default": [],
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "file_search": {
+                "type": "object",
+                "properties": {
+                  "vector_store_ids": {
+                    "type": "array",
+                    "description": "The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "vector_stores": {
+                    "type": "array",
+                    "description": "A helper to create a [vector store](/docs/api-reference/vector-stores/object) with file_ids and attach it to this thread. There can be a maximum of 1 vector store attached to the thread.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "file_ids": {
+                          "type": "array",
+                          "description": "A list of [file](/docs/api-reference/files) IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.\n",
+                          "maxItems": 10000,
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "chunking_strategy": {
+                          "type": "object",
+                          "description": "The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.",
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "title": "Auto Chunking Strategy",
+                              "description": "The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.",
+                              "additionalProperties": false,
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "Always `auto`.",
+                                  "enum": [
+                                    "auto"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "title": "Static Chunking Strategy",
+                              "additionalProperties": false,
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "description": "Always `static`.",
+                                  "enum": [
+                                    "static"
+                                  ]
+                                },
+                                "static": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "max_chunk_size_tokens": {
+                                      "type": "integer",
+                                      "minimum": 100,
+                                      "maximum": 4096,
+                                      "description": "The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`."
+                                    },
+                                    "chunk_overlap_tokens": {
+                                      "type": "integer",
+                                      "description": "The number of tokens that overlap between chunks. The default value is `400`.\n\nNote that the overlap must not exceed half of `max_chunk_size_tokens`.\n"
+                                    }
+                                  },
+                                  "required": [
+                                    "max_chunk_size_tokens",
+                                    "chunk_overlap_tokens"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "static"
+                              ]
+                            }
+                          ],
+                          "x-oaiExpandable": true
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "description": "Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+                          "x-oaiTypeLabel": "map"
+                        }
+                      },
+                      "x-oaiExpandable": true
+                    }
+                  }
+                },
+                "oneOf": [
+                  {
+                    "required": [
+                      "vector_store_ids"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "vector_stores"
+                    ]
+                  }
+                ]
+              }
+            },
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        }
+      },
+      "ModifyThreadRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tool_resources": {
+            "type": "object",
+            "description": "A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.\n",
+            "properties": {
+              "code_interpreter": {
+                "type": "object",
+                "properties": {
+                  "file_ids": {
+                    "type": "array",
+                    "description": "A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.\n",
+                    "default": [],
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "file_search": {
+                "type": "object",
+                "properties": {
+                  "vector_store_ids": {
+                    "type": "array",
+                    "description": "The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.\n",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        }
+      },
+      "DeleteThreadResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "thread.deleted"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ]
+      },
+      "ListThreadsResponse": {
+        "properties": {
+          "object": {
+            "type": "string",
+            "example": "list"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThreadObject"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "example": "asst_abc123"
+          },
+          "last_id": {
+            "type": "string",
+            "example": "asst_abc456"
+          },
+          "has_more": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "MessageObject": {
+        "type": "object",
+        "title": "The message object",
+        "description": "Represents a message within a [thread](/docs/api-reference/threads).",
+        "properties": {
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `thread.message`.",
+            "type": "string",
+            "enum": [
+              "thread.message"
+            ]
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the message was created.",
+            "type": "integer"
+          },
+          "thread_id": {
+            "description": "The [thread](/docs/api-reference/threads) ID that this message belongs to.",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the message, which can be either `in_progress`, `incomplete`, or `completed`.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "incomplete",
+              "completed"
+            ]
+          },
+          "incomplete_details": {
+            "description": "On an incomplete message, details about why the message is incomplete.",
+            "type": "object",
+            "properties": {
+              "reason": {
+                "type": "string",
+                "description": "The reason the message is incomplete.",
+                "enum": [
+                  "content_filter",
+                  "max_tokens",
+                  "run_cancelled",
+                  "run_expired",
+                  "run_failed"
+                ]
+              }
+            },
+            "nullable": true,
+            "required": [
+              "reason"
+            ]
+          },
+          "completed_at": {
+            "description": "The Unix timestamp (in seconds) for when the message was completed.",
+            "type": "integer",
+            "nullable": true
+          },
+          "incomplete_at": {
+            "description": "The Unix timestamp (in seconds) for when the message was marked as incomplete.",
+            "type": "integer",
+            "nullable": true
+          },
+          "role": {
+            "description": "The entity that produced the message. One of `user` or `assistant`.",
+            "type": "string",
+            "enum": [
+              "user",
+              "assistant"
+            ]
+          },
+          "content": {
+            "description": "The content of the message in array of text and/or images.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MessageContentImageFileObject"
+                },
+                {
+                  "$ref": "#/components/schemas/MessageContentImageUrlObject"
+                },
+                {
+                  "$ref": "#/components/schemas/MessageContentTextObject"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          },
+          "assistant_id": {
+            "description": "If applicable, the ID of the [assistant](/docs/api-reference/assistants) that authored this message.",
+            "type": "string",
+            "nullable": true
+          },
+          "run_id": {
+            "description": "The ID of the [run](/docs/api-reference/runs) associated with the creation of this message. Value is `null` when messages are created manually using the create message or create thread endpoints.",
+            "type": "string",
+            "nullable": true
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "file_id": {
+                  "type": "string",
+                  "description": "The ID of the file to attach to the message."
+                },
+                "tools": {
+                  "description": "The tools to add this file to.",
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/AssistantToolsCode"
+                      },
+                      {
+                        "$ref": "#/components/schemas/AssistantToolsFileSearchTypeOnly"
+                      }
+                    ],
+                    "x-oaiExpandable": true
+                  }
+                }
+              }
+            },
+            "description": "A list of files attached to the message, and the tools they were added to.",
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "thread_id",
+          "status",
+          "incomplete_details",
+          "completed_at",
+          "incomplete_at",
+          "role",
+          "content",
+          "assistant_id",
+          "run_id",
+          "attachments",
+          "metadata"
+        ],
+        "x-oaiMeta": {
+          "name": "The message object",
+          "beta": true,
+          "example": "{\n  \"id\": \"msg_abc123\",\n  \"object\": \"thread.message\",\n  \"created_at\": 1698983503,\n  \"thread_id\": \"thread_abc123\",\n  \"role\": \"assistant\",\n  \"content\": [\n    {\n      \"type\": \"text\",\n      \"text\": {\n        \"value\": \"Hi! How can I help you today?\",\n        \"annotations\": []\n      }\n    }\n  ],\n  \"assistant_id\": \"asst_abc123\",\n  \"run_id\": \"run_abc123\",\n  \"attachments\": [],\n  \"metadata\": {}\n}\n"
+        }
+      },
+      "MessageDeltaObject": {
+        "type": "object",
+        "title": "Message delta object",
+        "description": "Represents a message delta i.e. any changed fields on a message during streaming.\n",
+        "properties": {
+          "id": {
+            "description": "The identifier of the message, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `thread.message.delta`.",
+            "type": "string",
+            "enum": [
+              "thread.message.delta"
+            ]
+          },
+          "delta": {
+            "description": "The delta containing the fields that have changed on the Message.",
+            "type": "object",
+            "properties": {
+              "role": {
+                "description": "The entity that produced the message. One of `user` or `assistant`.",
+                "type": "string",
+                "enum": [
+                  "user",
+                  "assistant"
+                ]
+              },
+              "content": {
+                "description": "The content of the message in array of text and/or images.",
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MessageDeltaContentImageFileObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessageDeltaContentTextObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessageDeltaContentImageUrlObject"
+                    }
+                  ],
+                  "x-oaiExpandable": true
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "delta"
+        ],
+        "x-oaiMeta": {
+          "name": "The message delta object",
+          "beta": true,
+          "example": "{\n  \"id\": \"msg_123\",\n  \"object\": \"thread.message.delta\",\n  \"delta\": {\n    \"content\": [\n      {\n        \"index\": 0,\n        \"type\": \"text\",\n        \"text\": { \"value\": \"Hello\", \"annotations\": [] }\n      }\n    ]\n  }\n}\n"
+        }
+      },
+      "CreateMessageRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "role",
+          "content"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "assistant"
+            ],
+            "description": "The role of the entity that is creating the message. Allowed values include:\n- `user`: Indicates the message is sent by an actual user and should be used in most cases to represent user-generated messages.\n- `assistant`: Indicates the message is generated by the assistant. Use this value to insert messages from the assistant into the conversation.\n"
+          },
+          "content": {
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "The text contents of the message.",
+                "title": "Text content"
+              },
+              {
+                "type": "array",
+                "description": "An array of content parts with a defined type, each can be of type `text` or images can be passed with `image_url` or `image_file`. Image types are only supported on [Vision-compatible models](/docs/models/overview).",
+                "title": "Array of content parts",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MessageContentImageFileObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessageContentImageUrlObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessageRequestContentTextObject"
+                    }
+                  ],
+                  "x-oaiExpandable": true
+                },
+                "minItems": 1
+              }
+            ],
+            "x-oaiExpandable": true
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "file_id": {
+                  "type": "string",
+                  "description": "The ID of the file to attach to the message."
+                },
+                "tools": {
+                  "description": "The tools to add this file to.",
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/AssistantToolsCode"
+                      },
+                      {
+                        "$ref": "#/components/schemas/AssistantToolsFileSearchTypeOnly"
+                      }
+                    ],
+                    "x-oaiExpandable": true
+                  }
+                }
+              }
+            },
+            "description": "A list of files attached to the message, and the tools they should be added to.",
+            "required": [
+              "file_id",
+              "tools"
+            ],
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        }
+      },
+      "ModifyMessageRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        }
+      },
+      "DeleteMessageResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "thread.message.deleted"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ]
+      },
+      "ListMessagesResponse": {
+        "properties": {
+          "object": {
+            "type": "string",
+            "example": "list"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageObject"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "example": "msg_abc123"
+          },
+          "last_id": {
+            "type": "string",
+            "example": "msg_abc123"
+          },
+          "has_more": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "MessageContentImageFileObject": {
+        "title": "Image file",
+        "type": "object",
+        "description": "References an image [File](/docs/api-reference/files) in the content of a message.",
+        "properties": {
+          "type": {
+            "description": "Always `image_file`.",
+            "type": "string",
+            "enum": [
+              "image_file"
+            ]
+          },
+          "image_file": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "description": "The [File](/docs/api-reference/files) ID of the image in the message content. Set `purpose=\"vision\"` when uploading the File if you need to later display the file content.",
+                "type": "string"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Specifies the detail level of the image if specified by the user. `low` uses fewer tokens, you can opt in to high resolution using `high`.",
+                "enum": [
+                  "auto",
+                  "low",
+                  "high"
+                ],
+                "default": "auto"
+              }
+            },
+            "required": [
+              "file_id"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "image_file"
+        ]
+      },
+      "MessageDeltaContentImageFileObject": {
+        "title": "Image file",
+        "type": "object",
+        "description": "References an image [File](/docs/api-reference/files) in the content of a message.",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the content part in the message."
+          },
+          "type": {
+            "description": "Always `image_file`.",
+            "type": "string",
+            "enum": [
+              "image_file"
+            ]
+          },
+          "image_file": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "description": "The [File](/docs/api-reference/files) ID of the image in the message content. Set `purpose=\"vision\"` when uploading the File if you need to later display the file content.",
+                "type": "string"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Specifies the detail level of the image if specified by the user. `low` uses fewer tokens, you can opt in to high resolution using `high`.",
+                "enum": [
+                  "auto",
+                  "low",
+                  "high"
+                ],
+                "default": "auto"
+              }
+            }
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "MessageContentImageUrlObject": {
+        "title": "Image URL",
+        "type": "object",
+        "description": "References an image URL in the content of a message.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "image_url"
+            ],
+            "description": "The type of the content part."
+          },
+          "image_url": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "The external URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp.",
+                "format": "uri"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Specifies the detail level of the image. `low` uses fewer tokens, you can opt in to high resolution using `high`. Default value is `auto`",
+                "enum": [
+                  "auto",
+                  "low",
+                  "high"
+                ],
+                "default": "auto"
+              }
+            },
+            "required": [
+              "url"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "image_url"
+        ]
+      },
+      "MessageDeltaContentImageUrlObject": {
+        "title": "Image URL",
+        "type": "object",
+        "description": "References an image URL in the content of a message.",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the content part in the message."
+          },
+          "type": {
+            "description": "Always `image_url`.",
+            "type": "string",
+            "enum": [
+              "image_url"
+            ]
+          },
+          "image_url": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "description": "The URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp.",
+                "type": "string"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Specifies the detail level of the image. `low` uses fewer tokens, you can opt in to high resolution using `high`.",
+                "enum": [
+                  "auto",
+                  "low",
+                  "high"
+                ],
+                "default": "auto"
+              }
+            }
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "MessageContentTextObject": {
+        "title": "Text",
+        "type": "object",
+        "description": "The text content that is part of a message.",
+        "properties": {
+          "type": {
+            "description": "Always `text`.",
+            "type": "string",
+            "enum": [
+              "text"
+            ]
+          },
+          "text": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "description": "The data that makes up the text.",
+                "type": "string"
+              },
+              "annotations": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MessageContentTextAnnotationsFileCitationObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessageContentTextAnnotationsFilePathObject"
+                    }
+                  ],
+                  "x-oaiExpandable": true
+                }
+              }
+            },
+            "required": [
+              "value",
+              "annotations"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ]
+      },
+      "MessageRequestContentTextObject": {
+        "title": "Text",
+        "type": "object",
+        "description": "The text content that is part of a message.",
+        "properties": {
+          "type": {
+            "description": "Always `text`.",
+            "type": "string",
+            "enum": [
+              "text"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "description": "Text content to be sent to the model"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ]
+      },
+      "MessageContentTextAnnotationsFileCitationObject": {
+        "title": "File citation",
+        "type": "object",
+        "description": "A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the \"file_search\" tool to search files.",
+        "properties": {
+          "type": {
+            "description": "Always `file_citation`.",
+            "type": "string",
+            "enum": [
+              "file_citation"
+            ]
+          },
+          "text": {
+            "description": "The text in the message content that needs to be replaced.",
+            "type": "string"
+          },
+          "file_citation": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "description": "The ID of the specific File the citation is from.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_id"
+            ]
+          },
+          "start_index": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "end_index": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "type",
+          "text",
+          "file_citation",
+          "start_index",
+          "end_index"
+        ]
+      },
+      "MessageContentTextAnnotationsFilePathObject": {
+        "title": "File path",
+        "type": "object",
+        "description": "A URL for the file that's generated when the assistant used the `code_interpreter` tool to generate a file.",
+        "properties": {
+          "type": {
+            "description": "Always `file_path`.",
+            "type": "string",
+            "enum": [
+              "file_path"
+            ]
+          },
+          "text": {
+            "description": "The text in the message content that needs to be replaced.",
+            "type": "string"
+          },
+          "file_path": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "description": "The ID of the file that was generated.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_id"
+            ]
+          },
+          "start_index": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "end_index": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "type",
+          "text",
+          "file_path",
+          "start_index",
+          "end_index"
+        ]
+      },
+      "MessageDeltaContentTextObject": {
+        "title": "Text",
+        "type": "object",
+        "description": "The text content that is part of a message.",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the content part in the message."
+          },
+          "type": {
+            "description": "Always `text`.",
+            "type": "string",
+            "enum": [
+              "text"
+            ]
+          },
+          "text": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "description": "The data that makes up the text.",
+                "type": "string"
+              },
+              "annotations": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MessageDeltaContentTextAnnotationsFileCitationObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessageDeltaContentTextAnnotationsFilePathObject"
+                    }
+                  ],
+                  "x-oaiExpandable": true
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "MessageDeltaContentTextAnnotationsFileCitationObject": {
+        "title": "File citation",
+        "type": "object",
+        "description": "A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the \"file_search\" tool to search files.",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the annotation in the text content part."
+          },
+          "type": {
+            "description": "Always `file_citation`.",
+            "type": "string",
+            "enum": [
+              "file_citation"
+            ]
+          },
+          "text": {
+            "description": "The text in the message content that needs to be replaced.",
+            "type": "string"
+          },
+          "file_citation": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "description": "The ID of the specific File the citation is from.",
+                "type": "string"
+              },
+              "quote": {
+                "description": "The specific quote in the file.",
+                "type": "string"
+              }
+            }
+          },
+          "start_index": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "end_index": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "MessageDeltaContentTextAnnotationsFilePathObject": {
+        "title": "File path",
+        "type": "object",
+        "description": "A URL for the file that's generated when the assistant used the `code_interpreter` tool to generate a file.",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the annotation in the text content part."
+          },
+          "type": {
+            "description": "Always `file_path`.",
+            "type": "string",
+            "enum": [
+              "file_path"
+            ]
+          },
+          "text": {
+            "description": "The text in the message content that needs to be replaced.",
+            "type": "string"
+          },
+          "file_path": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "description": "The ID of the file that was generated.",
+                "type": "string"
+              }
+            }
+          },
+          "start_index": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "end_index": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "RunStepObject": {
+        "type": "object",
+        "title": "Run steps",
+        "description": "Represents a step in execution of a run.\n",
+        "properties": {
+          "id": {
+            "description": "The identifier of the run step, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `thread.run.step`.",
+            "type": "string",
+            "enum": [
+              "thread.run.step"
+            ]
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step was created.",
+            "type": "integer"
+          },
+          "assistant_id": {
+            "description": "The ID of the [assistant](/docs/api-reference/assistants) associated with the run step.",
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "The ID of the [thread](/docs/api-reference/threads) that was run.",
+            "type": "string"
+          },
+          "run_id": {
+            "description": "The ID of the [run](/docs/api-reference/runs) that this run step is a part of.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of run step, which can be either `message_creation` or `tool_calls`.",
+            "type": "string",
+            "enum": [
+              "message_creation",
+              "tool_calls"
+            ]
+          },
+          "status": {
+            "description": "The status of the run step, which can be either `in_progress`, `cancelled`, `failed`, `completed`, or `expired`.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "cancelled",
+              "failed",
+              "completed",
+              "expired"
+            ]
+          },
+          "step_details": {
+            "type": "object",
+            "description": "The details of the run step.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/RunStepDetailsMessageCreationObject"
+              },
+              {
+                "$ref": "#/components/schemas/RunStepDetailsToolCallsObject"
+              }
+            ],
+            "x-oaiExpandable": true
+          },
+          "last_error": {
+            "type": "object",
+            "description": "The last error associated with this run step. Will be `null` if there are no errors.",
+            "nullable": true,
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "One of `server_error` or `rate_limit_exceeded`.",
+                "enum": [
+                  "server_error",
+                  "rate_limit_exceeded"
+                ]
+              },
+              "message": {
+                "type": "string",
+                "description": "A human-readable description of the error."
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          },
+          "expired_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step expired. A step is considered expired if the parent run is expired.",
+            "type": "integer",
+            "nullable": true
+          },
+          "cancelled_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step was cancelled.",
+            "type": "integer",
+            "nullable": true
+          },
+          "failed_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step failed.",
+            "type": "integer",
+            "nullable": true
+          },
+          "completed_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step completed.",
+            "type": "integer",
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          },
+          "usage": {
+            "$ref": "#/components/schemas/RunStepCompletionUsage"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "assistant_id",
+          "thread_id",
+          "run_id",
+          "type",
+          "status",
+          "step_details",
+          "last_error",
+          "expired_at",
+          "cancelled_at",
+          "failed_at",
+          "completed_at",
+          "metadata",
+          "usage"
+        ],
+        "x-oaiMeta": {
+          "name": "The run step object",
+          "beta": true,
+          "example": "{\n  \"id\": \"step_abc123\",\n  \"object\": \"thread.run.step\",\n  \"created_at\": 1699063291,\n  \"run_id\": \"run_abc123\",\n  \"assistant_id\": \"asst_abc123\",\n  \"thread_id\": \"thread_abc123\",\n  \"type\": \"message_creation\",\n  \"status\": \"completed\",\n  \"cancelled_at\": null,\n  \"completed_at\": 1699063291,\n  \"expired_at\": null,\n  \"failed_at\": null,\n  \"last_error\": null,\n  \"step_details\": {\n    \"type\": \"message_creation\",\n    \"message_creation\": {\n      \"message_id\": \"msg_abc123\"\n    }\n  },\n  \"usage\": {\n    \"prompt_tokens\": 123,\n    \"completion_tokens\": 456,\n    \"total_tokens\": 579\n  }\n}\n"
+        }
+      },
+      "RunStepDeltaObject": {
+        "type": "object",
+        "title": "Run step delta object",
+        "description": "Represents a run step delta i.e. any changed fields on a run step during streaming.\n",
+        "properties": {
+          "id": {
+            "description": "The identifier of the run step, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `thread.run.step.delta`.",
+            "type": "string",
+            "enum": [
+              "thread.run.step.delta"
+            ]
+          },
+          "delta": {
+            "description": "The delta containing the fields that have changed on the run step.",
+            "type": "object",
+            "properties": {
+              "step_details": {
+                "type": "object",
+                "description": "The details of the run step.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/RunStepDeltaStepDetailsMessageCreationObject"
+                  },
+                  {
+                    "$ref": "#/components/schemas/RunStepDeltaStepDetailsToolCallsObject"
+                  }
+                ],
+                "x-oaiExpandable": true
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "delta"
+        ],
+        "x-oaiMeta": {
+          "name": "The run step delta object",
+          "beta": true,
+          "example": "{\n  \"id\": \"step_123\",\n  \"object\": \"thread.run.step.delta\",\n  \"delta\": {\n    \"step_details\": {\n      \"type\": \"tool_calls\",\n      \"tool_calls\": [\n        {\n          \"index\": 0,\n          \"id\": \"call_123\",\n          \"type\": \"code_interpreter\",\n          \"code_interpreter\": { \"input\": \"\", \"outputs\": [] }\n        }\n      ]\n    }\n  }\n}\n"
+        }
+      },
+      "ListRunStepsResponse": {
+        "properties": {
+          "object": {
+            "type": "string",
+            "example": "list"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RunStepObject"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "example": "step_abc123"
+          },
+          "last_id": {
+            "type": "string",
+            "example": "step_abc456"
+          },
+          "has_more": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "RunStepDetailsMessageCreationObject": {
+        "title": "Message creation",
+        "type": "object",
+        "description": "Details of the message creation by the run step.",
+        "properties": {
+          "type": {
+            "description": "Always `message_creation`.",
+            "type": "string",
+            "enum": [
+              "message_creation"
+            ]
+          },
+          "message_creation": {
+            "type": "object",
+            "properties": {
+              "message_id": {
+                "type": "string",
+                "description": "The ID of the message that was created by this run step."
+              }
+            },
+            "required": [
+              "message_id"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "message_creation"
+        ]
+      },
+      "RunStepDeltaStepDetailsMessageCreationObject": {
+        "title": "Message creation",
+        "type": "object",
+        "description": "Details of the message creation by the run step.",
+        "properties": {
+          "type": {
+            "description": "Always `message_creation`.",
+            "type": "string",
+            "enum": [
+              "message_creation"
+            ]
+          },
+          "message_creation": {
+            "type": "object",
+            "properties": {
+              "message_id": {
+                "type": "string",
+                "description": "The ID of the message that was created by this run step."
+              }
+            }
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "RunStepDetailsToolCallsObject": {
+        "title": "Tool calls",
+        "type": "object",
+        "description": "Details of the tool call.",
+        "properties": {
+          "type": {
+            "description": "Always `tool_calls`.",
+            "type": "string",
+            "enum": [
+              "tool_calls"
+            ]
+          },
+          "tool_calls": {
+            "type": "array",
+            "description": "An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `file_search`, or `function`.\n",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RunStepDetailsToolCallsCodeObject"
+                },
+                {
+                  "$ref": "#/components/schemas/RunStepDetailsToolCallsFileSearchObject"
+                },
+                {
+                  "$ref": "#/components/schemas/RunStepDetailsToolCallsFunctionObject"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          }
+        },
+        "required": [
+          "type",
+          "tool_calls"
+        ]
+      },
+      "RunStepDeltaStepDetailsToolCallsObject": {
+        "title": "Tool calls",
+        "type": "object",
+        "description": "Details of the tool call.",
+        "properties": {
+          "type": {
+            "description": "Always `tool_calls`.",
+            "type": "string",
+            "enum": [
+              "tool_calls"
+            ]
+          },
+          "tool_calls": {
+            "type": "array",
+            "description": "An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `file_search`, or `function`.\n",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeObject"
+                },
+                {
+                  "$ref": "#/components/schemas/RunStepDeltaStepDetailsToolCallsFileSearchObject"
+                },
+                {
+                  "$ref": "#/components/schemas/RunStepDeltaStepDetailsToolCallsFunctionObject"
+                }
+              ],
+              "x-oaiExpandable": true
+            }
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "RunStepDetailsToolCallsCodeObject": {
+        "title": "Code Interpreter tool call",
+        "type": "object",
+        "description": "Details of the Code Interpreter tool call the run step was involved in.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of tool call. This is always going to be `code_interpreter` for this type of tool call.",
+            "enum": [
+              "code_interpreter"
+            ]
+          },
+          "code_interpreter": {
+            "type": "object",
+            "description": "The Code Interpreter tool call definition.",
+            "required": [
+              "input",
+              "outputs"
+            ],
+            "properties": {
+              "input": {
+                "type": "string",
+                "description": "The input to the Code Interpreter tool call."
+              },
+              "outputs": {
+                "type": "array",
+                "description": "The outputs from the Code Interpreter tool call. Code Interpreter can output one or more items, including text (`logs`) or images (`image`). Each of these are represented by a different object type.",
+                "items": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RunStepDetailsToolCallsCodeOutputLogsObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RunStepDetailsToolCallsCodeOutputImageObject"
+                    }
+                  ],
+                  "x-oaiExpandable": true
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "code_interpreter"
+        ]
+      },
+      "RunStepDeltaStepDetailsToolCallsCodeObject": {
+        "title": "Code interpreter tool call",
+        "type": "object",
+        "description": "Details of the Code Interpreter tool call the run step was involved in.",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the tool call in the tool calls array."
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of tool call. This is always going to be `code_interpreter` for this type of tool call.",
+            "enum": [
+              "code_interpreter"
+            ]
+          },
+          "code_interpreter": {
+            "type": "object",
+            "description": "The Code Interpreter tool call definition.",
+            "properties": {
+              "input": {
+                "type": "string",
+                "description": "The input to the Code Interpreter tool call."
+              },
+              "outputs": {
+                "type": "array",
+                "description": "The outputs from the Code Interpreter tool call. Code Interpreter can output one or more items, including text (`logs`) or images (`image`). Each of these are represented by a different object type.",
+                "items": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputImageObject"
+                    }
+                  ],
+                  "x-oaiExpandable": true
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "RunStepDetailsToolCallsCodeOutputLogsObject": {
+        "title": "Code Interpreter log output",
+        "type": "object",
+        "description": "Text output from the Code Interpreter tool call as part of a run step.",
+        "properties": {
+          "type": {
+            "description": "Always `logs`.",
+            "type": "string",
+            "enum": [
+              "logs"
+            ]
+          },
+          "logs": {
+            "type": "string",
+            "description": "The text output from the Code Interpreter tool call."
+          }
+        },
+        "required": [
+          "type",
+          "logs"
+        ]
+      },
+      "RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject": {
+        "title": "Code interpreter log output",
+        "type": "object",
+        "description": "Text output from the Code Interpreter tool call as part of a run step.",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the output in the outputs array."
+          },
+          "type": {
+            "description": "Always `logs`.",
+            "type": "string",
+            "enum": [
+              "logs"
+            ]
+          },
+          "logs": {
+            "type": "string",
+            "description": "The text output from the Code Interpreter tool call."
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "RunStepDetailsToolCallsCodeOutputImageObject": {
+        "title": "Code Interpreter image output",
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Always `image`.",
+            "type": "string",
+            "enum": [
+              "image"
+            ]
+          },
+          "image": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "description": "The [file](/docs/api-reference/files) ID of the image.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_id"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "image"
+        ]
+      },
+      "RunStepDeltaStepDetailsToolCallsCodeOutputImageObject": {
+        "title": "Code interpreter image output",
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the output in the outputs array."
+          },
+          "type": {
+            "description": "Always `image`.",
+            "type": "string",
+            "enum": [
+              "image"
+            ]
+          },
+          "image": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "description": "The [file](/docs/api-reference/files) ID of the image.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "RunStepDetailsToolCallsFileSearchObject": {
+        "title": "File search tool call",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call object."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of tool call. This is always going to be `file_search` for this type of tool call.",
+            "enum": [
+              "file_search"
+            ]
+          },
+          "file_search": {
+            "type": "object",
+            "description": "For now, this is always going to be an empty object.",
+            "x-oaiTypeLabel": "map"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "file_search"
+        ]
+      },
+      "RunStepDeltaStepDetailsToolCallsFileSearchObject": {
+        "title": "File search tool call",
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the tool call in the tool calls array."
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call object."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of tool call. This is always going to be `file_search` for this type of tool call.",
+            "enum": [
+              "file_search"
+            ]
+          },
+          "file_search": {
+            "type": "object",
+            "description": "For now, this is always going to be an empty object.",
+            "x-oaiTypeLabel": "map"
+          }
+        },
+        "required": [
+          "index",
+          "type",
+          "file_search"
+        ]
+      },
+      "RunStepDetailsToolCallsFunctionObject": {
+        "type": "object",
+        "title": "Function tool call",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call object."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of tool call. This is always going to be `function` for this type of tool call.",
+            "enum": [
+              "function"
+            ]
+          },
+          "function": {
+            "type": "object",
+            "description": "The definition of the function that was called.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the function."
+              },
+              "arguments": {
+                "type": "string",
+                "description": "The arguments passed to the function."
+              },
+              "output": {
+                "type": "string",
+                "description": "The output of the function. This will be `null` if the outputs have not been [submitted](/docs/api-reference/runs/submitToolOutputs) yet.",
+                "nullable": true
+              }
+            },
+            "required": [
+              "name",
+              "arguments",
+              "output"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "function"
+        ]
+      },
+      "RunStepDeltaStepDetailsToolCallsFunctionObject": {
+        "type": "object",
+        "title": "Function tool call",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "The index of the tool call in the tool calls array."
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of the tool call object."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of tool call. This is always going to be `function` for this type of tool call.",
+            "enum": [
+              "function"
+            ]
+          },
+          "function": {
+            "type": "object",
+            "description": "The definition of the function that was called.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the function."
+              },
+              "arguments": {
+                "type": "string",
+                "description": "The arguments passed to the function."
+              },
+              "output": {
+                "type": "string",
+                "description": "The output of the function. This will be `null` if the outputs have not been [submitted](/docs/api-reference/runs/submitToolOutputs) yet.",
+                "nullable": true
+              }
+            }
+          }
+        },
+        "required": [
+          "index",
+          "type"
+        ]
+      },
+      "VectorStoreExpirationAfter": {
+        "type": "object",
+        "title": "Vector store expiration policy",
+        "description": "The expiration policy for a vector store.",
+        "properties": {
+          "anchor": {
+            "description": "Anchor timestamp after which the expiration policy applies. Supported anchors: `last_active_at`.",
+            "type": "string",
+            "enum": [
+              "last_active_at"
+            ]
+          },
+          "days": {
+            "description": "The number of days after the anchor time that the vector store will expire.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 365
+          }
+        },
+        "required": [
+          "anchor",
+          "days"
+        ]
+      },
+      "VectorStoreObject": {
+        "type": "object",
+        "title": "Vector store",
+        "description": "A vector store is a collection of processed files can be used by the `file_search` tool.",
+        "properties": {
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `vector_store`.",
+            "type": "string",
+            "enum": [
+              "vector_store"
+            ]
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the vector store was created.",
+            "type": "integer"
+          },
+          "name": {
+            "description": "The name of the vector store.",
+            "type": "string"
+          },
+          "usage_bytes": {
+            "description": "The total number of bytes used by the files in the vector store.",
+            "type": "integer"
+          },
+          "file_counts": {
+            "type": "object",
+            "properties": {
+              "in_progress": {
+                "description": "The number of files that are currently being processed.",
+                "type": "integer"
+              },
+              "completed": {
+                "description": "The number of files that have been successfully processed.",
+                "type": "integer"
+              },
+              "failed": {
+                "description": "The number of files that have failed to process.",
+                "type": "integer"
+              },
+              "cancelled": {
+                "description": "The number of files that were cancelled.",
+                "type": "integer"
+              },
+              "total": {
+                "description": "The total number of files.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "in_progress",
+              "completed",
+              "failed",
+              "cancelled",
+              "total"
+            ]
+          },
+          "status": {
+            "description": "The status of the vector store, which can be either `expired`, `in_progress`, or `completed`. A status of `completed` indicates that the vector store is ready for use.",
+            "type": "string",
+            "enum": [
+              "expired",
+              "in_progress",
+              "completed"
+            ]
+          },
+          "expires_after": {
+            "$ref": "#/components/schemas/VectorStoreExpirationAfter"
+          },
+          "expires_at": {
+            "description": "The Unix timestamp (in seconds) for when the vector store will expire.",
+            "type": "integer",
+            "nullable": true
+          },
+          "last_active_at": {
+            "description": "The Unix timestamp (in seconds) for when the vector store was last active.",
+            "type": "integer",
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "usage_bytes",
+          "created_at",
+          "status",
+          "last_active_at",
+          "name",
+          "file_counts",
+          "metadata"
+        ],
+        "x-oaiMeta": {
+          "name": "The vector store object",
+          "beta": true,
+          "example": "{\n  \"id\": \"vs_123\",\n  \"object\": \"vector_store\",\n  \"created_at\": 1698107661,\n  \"usage_bytes\": 123456,\n  \"last_active_at\": 1698107661,\n  \"name\": \"my_vector_store\",\n  \"status\": \"completed\",\n  \"file_counts\": {\n    \"in_progress\": 0,\n    \"completed\": 100,\n    \"cancelled\": 0,\n    \"failed\": 0,\n    \"total\": 100\n  },\n  \"metadata\": {},\n  \"last_used_at\": 1698107661\n}\n"
+        }
+      },
+      "CreateVectorStoreRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "file_ids": {
+            "description": "A list of [File](/docs/api-reference/files) IDs that the vector store should use. Useful for tools like `file_search` that can access files.",
+            "type": "array",
+            "maxItems": 500,
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "description": "The name of the vector store.",
+            "type": "string"
+          },
+          "expires_after": {
+            "$ref": "#/components/schemas/VectorStoreExpirationAfter"
+          },
+          "chunking_strategy": {
+            "type": "object",
+            "description": "The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy. Only applicable if `file_ids` is non-empty.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AutoChunkingStrategyRequestParam"
+              },
+              {
+                "$ref": "#/components/schemas/StaticChunkingStrategyRequestParam"
+              }
+            ],
+            "x-oaiExpandable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        }
+      },
+      "UpdateVectorStoreRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The name of the vector store.",
+            "type": "string",
+            "nullable": true
+          },
+          "expires_after": {
+            "$ref": "#/components/schemas/VectorStoreExpirationAfter",
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        }
+      },
+      "ListVectorStoresResponse": {
+        "properties": {
+          "object": {
+            "type": "string",
+            "example": "list"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VectorStoreObject"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "example": "vs_abc123"
+          },
+          "last_id": {
+            "type": "string",
+            "example": "vs_abc456"
+          },
+          "has_more": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "DeleteVectorStoreResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "vector_store.deleted"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ]
+      },
+      "VectorStoreFileObject": {
+        "type": "object",
+        "title": "Vector store files",
+        "description": "A list of files attached to a vector store.",
+        "properties": {
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `vector_store.file`.",
+            "type": "string",
+            "enum": [
+              "vector_store.file"
+            ]
+          },
+          "usage_bytes": {
+            "description": "The total vector store usage in bytes. Note that this may be different from the original file size.",
+            "type": "integer"
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the vector store file was created.",
+            "type": "integer"
+          },
+          "vector_store_id": {
+            "description": "The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files) is attached to.",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the vector store file, which can be either `in_progress`, `completed`, `cancelled`, or `failed`. The status `completed` indicates that the vector store file is ready for use.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "cancelled",
+              "failed"
+            ]
+          },
+          "last_error": {
+            "type": "object",
+            "description": "The last error associated with this vector store file. Will be `null` if there are no errors.",
+            "nullable": true,
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "One of `server_error` or `rate_limit_exceeded`.",
+                "enum": [
+                  "internal_error",
+                  "file_not_found",
+                  "parsing_error",
+                  "unhandled_mime_type"
+                ]
+              },
+              "message": {
+                "type": "string",
+                "description": "A human-readable description of the error."
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          },
+          "chunking_strategy": {
+            "type": "object",
+            "description": "The strategy used to chunk the file.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/StaticChunkingStrategyResponseParam"
+              },
+              {
+                "$ref": "#/components/schemas/OtherChunkingStrategyResponseParam"
+              }
+            ],
+            "x-oaiExpandable": true
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "usage_bytes",
+          "created_at",
+          "vector_store_id",
+          "status",
+          "last_error"
+        ],
+        "x-oaiMeta": {
+          "name": "The vector store file object",
+          "beta": true,
+          "example": "{\n  \"id\": \"file-abc123\",\n  \"object\": \"vector_store.file\",\n  \"usage_bytes\": 1234,\n  \"created_at\": 1698107661,\n  \"vector_store_id\": \"vs_abc123\",\n  \"status\": \"completed\",\n  \"last_error\": null,\n  \"chunking_strategy\": {\n    \"type\": \"static\",\n    \"static\": {\n      \"max_chunk_size_tokens\": 800,\n      \"chunk_overlap_tokens\": 400\n    }\n  }\n}\n"
+        }
+      },
+      "OtherChunkingStrategyResponseParam": {
+        "type": "object",
+        "title": "Other Chunking Strategy",
+        "description": "This is returned when the chunking strategy is unknown. Typically, this is because the file was indexed before the `chunking_strategy` concept was introduced in the API.",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Always `other`.",
+            "enum": [
+              "other"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "StaticChunkingStrategyResponseParam": {
+        "type": "object",
+        "title": "Static Chunking Strategy",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Always `static`.",
+            "enum": [
+              "static"
+            ]
+          },
+          "static": {
+            "$ref": "#/components/schemas/StaticChunkingStrategy"
+          }
+        },
+        "required": [
+          "type",
+          "static"
+        ]
+      },
+      "StaticChunkingStrategy": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "max_chunk_size_tokens": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 4096,
+            "description": "The maximum number of tokens in each chunk. The default value is `800`. The minimum value is `100` and the maximum value is `4096`."
+          },
+          "chunk_overlap_tokens": {
+            "type": "integer",
+            "description": "The number of tokens that overlap between chunks. The default value is `400`.\n\nNote that the overlap must not exceed half of `max_chunk_size_tokens`.\n"
+          }
+        },
+        "required": [
+          "max_chunk_size_tokens",
+          "chunk_overlap_tokens"
+        ]
+      },
+      "AutoChunkingStrategyRequestParam": {
+        "type": "object",
+        "title": "Auto Chunking Strategy",
+        "description": "The default strategy. This strategy currently uses a `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Always `auto`.",
+            "enum": [
+              "auto"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "StaticChunkingStrategyRequestParam": {
+        "type": "object",
+        "title": "Static Chunking Strategy",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Always `static`.",
+            "enum": [
+              "static"
+            ]
+          },
+          "static": {
+            "$ref": "#/components/schemas/StaticChunkingStrategy"
+          }
+        },
+        "required": [
+          "type",
+          "static"
+        ]
+      },
+      "ChunkingStrategyRequestParam": {
+        "type": "object",
+        "description": "The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AutoChunkingStrategyRequestParam"
+          },
+          {
+            "$ref": "#/components/schemas/StaticChunkingStrategyRequestParam"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "CreateVectorStoreFileRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "file_id": {
+            "description": "A [File](/docs/api-reference/files) ID that the vector store should use. Useful for tools like `file_search` that can access files.",
+            "type": "string"
+          },
+          "chunking_strategy": {
+            "$ref": "#/components/schemas/ChunkingStrategyRequestParam"
+          }
+        },
+        "required": [
+          "file_id"
+        ]
+      },
+      "ListVectorStoreFilesResponse": {
+        "properties": {
+          "object": {
+            "type": "string",
+            "example": "list"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VectorStoreFileObject"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "example": "file-abc123"
+          },
+          "last_id": {
+            "type": "string",
+            "example": "file-abc456"
+          },
+          "has_more": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "DeleteVectorStoreFileResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "vector_store.file.deleted"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ]
+      },
+      "VectorStoreFileBatchObject": {
+        "type": "object",
+        "title": "Vector store file batch",
+        "description": "A batch of files attached to a vector store.",
+        "properties": {
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `vector_store.file_batch`.",
+            "type": "string",
+            "enum": [
+              "vector_store.files_batch"
+            ]
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the vector store files batch was created.",
+            "type": "integer"
+          },
+          "vector_store_id": {
+            "description": "The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files) is attached to.",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the vector store files batch, which can be either `in_progress`, `completed`, `cancelled` or `failed`.",
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "cancelled",
+              "failed"
+            ]
+          },
+          "file_counts": {
+            "type": "object",
+            "properties": {
+              "in_progress": {
+                "description": "The number of files that are currently being processed.",
+                "type": "integer"
+              },
+              "completed": {
+                "description": "The number of files that have been processed.",
+                "type": "integer"
+              },
+              "failed": {
+                "description": "The number of files that have failed to process.",
+                "type": "integer"
+              },
+              "cancelled": {
+                "description": "The number of files that where cancelled.",
+                "type": "integer"
+              },
+              "total": {
+                "description": "The total number of files.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "in_progress",
+              "completed",
+              "cancelled",
+              "failed",
+              "total"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "vector_store_id",
+          "status",
+          "file_counts"
+        ],
+        "x-oaiMeta": {
+          "name": "The vector store files batch object",
+          "beta": true,
+          "example": "{\n  \"id\": \"vsfb_123\",\n  \"object\": \"vector_store.files_batch\",\n  \"created_at\": 1698107661,\n  \"vector_store_id\": \"vs_abc123\",\n  \"status\": \"completed\",\n  \"file_counts\": {\n    \"in_progress\": 0,\n    \"completed\": 100,\n    \"failed\": 0,\n    \"cancelled\": 0,\n    \"total\": 100\n  }\n}\n"
+        }
+      },
+      "CreateVectorStoreFileBatchRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "file_ids": {
+            "description": "A list of [File](/docs/api-reference/files) IDs that the vector store should use. Useful for tools like `file_search` that can access files.",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 500,
+            "items": {
+              "type": "string"
+            }
+          },
+          "chunking_strategy": {
+            "$ref": "#/components/schemas/ChunkingStrategyRequestParam"
+          }
+        },
+        "required": [
+          "file_ids"
+        ]
+      },
+      "AssistantStreamEvent": {
+        "description": "Represents an event emitted when streaming a Run.\n\nEach event in a server-sent events stream has an `event` and `data` property:\n\n```\nevent: thread.created\ndata: {\"id\": \"thread_123\", \"object\": \"thread\", ...}\n```\n\nWe emit events whenever a new object is created, transitions to a new state, or is being\nstreamed in parts (deltas). For example, we emit `thread.run.created` when a new run\nis created, `thread.run.completed` when a run completes, and so on. When an Assistant chooses\nto create a message during a run, we emit a `thread.message.created event`, a\n`thread.message.in_progress` event, many `thread.message.delta` events, and finally a\n`thread.message.completed` event.\n\nWe may add additional events over time, so we recommend handling unknown events gracefully\nin your code. See the [Assistants API quickstart](/docs/assistants/overview) to learn how to\nintegrate the Assistants API with streaming.\n",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ThreadStreamEvent"
+          },
+          {
+            "$ref": "#/components/schemas/RunStreamEvent"
+          },
+          {
+            "$ref": "#/components/schemas/RunStepStreamEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessageStreamEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorEvent"
+          },
+          {
+            "$ref": "#/components/schemas/DoneEvent"
+          }
+        ],
+        "x-oaiMeta": {
+          "name": "Assistant stream events",
+          "beta": true
+        }
+      },
+      "ThreadStreamEvent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.created"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/ThreadObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a new [thread](/docs/api-reference/threads/object) is created.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [thread](/docs/api-reference/threads/object)"
+            }
+          }
+        ]
+      },
+      "RunStreamEvent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.created"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a new [run](/docs/api-reference/runs/object) is created.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.queued"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) moves to a `queued` status.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.in_progress"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) moves to an `in_progress` status.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.requires_action"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) moves to a `requires_action` status.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.completed"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) is completed.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.incomplete"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) ends with status `incomplete`.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.failed"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) fails.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.cancelling"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) moves to a `cancelling` status.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.cancelled"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) is cancelled.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.expired"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run](/docs/api-reference/runs/object) expires.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run](/docs/api-reference/runs/object)"
+            }
+          }
+        ]
+      },
+      "RunStepStreamEvent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.step.created"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunStepObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run step](/docs/api-reference/runs/step-object) is created.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run step](/docs/api-reference/runs/step-object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.step.in_progress"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunStepObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run step](/docs/api-reference/runs/step-object) moves to an `in_progress` state.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run step](/docs/api-reference/runs/step-object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.step.delta"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunStepDeltaObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when parts of a [run step](/docs/api-reference/runs/step-object) are being streamed.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run step delta](/docs/api-reference/assistants-streaming/run-step-delta-object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.step.completed"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunStepObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run step](/docs/api-reference/runs/step-object) is completed.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run step](/docs/api-reference/runs/step-object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.step.failed"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunStepObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run step](/docs/api-reference/runs/step-object) fails.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run step](/docs/api-reference/runs/step-object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.step.cancelled"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunStepObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run step](/docs/api-reference/runs/step-object) is cancelled.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run step](/docs/api-reference/runs/step-object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.run.step.expired"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/RunStepObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [run step](/docs/api-reference/runs/step-object) expires.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [run step](/docs/api-reference/runs/step-object)"
+            }
+          }
+        ]
+      },
+      "MessageStreamEvent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.message.created"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/MessageObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [message](/docs/api-reference/messages/object) is created.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [message](/docs/api-reference/messages/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.message.in_progress"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/MessageObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [message](/docs/api-reference/messages/object) moves to an `in_progress` state.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [message](/docs/api-reference/messages/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.message.delta"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/MessageDeltaObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when parts of a [Message](/docs/api-reference/messages/object) are being streamed.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [message delta](/docs/api-reference/assistants-streaming/message-delta-object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.message.completed"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/MessageObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [message](/docs/api-reference/messages/object) is completed.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [message](/docs/api-reference/messages/object)"
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "enum": [
+                  "thread.message.incomplete"
+                ]
+              },
+              "data": {
+                "$ref": "#/components/schemas/MessageObject"
+              }
+            },
+            "required": [
+              "event",
+              "data"
+            ],
+            "description": "Occurs when a [message](/docs/api-reference/messages/object) ends before it is completed.",
+            "x-oaiMeta": {
+              "dataDescription": "`data` is a [message](/docs/api-reference/messages/object)"
+            }
+          }
+        ]
+      },
+      "ErrorEvent": {
+        "type": "object",
+        "properties": {
+          "event": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "data": {
+            "$ref": "#/components/schemas/Error"
+          }
+        },
+        "required": [
+          "event",
+          "data"
+        ],
+        "description": "Occurs when an [error](/docs/guides/error-codes/api-errors) occurs. This can happen due to an internal server error or a timeout.",
+        "x-oaiMeta": {
+          "dataDescription": "`data` is an [error](/docs/guides/error-codes/api-errors)"
+        }
+      },
+      "DoneEvent": {
+        "type": "object",
+        "properties": {
+          "event": {
+            "type": "string",
+            "enum": [
+              "done"
+            ]
+          },
+          "data": {
+            "type": "string",
+            "enum": [
+              "[DONE]"
+            ]
+          }
+        },
+        "required": [
+          "event",
+          "data"
+        ],
+        "description": "Occurs when a stream ends.",
+        "x-oaiMeta": {
+          "dataDescription": "`data` is `[DONE]`"
+        }
+      },
+      "Batch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "batch"
+            ],
+            "description": "The object type, which is always `batch`."
+          },
+          "endpoint": {
+            "type": "string",
+            "description": "The OpenAI API endpoint used by the batch."
+          },
+          "errors": {
+            "type": "object",
+            "properties": {
+              "object": {
+                "type": "string",
+                "description": "The object type, which is always `list`."
+              },
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "description": "An error code identifying the error type."
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "A human-readable message providing more details about the error."
+                    },
+                    "param": {
+                      "type": "string",
+                      "description": "The name of the parameter that caused the error, if applicable.",
+                      "nullable": true
+                    },
+                    "line": {
+                      "type": "integer",
+                      "description": "The line number of the input file where the error occurred, if applicable.",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "input_file_id": {
+            "type": "string",
+            "description": "The ID of the input file for the batch."
+          },
+          "completion_window": {
+            "type": "string",
+            "description": "The time frame within which the batch should be processed."
+          },
+          "status": {
+            "type": "string",
+            "description": "The current status of the batch.",
+            "enum": [
+              "validating",
+              "failed",
+              "in_progress",
+              "finalizing",
+              "completed",
+              "expired",
+              "cancelling",
+              "cancelled"
+            ]
+          },
+          "output_file_id": {
+            "type": "string",
+            "description": "The ID of the file containing the outputs of successfully executed requests."
+          },
+          "error_file_id": {
+            "type": "string",
+            "description": "The ID of the file containing the outputs of requests with errors."
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch was created."
+          },
+          "in_progress_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch started processing."
+          },
+          "expires_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch will expire."
+          },
+          "finalizing_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch started finalizing."
+          },
+          "completed_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch was completed."
+          },
+          "failed_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch failed."
+          },
+          "expired_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch expired."
+          },
+          "cancelling_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch started cancelling."
+          },
+          "cancelled_at": {
+            "type": "integer",
+            "description": "The Unix timestamp (in seconds) for when the batch was cancelled."
+          },
+          "request_counts": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer",
+                "description": "Total number of requests in the batch."
+              },
+              "completed": {
+                "type": "integer",
+                "description": "Number of requests that have been completed successfully."
+              },
+              "failed": {
+                "type": "integer",
+                "description": "Number of requests that have failed."
+              }
+            },
+            "required": [
+              "total",
+              "completed",
+              "failed"
+            ],
+            "description": "The request counts for different statuses within the batch."
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "type": "object",
+            "x-oaiTypeLabel": "map",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "endpoint",
+          "input_file_id",
+          "completion_window",
+          "status",
+          "created_at"
+        ],
+        "x-oaiMeta": {
+          "name": "The batch object",
+          "example": "{\n  \"id\": \"batch_abc123\",\n  \"object\": \"batch\",\n  \"endpoint\": \"/v1/completions\",\n  \"errors\": null,\n  \"input_file_id\": \"file-abc123\",\n  \"completion_window\": \"24h\",\n  \"status\": \"completed\",\n  \"output_file_id\": \"file-cvaTdG\",\n  \"error_file_id\": \"file-HOWS94\",\n  \"created_at\": 1711471533,\n  \"in_progress_at\": 1711471538,\n  \"expires_at\": 1711557933,\n  \"finalizing_at\": 1711493133,\n  \"completed_at\": 1711493163,\n  \"failed_at\": null,\n  \"expired_at\": null,\n  \"cancelling_at\": null,\n  \"cancelled_at\": null,\n  \"request_counts\": {\n    \"total\": 100,\n    \"completed\": 95,\n    \"failed\": 5\n  },\n  \"metadata\": {\n    \"customer_id\": \"user_123456789\",\n    \"batch_description\": \"Nightly eval job\",\n  }\n}\n"
+        }
+      },
+      "BatchRequestInput": {
+        "type": "object",
+        "description": "The per-line object of the batch input file",
+        "properties": {
+          "custom_id": {
+            "type": "string",
+            "description": "A developer-provided per-request id that will be used to match outputs to inputs. Must be unique for each request in a batch."
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "POST"
+            ],
+            "description": "The HTTP method to be used for the request. Currently only `POST` is supported."
+          },
+          "url": {
+            "type": "string",
+            "description": "The OpenAI API relative URL to be used for the request. Currently `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are supported."
+          }
+        },
+        "x-oaiMeta": {
+          "name": "The request input object",
+          "example": "{\"custom_id\": \"request-1\", \"method\": \"POST\", \"url\": \"/v1/chat/completions\", \"body\": {\"model\": \"gpt-3.5-turbo\", \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"What is 2+2?\"}]}}\n"
+        }
+      },
+      "BatchRequestOutput": {
+        "type": "object",
+        "description": "The per-line object of the batch output and error files",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "custom_id": {
+            "type": "string",
+            "description": "A developer-provided per-request id that will be used to match outputs to inputs."
+          },
+          "response": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "status_code": {
+                "type": "integer",
+                "description": "The HTTP status code of the response"
+              },
+              "request_id": {
+                "type": "string",
+                "description": "An unique identifier for the OpenAI API request. Please include this request ID when contacting support."
+              },
+              "body": {
+                "type": "object",
+                "x-oaiTypeLabel": "map",
+                "description": "The JSON body of the response"
+              }
+            }
+          },
+          "error": {
+            "type": "object",
+            "nullable": true,
+            "description": "For requests that failed with a non-HTTP error, this will contain more information on the cause of the failure.",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "A machine-readable error code."
+              },
+              "message": {
+                "type": "string",
+                "description": "A human-readable error message."
+              }
+            }
+          }
+        },
+        "x-oaiMeta": {
+          "name": "The request output object",
+          "example": "{\"id\": \"batch_req_wnaDys\", \"custom_id\": \"request-2\", \"response\": {\"status_code\": 200, \"request_id\": \"req_c187b3\", \"body\": {\"id\": \"chatcmpl-9758Iw\", \"object\": \"chat.completion\", \"created\": 1711475054, \"model\": \"gpt-3.5-turbo\", \"choices\": [{\"index\": 0, \"message\": {\"role\": \"assistant\", \"content\": \"2 + 2 equals 4.\"}, \"finish_reason\": \"stop\"}], \"usage\": {\"prompt_tokens\": 24, \"completion_tokens\": 15, \"total_tokens\": 39}, \"system_fingerprint\": null}}, \"error\": null}\n"
+        }
+      },
+      "ListBatchesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Batch"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "example": "batch_abc123"
+          },
+          "last_id": {
+            "type": "string",
+            "example": "batch_abc456"
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ]
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "x-oaiMeta": {
+    "navigationGroups": [
+      {
+        "id": "endpoints",
+        "title": "Endpoints"
+      },
+      {
+        "id": "assistants",
+        "title": "Assistants"
+      },
+      {
+        "id": "legacy",
+        "title": "Legacy"
+      }
+    ],
+    "groups": [
+      {
+        "id": "audio",
+        "title": "Audio",
+        "description": "Learn how to turn audio into text or text into audio.\n\nRelated guide: [Speech to text](/docs/guides/speech-to-text)\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createSpeech",
+            "path": "createSpeech"
+          },
+          {
+            "type": "endpoint",
+            "key": "createTranscription",
+            "path": "createTranscription"
+          },
+          {
+            "type": "endpoint",
+            "key": "createTranslation",
+            "path": "createTranslation"
+          },
+          {
+            "type": "object",
+            "key": "CreateTranscriptionResponseJson",
+            "path": "json-object"
+          },
+          {
+            "type": "object",
+            "key": "CreateTranscriptionResponseVerboseJson",
+            "path": "verbose-json-object"
+          }
+        ]
+      },
+      {
+        "id": "chat",
+        "title": "Chat",
+        "description": "Given a list of messages comprising a conversation, the model will return a response.\n\nRelated guide: [Chat Completions](/docs/guides/text-generation)\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createChatCompletion",
+            "path": "create"
+          },
+          {
+            "type": "object",
+            "key": "CreateChatCompletionResponse",
+            "path": "object"
+          },
+          {
+            "type": "object",
+            "key": "CreateChatCompletionStreamResponse",
+            "path": "streaming"
+          }
+        ]
+      },
+      {
+        "id": "embeddings",
+        "title": "Embeddings",
+        "description": "Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.\n\nRelated guide: [Embeddings](/docs/guides/embeddings)\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createEmbedding",
+            "path": "create"
+          },
+          {
+            "type": "object",
+            "key": "Embedding",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "fine-tuning",
+        "title": "Fine-tuning",
+        "description": "Manage fine-tuning jobs to tailor a model to your specific training data.\n\nRelated guide: [Fine-tune models](/docs/guides/fine-tuning)\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createFineTuningJob",
+            "path": "create"
+          },
+          {
+            "type": "endpoint",
+            "key": "listPaginatedFineTuningJobs",
+            "path": "list"
+          },
+          {
+            "type": "endpoint",
+            "key": "listFineTuningEvents",
+            "path": "list-events"
+          },
+          {
+            "type": "endpoint",
+            "key": "listFineTuningJobCheckpoints",
+            "path": "list-checkpoints"
+          },
+          {
+            "type": "endpoint",
+            "key": "retrieveFineTuningJob",
+            "path": "retrieve"
+          },
+          {
+            "type": "endpoint",
+            "key": "cancelFineTuningJob",
+            "path": "cancel"
+          },
+          {
+            "type": "object",
+            "key": "FinetuneChatRequestInput",
+            "path": "chat-input"
+          },
+          {
+            "type": "object",
+            "key": "FinetuneCompletionRequestInput",
+            "path": "completions-input"
+          },
+          {
+            "type": "object",
+            "key": "FineTuningJob",
+            "path": "object"
+          },
+          {
+            "type": "object",
+            "key": "FineTuningJobEvent",
+            "path": "event-object"
+          },
+          {
+            "type": "object",
+            "key": "FineTuningJobCheckpoint",
+            "path": "checkpoint-object"
+          }
+        ]
+      },
+      {
+        "id": "batch",
+        "title": "Batch",
+        "description": "Create large batches of API requests for asynchronous processing. The Batch API returns completions within 24 hours for a 50% discount.\n\nRelated guide: [Batch](/docs/guides/batch)\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createBatch",
+            "path": "create"
+          },
+          {
+            "type": "endpoint",
+            "key": "retrieveBatch",
+            "path": "retrieve"
+          },
+          {
+            "type": "endpoint",
+            "key": "cancelBatch",
+            "path": "cancel"
+          },
+          {
+            "type": "endpoint",
+            "key": "listBatches",
+            "path": "list"
+          },
+          {
+            "type": "object",
+            "key": "Batch",
+            "path": "object"
+          },
+          {
+            "type": "object",
+            "key": "BatchRequestInput",
+            "path": "request-input"
+          },
+          {
+            "type": "object",
+            "key": "BatchRequestOutput",
+            "path": "request-output"
+          }
+        ]
+      },
+      {
+        "id": "files",
+        "title": "Files",
+        "description": "Files are used to upload documents that can be used with features like [Assistants](/docs/api-reference/assistants), [Fine-tuning](/docs/api-reference/fine-tuning), and [Batch API](/docs/guides/batch).\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createFile",
+            "path": "create"
+          },
+          {
+            "type": "endpoint",
+            "key": "listFiles",
+            "path": "list"
+          },
+          {
+            "type": "endpoint",
+            "key": "retrieveFile",
+            "path": "retrieve"
+          },
+          {
+            "type": "endpoint",
+            "key": "deleteFile",
+            "path": "delete"
+          },
+          {
+            "type": "endpoint",
+            "key": "downloadFile",
+            "path": "retrieve-contents"
+          },
+          {
+            "type": "object",
+            "key": "OpenAIFile",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "uploads",
+        "title": "Uploads",
+        "description": "Allows you to upload large files in multiple parts.\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createUpload",
+            "path": "create"
+          },
+          {
+            "type": "endpoint",
+            "key": "addUploadPart",
+            "path": "add-part"
+          },
+          {
+            "type": "endpoint",
+            "key": "completeUpload",
+            "path": "complete"
+          },
+          {
+            "type": "endpoint",
+            "key": "cancelUpload",
+            "path": "cancel"
+          },
+          {
+            "type": "object",
+            "key": "Upload",
+            "path": "object"
+          },
+          {
+            "type": "object",
+            "key": "UploadPart",
+            "path": "part-object"
+          }
+        ]
+      },
+      {
+        "id": "images",
+        "title": "Images",
+        "description": "Given a prompt and/or an input image, the model will generate a new image.\n\nRelated guide: [Image generation](/docs/guides/images)\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createImage",
+            "path": "create"
+          },
+          {
+            "type": "endpoint",
+            "key": "createImageEdit",
+            "path": "createEdit"
+          },
+          {
+            "type": "endpoint",
+            "key": "createImageVariation",
+            "path": "createVariation"
+          },
+          {
+            "type": "object",
+            "key": "Image",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "models",
+        "title": "Models",
+        "description": "List and describe the various models available in the API. You can refer to the [Models](/docs/models) documentation to understand what models are available and the differences between them.\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "listModels",
+            "path": "list"
+          },
+          {
+            "type": "endpoint",
+            "key": "retrieveModel",
+            "path": "retrieve"
+          },
+          {
+            "type": "endpoint",
+            "key": "deleteModel",
+            "path": "delete"
+          },
+          {
+            "type": "object",
+            "key": "Model",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "moderations",
+        "title": "Moderations",
+        "description": "Given some input text, outputs if the model classifies it as potentially harmful across several categories.\n\nRelated guide: [Moderations](/docs/guides/moderation)\n",
+        "navigationGroup": "endpoints",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createModeration",
+            "path": "create"
+          },
+          {
+            "type": "object",
+            "key": "CreateModerationResponse",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "assistants",
+        "title": "Assistants",
+        "beta": true,
+        "description": "Build assistants that can call models and use tools to perform tasks.\n\n[Get started with the Assistants API](/docs/assistants)\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createAssistant",
+            "path": "createAssistant"
+          },
+          {
+            "type": "endpoint",
+            "key": "listAssistants",
+            "path": "listAssistants"
+          },
+          {
+            "type": "endpoint",
+            "key": "getAssistant",
+            "path": "getAssistant"
+          },
+          {
+            "type": "endpoint",
+            "key": "modifyAssistant",
+            "path": "modifyAssistant"
+          },
+          {
+            "type": "endpoint",
+            "key": "deleteAssistant",
+            "path": "deleteAssistant"
+          },
+          {
+            "type": "object",
+            "key": "AssistantObject",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "threads",
+        "title": "Threads",
+        "beta": true,
+        "description": "Create threads that assistants can interact with.\n\nRelated guide: [Assistants](/docs/assistants/overview)\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createThread",
+            "path": "createThread"
+          },
+          {
+            "type": "endpoint",
+            "key": "getThread",
+            "path": "getThread"
+          },
+          {
+            "type": "endpoint",
+            "key": "modifyThread",
+            "path": "modifyThread"
+          },
+          {
+            "type": "endpoint",
+            "key": "deleteThread",
+            "path": "deleteThread"
+          },
+          {
+            "type": "object",
+            "key": "ThreadObject",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "messages",
+        "title": "Messages",
+        "beta": true,
+        "description": "Create messages within threads\n\nRelated guide: [Assistants](/docs/assistants/overview)\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createMessage",
+            "path": "createMessage"
+          },
+          {
+            "type": "endpoint",
+            "key": "listMessages",
+            "path": "listMessages"
+          },
+          {
+            "type": "endpoint",
+            "key": "getMessage",
+            "path": "getMessage"
+          },
+          {
+            "type": "endpoint",
+            "key": "modifyMessage",
+            "path": "modifyMessage"
+          },
+          {
+            "type": "endpoint",
+            "key": "deleteMessage",
+            "path": "deleteMessage"
+          },
+          {
+            "type": "object",
+            "key": "MessageObject",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "runs",
+        "title": "Runs",
+        "beta": true,
+        "description": "Represents an execution run on a thread.\n\nRelated guide: [Assistants](/docs/assistants/overview)\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createRun",
+            "path": "createRun"
+          },
+          {
+            "type": "endpoint",
+            "key": "createThreadAndRun",
+            "path": "createThreadAndRun"
+          },
+          {
+            "type": "endpoint",
+            "key": "listRuns",
+            "path": "listRuns"
+          },
+          {
+            "type": "endpoint",
+            "key": "getRun",
+            "path": "getRun"
+          },
+          {
+            "type": "endpoint",
+            "key": "modifyRun",
+            "path": "modifyRun"
+          },
+          {
+            "type": "endpoint",
+            "key": "submitToolOuputsToRun",
+            "path": "submitToolOutputs"
+          },
+          {
+            "type": "endpoint",
+            "key": "cancelRun",
+            "path": "cancelRun"
+          },
+          {
+            "type": "object",
+            "key": "RunObject",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "run-steps",
+        "title": "Run Steps",
+        "beta": true,
+        "description": "Represents the steps (model and tool calls) taken during the run.\n\nRelated guide: [Assistants](/docs/assistants/overview)\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "listRunSteps",
+            "path": "listRunSteps"
+          },
+          {
+            "type": "endpoint",
+            "key": "getRunStep",
+            "path": "getRunStep"
+          },
+          {
+            "type": "object",
+            "key": "RunStepObject",
+            "path": "step-object"
+          }
+        ]
+      },
+      {
+        "id": "vector-stores",
+        "title": "Vector Stores",
+        "beta": true,
+        "description": "Vector stores are used to store files for use by the `file_search` tool.\n\nRelated guide: [File Search](/docs/assistants/tools/file-search)\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createVectorStore",
+            "path": "create"
+          },
+          {
+            "type": "endpoint",
+            "key": "listVectorStores",
+            "path": "list"
+          },
+          {
+            "type": "endpoint",
+            "key": "getVectorStore",
+            "path": "retrieve"
+          },
+          {
+            "type": "endpoint",
+            "key": "modifyVectorStore",
+            "path": "modify"
+          },
+          {
+            "type": "endpoint",
+            "key": "deleteVectorStore",
+            "path": "delete"
+          },
+          {
+            "type": "object",
+            "key": "VectorStoreObject",
+            "path": "object"
+          }
+        ]
+      },
+      {
+        "id": "vector-stores-files",
+        "title": "Vector Store Files",
+        "beta": true,
+        "description": "Vector store files represent files inside a vector store.\n\nRelated guide: [File Search](/docs/assistants/tools/file-search)\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createVectorStoreFile",
+            "path": "createFile"
+          },
+          {
+            "type": "endpoint",
+            "key": "listVectorStoreFiles",
+            "path": "listFiles"
+          },
+          {
+            "type": "endpoint",
+            "key": "getVectorStoreFile",
+            "path": "getFile"
+          },
+          {
+            "type": "endpoint",
+            "key": "deleteVectorStoreFile",
+            "path": "deleteFile"
+          },
+          {
+            "type": "object",
+            "key": "VectorStoreFileObject",
+            "path": "file-object"
+          }
+        ]
+      },
+      {
+        "id": "vector-stores-file-batches",
+        "title": "Vector Store File Batches",
+        "beta": true,
+        "description": "Vector store file batches represent operations to add multiple files to a vector store.\n\nRelated guide: [File Search](/docs/assistants/tools/file-search)\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createVectorStoreFileBatch",
+            "path": "createBatch"
+          },
+          {
+            "type": "endpoint",
+            "key": "getVectorStoreFileBatch",
+            "path": "getBatch"
+          },
+          {
+            "type": "endpoint",
+            "key": "cancelVectorStoreFileBatch",
+            "path": "cancelBatch"
+          },
+          {
+            "type": "endpoint",
+            "key": "listFilesInVectorStoreBatch",
+            "path": "listBatchFiles"
+          },
+          {
+            "type": "object",
+            "key": "VectorStoreFileBatchObject",
+            "path": "batch-object"
+          }
+        ]
+      },
+      {
+        "id": "assistants-streaming",
+        "title": "Streaming",
+        "beta": true,
+        "description": "Stream the result of executing a Run or resuming a Run after submitting tool outputs.\n\nYou can stream events from the [Create Thread and Run](/docs/api-reference/runs/createThreadAndRun),\n[Create Run](/docs/api-reference/runs/createRun), and [Submit Tool Outputs](/docs/api-reference/runs/submitToolOutputs)\nendpoints by passing `\"stream\": true`. The response will be a [Server-Sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) stream.\n\nOur Node and Python SDKs provide helpful utilities to make streaming easy. Reference the\n[Assistants API quickstart](/docs/assistants/overview) to learn more.\n",
+        "navigationGroup": "assistants",
+        "sections": [
+          {
+            "type": "object",
+            "key": "MessageDeltaObject",
+            "path": "message-delta-object"
+          },
+          {
+            "type": "object",
+            "key": "RunStepDeltaObject",
+            "path": "run-step-delta-object"
+          },
+          {
+            "type": "object",
+            "key": "AssistantStreamEvent",
+            "path": "events"
+          }
+        ]
+      },
+      {
+        "id": "completions",
+        "title": "Completions",
+        "legacy": true,
+        "navigationGroup": "legacy",
+        "description": "Given a prompt, the model will return one or more predicted completions along with the probabilities of alternative tokens at each position. Most developer should use our [Chat Completions API](/docs/guides/text-generation/text-generation-models) to leverage our best and newest models.\n",
+        "sections": [
+          {
+            "type": "endpoint",
+            "key": "createCompletion",
+            "path": "create"
+          },
+          {
+            "type": "object",
+            "key": "CreateCompletionResponse",
+            "path": "object"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",
@@ -36,8 +36,10 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.12.7",
     "chalk": "^4.1.2",
+    "js-yaml": "^4.1.0",
     "prettier": "^3.2.5",
     "rimraf": "^5.0.5",
     "rollup": "^4.18.1",
@@ -50,5 +52,6 @@
     "lib",
     "src",
     "README.md"
-  ]
+  ],
+  "packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903"
 }

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -1032,7 +1032,12 @@ export namespace OpenApi {
     /**
      * Null type.
      */
-    export interface INull extends __ISignificant<"null"> {}
+    export interface INull extends __ISignificant<"null"> {
+      /**
+       * Default value.
+       */
+      default?: null;
+    }
 
     /**
      * Unknown, `any` type.

--- a/src/OpenApiV3.ts
+++ b/src/OpenApiV3.ts
@@ -180,11 +180,11 @@ export namespace OpenApiV3 {
     | IJsonSchema.IOneOf;
   export namespace IJsonSchema {
     export interface IBoolean extends __ISignificant<"boolean"> {
-      default?: boolean;
+      default?: boolean | null;
       enum?: boolean[];
     }
     export interface IInteger extends __ISignificant<"integer"> {
-      /** @type int64 */ default?: number;
+      /** @type int64 */ default?: number | null;
       /** @type int64 */ enum?: number[];
       /** @type int64 */ minimum?: number;
       /** @type int64 */ maximum?: number;
@@ -197,7 +197,7 @@ export namespace OpenApiV3 {
       multipleOf?: number;
     }
     export interface INumber extends __ISignificant<"number"> {
-      default?: number;
+      default?: number | null;
       enum?: number[];
       minimum?: number;
       maximum?: number;
@@ -206,7 +206,7 @@ export namespace OpenApiV3 {
       /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
     export interface IString extends __ISignificant<"string"> {
-      default?: string;
+      default?: string | null;
       enum?: string[];
       format?:
         | "binary"
@@ -260,6 +260,7 @@ export namespace OpenApiV3 {
     }
     export interface INullOnly extends __IAttribute {
       type: "null";
+      default?: null;
     }
     export interface IAllOf extends __IAttribute {
       allOf: IJsonSchema[];

--- a/src/OpenApiV3_1.ts
+++ b/src/OpenApiV3_1.ts
@@ -201,7 +201,7 @@ export namespace OpenApiV3_1 {
       type: Array<
         "boolean" | "integer" | "number" | "string" | "array" | "object"
       >;
-      default?: any[];
+      default?: any[] | null;
       enum?: any[];
     }
 
@@ -209,11 +209,11 @@ export namespace OpenApiV3_1 {
       const: boolean | number | string;
     }
     export interface IBoolean extends __ISignificant<"boolean"> {
-      default?: boolean;
+      default?: boolean | null;
       enum?: boolean[];
     }
     export interface IInteger extends __ISignificant<"integer"> {
-      /** @type int64 */ default?: number;
+      /** @type int64 */ default?: number | null;
       /** @type int64 */ enum?: number[];
       /** @type int64 */ minimum?: number;
       /** @type int64 */ maximum?: number;
@@ -226,7 +226,7 @@ export namespace OpenApiV3_1 {
       multipleOf?: number;
     }
     export interface INumber extends __ISignificant<"number"> {
-      default?: number;
+      default?: number | null;
       enum?: number[];
       minimum?: number;
       maximum?: number;
@@ -236,7 +236,7 @@ export namespace OpenApiV3_1 {
     }
     export interface IString extends __ISignificant<"string"> {
       contentMediaType?: string;
-      default?: string;
+      default?: string | null;
       enum?: string[];
       format?:
         | "binary"
@@ -271,7 +271,9 @@ export namespace OpenApiV3_1 {
     export interface IUnknown extends __IAttribute {
       type?: undefined;
     }
-    export interface INull extends __ISignificant<"null"> {}
+    export interface INull extends __ISignificant<"null"> {
+      default?: null;
+    }
     export interface IAllOf extends __IAttribute {
       allOf: IJsonSchema[];
     }

--- a/src/SwaggerV2.ts
+++ b/src/SwaggerV2.ts
@@ -130,11 +130,11 @@ export namespace SwaggerV2 {
     | IJsonSchema.IOneOf;
   export namespace IJsonSchema {
     export interface IBoolean extends __ISignificant<"boolean"> {
-      default?: boolean;
+      default?: boolean | null;
       enum?: boolean[];
     }
     export interface IInteger extends __ISignificant<"integer"> {
-      /** @type int64 */ default?: number;
+      /** @type int64 */ default?: number | null;
       /** @type int64 */ enum?: number[];
       /** @type int64 */ minimum?: number;
       /** @type int64 */ maximum?: number;
@@ -147,7 +147,7 @@ export namespace SwaggerV2 {
       multipleOf?: number;
     }
     export interface INumber extends __ISignificant<"number"> {
-      default?: number;
+      default?: number | null;
       enum?: number[];
       minimum?: number;
       maximum?: number;
@@ -156,7 +156,7 @@ export namespace SwaggerV2 {
       /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
     export interface IString extends __ISignificant<"string"> {
-      default?: string;
+      default?: string | null;
       enum?: string[];
       format?:
         | "binary"
@@ -210,6 +210,7 @@ export namespace SwaggerV2 {
     }
     export interface INullOnly extends __IAttribute {
       type: "null";
+      default?: null;
     }
     export interface IAllOf extends __IAttribute {
       allOf: IJsonSchema[];

--- a/src/internal/OpenApiV3Downgrader.ts
+++ b/src/internal/OpenApiV3Downgrader.ts
@@ -219,7 +219,7 @@ export namespace OpenApiV3Downgrader {
               ];
               if (elements.length === 0) return {};
               return {
-                oneOf: elements.map(downgradeSchema(collection)),
+                oneOf: elements.map(downgradeSchema(collection) as any),
               };
             })(),
             minItems: schema.prefixItems.length,
@@ -276,8 +276,8 @@ export namespace OpenApiV3Downgrader {
       visitConstant(input);
       if (nullable === true)
         for (const u of union)
-          if (OpenApiTypeChecker.isReference(u))
-            downgradeNullableReference(collection)(u);
+          if (OpenApiTypeChecker.isReference(u as any))
+            downgradeNullableReference(collection)(u as any);
           else (u as OpenApiV3.IJsonSchema.IArray).nullable = true;
       if (nullable === true && union.length === 0)
         return { type: "null", ...attribute };

--- a/src/internal/OpenApiV3_1Converter.ts
+++ b/src/internal/OpenApiV3_1Converter.ts
@@ -282,15 +282,21 @@ export namespace OpenApiV3_1Converter {
           ),
         ),
       };
-      const nullable: { value: boolean } = { value: false };
+      const nullable: { value: boolean; default?: null } = {
+        value: false,
+        default: undefined,
+      };
 
       const visit = (schema: OpenApiV3_1.IJsonSchema): void => {
         // NULLABLE PROPERTY
         if (
           (schema as OpenApiV3_1.IJsonSchema.__ISignificant<any>).nullable ===
           true
-        )
+        ) {
           nullable.value ||= true;
+          if ((schema as OpenApiV3_1.IJsonSchema.INumber).default === null)
+            nullable.default = null;
+        }
         // MIXED TYPE CASE
         if (TypeChecker.isMixed(schema)) {
           if (schema.const !== undefined)
@@ -364,6 +370,7 @@ export namespace OpenApiV3_1Converter {
           else
             union.push({
               ...schema,
+              default: schema.default ?? undefined,
               ...{
                 enum: undefined,
               },
@@ -388,6 +395,7 @@ export namespace OpenApiV3_1Converter {
           else
             union.push({
               ...schema,
+              default: schema.default ?? undefined,
               ...{
                 enum: undefined,
               },
@@ -423,6 +431,7 @@ export namespace OpenApiV3_1Converter {
           else
             union.push({
               ...schema,
+              default: schema.default ?? undefined,
               ...{
                 enum: undefined,
               },
@@ -513,7 +522,10 @@ export namespace OpenApiV3_1Converter {
         nullable.value === true &&
         !union.some((e) => (e as OpenApi.IJsonSchema.INull).type === "null")
       )
-        union.push({ type: "null" });
+        union.push({
+          type: "null",
+          default: nullable.default,
+        });
       return {
         ...(union.length === 0
           ? { type: undefined }

--- a/src/internal/SwaggerV2Downgrader.ts
+++ b/src/internal/SwaggerV2Downgrader.ts
@@ -231,7 +231,7 @@ export namespace SwaggerV2Downgrader {
               ];
               if (elements.length === 0) return {};
               return {
-                "x-oneOf": elements.map(downgradeSchema(collection)),
+                "x-oneOf": elements.map(downgradeSchema(collection) as any),
               };
             })(),
             minItems: schema.prefixItems.length,
@@ -286,8 +286,8 @@ export namespace SwaggerV2Downgrader {
       visitConstant(input);
       if (nullable)
         for (const u of union)
-          if (OpenApiTypeChecker.isReference(u))
-            downgradeNullableReference(collection)(u);
+          if (OpenApiTypeChecker.isReference(u as any))
+            downgradeNullableReference(collection)(u as any);
           else (u as SwaggerV2.IJsonSchema.IArray)["x-nullable"] = true;
 
       if (nullable === true && union.length === 0)


### PR DESCRIPTION
Trying to test OpenAI's swagger document file, I found a bug that current `@samchon/openapi` could not cover `default: null` value case about nullable atomic type case like `type: string` and `type: number`.

This PR fixes the bug, by changing types and converters.