### PR TITLE
Avoid comment escaping text.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/internal/MigrateRouteConverter.ts
+++ b/src/internal/MigrateRouteConverter.ts
@@ -330,11 +330,13 @@ export namespace MigrateRouteConverter {
     if (props.operation.tags)
       props.operation.tags.forEach((name) => add(`@tag ${name}`));
     if (props.operation.deprecated) add("@deprecated");
-    return description.length
+    description = description.length
       ? commentTags.length
         ? `${description}\n\n${commentTags.join("\n")}`
         : description
       : commentTags.join("\n");
+    description = description.split("*/").join("*\\/");
+    return description;
   };
 
   const writeIndented = (text: string, spaces: number): string =>


### PR DESCRIPTION
When composing `IMigrateRoute.comment` property, if target `OpenApi.IOperation.description` has comment escaping text like `"*/"`, it may break the OpenAPI generator libraries.

This PR solves the problem by escaping such comment breaking text.