### PR TITLE
Avoid reserved keyword in `IMigrateRoute.accessor`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/utils/NamingConvention.ts
+++ b/src/utils/NamingConvention.ts
@@ -1,86 +1,88 @@
 import { StringUtil } from "./StringUtil";
 
-export function snake(str: string): string {
-  const indexes: number[] = [];
-  for (let i: number = 0; i < str.length; i++) {
-    const code: number = str.charCodeAt(i);
-    if (65 <= code && code <= 90) indexes.push(i);
-  }
-  for (let i: number = indexes.length - 1; i > 0; --i) {
-    const now: number = indexes[i]!;
-    const prev: number = indexes[i - 1]!;
-    if (now - prev === 1) indexes.splice(i, 1);
-  }
-  if (indexes.length !== 0 && indexes[0] === 0) indexes.splice(0, 1);
-  if (indexes.length === 0) return str.toLowerCase();
-
-  let ret: string = "";
-  for (let i: number = 0; i < indexes.length; i++) {
-    const first: number = i === 0 ? 0 : indexes[i - 1]!;
-    const last: number = indexes[i]!;
-
-    ret += str.substring(first, last).toLowerCase();
-    ret += "_";
-  }
-  ret += str.substring(indexes[indexes.length - 1]!).toLowerCase();
-  return ret;
-}
-
-export function camel(str: string): string {
-  return unsnake((str: string) => {
-    if (str.length === 0) return str;
-    else if (str[0] === str[0]!.toUpperCase())
-      return str[0]!.toLowerCase() + str.substring(1);
-    else return str;
-  })(str);
-}
-
-export function pascal(str: string): string {
-  return unsnake((str: string) => {
-    if (str.length === 0) return str;
-    else if (str[0] === str[0]!.toLowerCase())
-      return str[0]!.toUpperCase() + str.substring(1);
-    else return str;
-  })(str);
-}
-
-const unsnake =
-  (escaper: (str: string) => string) =>
-  (str: string): string => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    let prefix: string = "";
+export namespace NamingConvention {
+  export function snake(str: string): string {
+    const indexes: number[] = [];
     for (let i: number = 0; i < str.length; i++) {
-      if (str[i] === "_") prefix += "_";
-      else break;
+      const code: number = str.charCodeAt(i);
+      if (65 <= code && code <= 90) indexes.push(i);
     }
-    if (prefix.length !== 0) str = str.substring(prefix.length);
-
-    const indexes: [number, number][] = [];
-    for (let i: number = 0; i < str.length; i++) {
-      const ch: string = str[i]!;
-      if (ch !== "_") continue;
-
-      const last = indexes[indexes.length - 1];
-      if (last === undefined || last[0] + last[1] !== i) indexes.push([i, 1]);
-      else ++last[1];
+    for (let i: number = indexes.length - 1; i > 0; --i) {
+      const now: number = indexes[i]!;
+      const prev: number = indexes[i - 1]!;
+      if (now - prev === 1) indexes.splice(i, 1);
     }
-    if (indexes.length === 0) return prefix + escaper(str);
+    if (indexes.length !== 0 && indexes[0] === 0) indexes.splice(0, 1);
+    if (indexes.length === 0) return str.toLowerCase();
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let ret: string = "";
     for (let i: number = 0; i < indexes.length; i++) {
-      const [first] = indexes[i]!;
-      if (i === 0)
-        if (first === 0) ret += "_";
-        else ret += str.substring(0, first);
-      else {
-        const [prevFirst, prevLength] = indexes[i - 1]!;
-        const piece: string = str.substring(prevFirst + prevLength, first);
-        if (piece.length) ret += StringUtil.capitalize(piece);
-      }
+      const first: number = i === 0 ? 0 : indexes[i - 1]!;
+      const last: number = indexes[i]!;
+
+      ret += str.substring(first, last).toLowerCase();
+      ret += "_";
     }
-    const last = indexes[indexes.length - 1]!;
-    const piece: string = str.substring(last[0] + last[1]);
-    if (last.length) ret += StringUtil.capitalize(piece);
-    return prefix + escaper(ret);
-  };
+    ret += str.substring(indexes[indexes.length - 1]!).toLowerCase();
+    return ret;
+  }
+
+  export function camel(str: string): string {
+    return unsnake((str: string) => {
+      if (str.length === 0) return str;
+      else if (str[0] === str[0]!.toUpperCase())
+        return str[0]!.toLowerCase() + str.substring(1);
+      else return str;
+    })(str);
+  }
+
+  export function pascal(str: string): string {
+    return unsnake((str: string) => {
+      if (str.length === 0) return str;
+      else if (str[0] === str[0]!.toLowerCase())
+        return str[0]!.toUpperCase() + str.substring(1);
+      else return str;
+    })(str);
+  }
+
+  const unsnake =
+    (escaper: (str: string) => string) =>
+    (str: string): string => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      let prefix: string = "";
+      for (let i: number = 0; i < str.length; i++) {
+        if (str[i] === "_") prefix += "_";
+        else break;
+      }
+      if (prefix.length !== 0) str = str.substring(prefix.length);
+
+      const indexes: [number, number][] = [];
+      for (let i: number = 0; i < str.length; i++) {
+        const ch: string = str[i]!;
+        if (ch !== "_") continue;
+
+        const last = indexes[indexes.length - 1];
+        if (last === undefined || last[0] + last[1] !== i) indexes.push([i, 1]);
+        else ++last[1];
+      }
+      if (indexes.length === 0) return prefix + escaper(str);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      let ret: string = "";
+      for (let i: number = 0; i < indexes.length; i++) {
+        const [first] = indexes[i]!;
+        if (i === 0)
+          if (first === 0) ret += "_";
+          else ret += str.substring(0, first);
+        else {
+          const [prevFirst, prevLength] = indexes[i - 1]!;
+          const piece: string = str.substring(prevFirst + prevLength, first);
+          if (piece.length) ret += StringUtil.capitalize(piece);
+        }
+      }
+      const last = indexes[indexes.length - 1]!;
+      const piece: string = str.substring(last[0] + last[1]);
+      if (last.length) ret += StringUtil.capitalize(piece);
+      return prefix + escaper(ret);
+    };
+}

--- a/src/utils/StringUtil.ts
+++ b/src/utils/StringUtil.ts
@@ -1,16 +1,16 @@
-import { NamingConvention } from "typia/lib/utils/NamingConvention";
+import { NamingConvention } from "./NamingConvention";
 
 export namespace StringUtil {
-  export const capitalize = (str: string) =>
-    str[0].toUpperCase() + str.slice(1).toLowerCase();
+  export const capitalize = (str: string): string =>
+    str.length !== 0 ? str[0].toUpperCase() + str.slice(1).toLowerCase() : str;
 
-  export const pascal = (path: string) =>
+  export const pascal = (path: string): string =>
     splitWithNormalization(path)
       .filter((str) => str[0] !== "{")
       .map(NamingConvention.pascal)
       .join("");
 
-  export const splitWithNormalization = (path: string) =>
+  export const splitWithNormalization = (path: string): string[] =>
     path
       .split("/")
       .map((str) => normalize(str.trim()))
@@ -27,11 +27,56 @@ export namespace StringUtil {
       )
       .join("/");
 
-  export const normalize = (str: string) =>
-    str.split(".").join("_").split("-").join("_");
+  export const normalize = (str: string): string => {
+    str = str.split(".").join("_").split("-").join("_").trim();
+    if (RESERVED.has(str)) return `_${str}`;
+    else if (str.length !== 0 && "0" <= str[0] && str[0] <= "9")
+      str = `_${str}`;
+    return str;
+  };
 
   export const escapeDuplicate =
     (keep: string[]) =>
     (change: string): string =>
       keep.includes(change) ? escapeDuplicate(keep)(`_${change}`) : change;
 }
+
+const RESERVED: Set<string> = new Set([
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "package",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+]);


### PR DESCRIPTION
Looking at github's swagger.json file, reserved keyword like `public`, `private` are used in `OpenApi.IOperation.path` and type name in `OpenApi.IJsonSchema.IReference.$ref`. 

No way at type name, but it would better to avoid the reserved keyword on `IMigrateRoute.accessor` composed by parsing and spitting the `OpenApi.IOperation.path`.

This PR fixes the problem, so that helps OpenAPI generator libraries to be safer.