### PR TITLE
Exact JSON schema downgrading.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/converters/HttpLlmConverter.ts
+++ b/src/converters/HttpLlmConverter.ts
@@ -201,7 +201,7 @@ const escape = (props: {
     if (oneOf.some((v) => v === null)) return null;
     return {
       ...props.input,
-      oneOf: oneOf as OpenApi.IJsonSchema[],
+      oneOf: flat(oneOf as OpenApi.IJsonSchema[]),
     };
   } else if (OpenApiTypeChecker.isObject(props.input)) {
     // OBJECT
@@ -282,3 +282,8 @@ const escape = (props: {
   }
   return props.input;
 };
+
+const flat = (elements: OpenApi.IJsonSchema[]): OpenApi.IJsonSchema[] =>
+  elements
+    .map((elem) => (OpenApiTypeChecker.isOneOf(elem) ? flat(elem.oneOf) : elem))
+    .flat();

--- a/test/features/llm/test_llm_schema_nullable.ts
+++ b/test/features/llm/test_llm_schema_nullable.ts
@@ -1,0 +1,54 @@
+import { TestValidator } from "@nestia/e2e";
+import { HttpLlm, ILlmSchema, OpenApi } from "@samchon/openapi";
+
+export const test_llm_schema_union = (): void => {
+  const components: OpenApi.IComponents = {
+    schemas: {
+      union1: {
+        oneOf: [
+          {
+            type: "string",
+          },
+          {
+            type: "number",
+          },
+          {
+            $ref: "#/components/schemas/union2",
+          },
+        ],
+      },
+      union2: {
+        oneOf: [
+          {
+            type: "boolean",
+          },
+          {
+            type: "null",
+          },
+        ],
+      },
+    },
+  };
+  const schema: OpenApi.IJsonSchema = {
+    oneOf: [
+      {
+        type: "boolean",
+      },
+      {
+        $ref: "#/components/schemas/union1",
+      },
+    ],
+  };
+  const llm: ILlmSchema | null = HttpLlm.schema({
+    components,
+    schema,
+  });
+  TestValidator.equals("nullable")(llm)({
+    oneOf: [
+      { type: "boolean", nullable: true },
+      { type: "string", nullable: true },
+      { type: "number", nullable: true },
+      { type: "boolean", nullable: true },
+    ],
+  });
+};

--- a/test/features/llm/test_llm_schema_union.ts
+++ b/test/features/llm/test_llm_schema_union.ts
@@ -1,0 +1,38 @@
+import { TestValidator } from "@nestia/e2e";
+import { HttpLlm, ILlmSchema, OpenApi } from "@samchon/openapi";
+
+export const test_llm_schema_union = (): void => {
+  const components: OpenApi.IComponents = {
+    schemas: {
+      named: {
+        oneOf: [
+          {
+            const: 4,
+          },
+          {
+            const: 5,
+          },
+        ],
+      },
+    },
+  };
+  const schema: OpenApi.IJsonSchema = {
+    oneOf: [
+      {
+        const: 3,
+      },
+      {
+        $ref: "#/components/schemas/named",
+      },
+    ],
+  };
+
+  const llm: ILlmSchema | null = HttpLlm.schema({
+    components,
+    schema,
+  });
+  TestValidator.equals("union")(llm)({
+    type: "number",
+    enum: [3, 4, 5],
+  });
+};

--- a/test/features/openapi/test_json_schema_downgrade_v20_enum.ts
+++ b/test/features/openapi/test_json_schema_downgrade_v20_enum.ts
@@ -1,14 +1,14 @@
 import { TestValidator } from "@nestia/e2e";
-import { OpenApi, OpenApiV3 } from "@samchon/openapi";
-import { OpenApiV3Downgrader } from "@samchon/openapi/lib/converters/OpenApiV3Downgrader";
+import { OpenApi, SwaggerV2 } from "@samchon/openapi";
+import { SwaggerV2Downgrader } from "@samchon/openapi/lib/converters/SwaggerV2Downgrader";
 
-export const test_json_schema_downgrade_v30 = () => {
+export const test_json_schema_downgrade_v20_enum = () => {
   const schema: OpenApi.IJsonSchema = {
     oneOf: [{ const: "a" }, { const: "b" }, { const: "c" }],
     title: "something",
     description: "nothing",
   };
-  const downgraded: OpenApiV3.IJsonSchema = OpenApiV3Downgrader.downgradeSchema(
+  const downgraded: SwaggerV2.IJsonSchema = SwaggerV2Downgrader.downgradeSchema(
     {
       original: {},
       downgraded: {},

--- a/test/features/openapi/test_json_schema_downgrade_v20_nullable.ts
+++ b/test/features/openapi/test_json_schema_downgrade_v20_nullable.ts
@@ -1,0 +1,67 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, SwaggerV2 } from "@samchon/openapi";
+import { SwaggerV2Downgrader } from "@samchon/openapi/lib/converters/SwaggerV2Downgrader";
+
+export const test_json_schema_downgrade_v20_nullable = (): void => {
+  const original: OpenApi.IComponents = {
+    schemas: {
+      union: {
+        oneOf: [
+          {
+            type: "null",
+          },
+          {
+            type: "string",
+          },
+          {
+            type: "number",
+          },
+        ],
+      },
+    },
+  };
+  const components: Record<string, SwaggerV2.IJsonSchema> = {};
+  const schema: SwaggerV2.IJsonSchema = SwaggerV2Downgrader.downgradeSchema({
+    original,
+    downgraded: components,
+  })({
+    oneOf: [
+      {
+        type: "boolean",
+      },
+      {
+        $ref: "#/components/schemas/union",
+      },
+    ],
+  } satisfies OpenApi.IJsonSchema);
+  TestValidator.equals("nullable")({
+    components,
+    schema,
+  })({
+    components: {
+      "union.Nullable": {
+        "x-oneOf": [
+          {
+            type: "string",
+            "x-nullable": true,
+          },
+          {
+            type: "number",
+            "x-nullable": true,
+          },
+        ],
+      },
+    },
+    schema: {
+      "x-oneOf": [
+        {
+          type: "boolean",
+          "x-nullable": true,
+        },
+        {
+          $ref: "#/definitions/union.Nullable",
+        },
+      ],
+    },
+  });
+};

--- a/test/features/openapi/test_json_schema_downgrade_v30_enum.ts
+++ b/test/features/openapi/test_json_schema_downgrade_v30_enum.ts
@@ -1,14 +1,14 @@
 import { TestValidator } from "@nestia/e2e";
-import { OpenApi, SwaggerV2 } from "@samchon/openapi";
-import { SwaggerV2Downgrader } from "@samchon/openapi/lib/converters/SwaggerV2Downgrader";
+import { OpenApi, OpenApiV3 } from "@samchon/openapi";
+import { OpenApiV3Downgrader } from "@samchon/openapi/lib/converters/OpenApiV3Downgrader";
 
-export const test_json_schema_downgrade_v20 = () => {
+export const test_json_schema_downgrade_v30_enum = () => {
   const schema: OpenApi.IJsonSchema = {
     oneOf: [{ const: "a" }, { const: "b" }, { const: "c" }],
     title: "something",
     description: "nothing",
   };
-  const downgraded: SwaggerV2.IJsonSchema = SwaggerV2Downgrader.downgradeSchema(
+  const downgraded: OpenApiV3.IJsonSchema = OpenApiV3Downgrader.downgradeSchema(
     {
       original: {},
       downgraded: {},

--- a/test/features/openapi/test_json_schema_downgrade_v30_nullable.ts
+++ b/test/features/openapi/test_json_schema_downgrade_v30_nullable.ts
@@ -1,0 +1,71 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi, OpenApiV3 } from "@samchon/openapi";
+import { OpenApiV3Downgrader } from "@samchon/openapi/lib/converters/OpenApiV3Downgrader";
+
+export const test_json_schema_downgrade_v30_nullable = (): void => {
+  const original: OpenApi.IComponents = {
+    schemas: {
+      union: {
+        oneOf: [
+          {
+            type: "null",
+          },
+          {
+            type: "string",
+          },
+          {
+            type: "number",
+          },
+        ],
+      },
+    },
+  };
+  const components: OpenApiV3.IComponents = {
+    schemas: {},
+  };
+  const schema: OpenApiV3.IJsonSchema = OpenApiV3Downgrader.downgradeSchema({
+    original,
+    downgraded: components,
+  })({
+    oneOf: [
+      {
+        type: "boolean",
+      },
+      {
+        $ref: "#/components/schemas/union",
+      },
+    ],
+  } satisfies OpenApi.IJsonSchema);
+  TestValidator.equals("nullable")({
+    components,
+    schema,
+  })({
+    components: {
+      schemas: {
+        "union.Nullable": {
+          oneOf: [
+            {
+              type: "string",
+              nullable: true,
+            },
+            {
+              type: "number",
+              nullable: true,
+            },
+          ],
+        },
+      },
+    },
+    schema: {
+      oneOf: [
+        {
+          type: "boolean",
+          nullable: true,
+        },
+        {
+          $ref: "#/components/schemas/union.Nullable",
+        },
+      ],
+    },
+  });
+};


### PR DESCRIPTION
Found some JSON schema downgrade bugs.

## Nested `oneOf` in the `oneOf` type
When oneOf type is referencing another oneOf type that is caplused in the `components.schema` as named schema, JSON schema downgraders had defined nested `oneOf` type under an `oneOf` type.

This PR fixes the bug, so that below test code works from now on.

```typescript
export const test_llm_schema_union = (): void => {
  const components: OpenApi.IComponents = {
    schemas: {
      named: {
        oneOf: [
          {
            const: 4,
          },
          {
            const: 5,
          },
        ],
      },
    },
  };
  const schema: OpenApi.IJsonSchema = {
    oneOf: [
      {
        const: 3,
      },
      {
        $ref: "#/components/schemas/named",
      },
    ],
  };

  const llm: ILlmSchema | null = HttpLlm.schema({
    components,
    schema,
  });
  TestValidator.equals("union")(llm)({
    type: "number",
    enum: [3, 4, 5],
  });
};
```

## Double nested `$ref` type is `nullable` case
When `nullable` type is nested in the `$ref` type, JSON schema downgrader could not detect it properly. This PR fixes the bug, so that makes below test function to be worked properly.

```typescript
export const test_json_schema_downgrade_v30_nullable = (): void => {
  const original: OpenApi.IComponents = {
    schemas: {
      union: {
        oneOf: [
          {
            type: "null",
          },
          {
            type: "string",
          },
          {
            type: "number",
          },
        ],
      },
    },
  };
  const components: OpenApiV3.IComponents = {
    schemas: {},
  };
  const schema: OpenApiV3.IJsonSchema = OpenApiV3Downgrader.downgradeSchema({
    original,
    downgraded: components,
  })({
    oneOf: [
      {
        type: "boolean",
      },
      {
        $ref: "#/components/schemas/union",
      },
    ],
  } satisfies OpenApi.IJsonSchema);
  TestValidator.equals("nullable")({
    components,
    schema,
  })({
    components: {
      schemas: {
        "union.Nullable": {
          oneOf: [
            {
              type: "string",
              nullable: true,
            },
            {
              type: "number",
              nullable: true,
            },
          ],
        },
      },
    },
    schema: {
      oneOf: [
        {
          type: "boolean",
          nullable: true,
        },
        {
          $ref: "#/components/schemas/union.Nullable",
        },
      ],
    },
  });
};
```