### PR TITLE
Fix samchon/nestia#1018: `HttpMigrateRouteFetcher` for React Native.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/http/HttpMigrateRouteFetcher.ts
+++ b/src/http/HttpMigrateRouteFetcher.ts
@@ -177,10 +177,9 @@ const requestFormDataBody = (input: Record<string, any>): FormData => {
   const encoded: FormData = new FormData();
   const append = (key: string) => (value: any) => {
     if (value === undefined) return;
-    else if (value instanceof Blob)
-      if (value instanceof File) encoded.append(key, value, value.name);
-      else encoded.append(key, value);
-    else encoded.append(key, String(value));
+    else if (typeof File === "function" && value instanceof File)
+      encoded.append(key, value, value.name);
+    else encoded.append(key, value);
   };
   for (const [key, value] of Object.entries(input))
     if (Array.isArray(value)) value.map(append(key));


### PR DESCRIPTION
In the React Native, it does not support the `File` class.

Instead, it can compose the `FormData` class instance by appending below primitive object type. The primitive type can replace the `File` class instance in the React Native.

In such reason, changed `HttpMigrateRouteFetcher` logic a little bit for the React Native `File` supporting issue.

```typescript
const form: FormData = new FormData();
form.append("key", {
  uri: "somewhere-uri-address-of-file-location",
  name: "file-name",
  type: "content-media-type",
});
```