### PR TITLE
Support recursive type in the LLM in v1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/HttpLlm.ts
+++ b/src/HttpLlm.ts
@@ -81,6 +81,7 @@ export namespace HttpLlm {
       {
         keyword: options?.keyword ?? false,
         separate: options?.separate ?? null,
+        recursive: options?.recursive ?? 3,
       },
     );
   };
@@ -101,7 +102,13 @@ export namespace HttpLlm {
   export const schema = (props: {
     components: OpenApi.IComponents;
     schema: OpenApi.IJsonSchema;
-  }): ILlmSchema | null => HttpLlmConverter.schema(props);
+    recursive?: false | number;
+  }): ILlmSchema | null =>
+    HttpLlmConverter.schema({
+      components: props.components,
+      schema: props.schema,
+      recursive: props.recursive ?? 3,
+    });
 
   /* -----------------------------------------------------------
     FETCHERS

--- a/src/structures/IHttpLlmApplication.ts
+++ b/src/structures/IHttpLlmApplication.ts
@@ -179,6 +179,18 @@ export namespace IHttpLlmApplication {
     keyword: boolean;
 
     /**
+     * Whether to allow recursive types or not.
+     *
+     * If allow, then how many times to repeat the recursive types.
+     *
+     * By the way, if the model is "chatgpt", the recursive types are always
+     * allowed without any limitation, due to it supports the reference type.
+     *
+     * @default 3
+     */
+    recursive: false | number;
+
+    /**
      * Separator function for the parameters.
      *
      * When composing parameter arguments through LLM function call,

--- a/src/structures/ILlmApplication.ts
+++ b/src/structures/ILlmApplication.ts
@@ -50,6 +50,18 @@ export namespace ILlmApplication {
    */
   export interface IOptions<Schema extends ILlmSchema = ILlmSchema> {
     /**
+     * Whether to allow recursive types or not.
+     *
+     * If allow, then how many times to repeat the recursive types.
+     *
+     * By the way, if the model is "chatgpt", the recursive types are always
+     * allowed without any limitation, due to it supports the reference type.
+     *
+     * @default 3
+     */
+    recursive: false | number;
+
+    /**
      * Separator function for the parameters.
      *
      * When composing parameter arguments through LLM function call,

--- a/test/features/llm/test_llm_schema_object.ts
+++ b/test/features/llm/test_llm_schema_object.ts
@@ -28,10 +28,13 @@ export const test_llm_schema_object = (): void => {
                 description: "Hello word",
               },
             },
+            additionalProperties: false,
           },
         },
+        additionalProperties: false,
       },
     },
+    additionalProperties: false,
   });
 };
 

--- a/test/features/llm/test_llm_schema_oneof.ts
+++ b/test/features/llm/test_llm_schema_oneof.ts
@@ -22,6 +22,7 @@ export const test_llm_schema_oneof = (): void => {
             type: "number",
           },
         },
+        additionalProperties: false,
         required: ["type", "radius"],
       },
       {
@@ -38,6 +39,7 @@ export const test_llm_schema_oneof = (): void => {
             type: "number",
           },
         },
+        additionalProperties: false,
         required: ["type", "base", "height"],
       },
       {
@@ -54,6 +56,7 @@ export const test_llm_schema_oneof = (): void => {
             type: "number",
           },
         },
+        additionalProperties: false,
         required: ["type", "width", "height"],
       },
     ],


### PR DESCRIPTION
When recursive type comes in the LLM function calling application schema composer, it had been banned due to `ILlmSchema` does not support the `oneOf` type.

However, this PR makes it possible by supporting a new configurable option, `IHttpLlmApplication.IOptions.recursive`. If you set it to be `false`, the recursive type still be banned. Otherwise you set it to a numeric value, the recursive type would be repeated following the number.

This PR is duplicated with v2 update, but decided to support in the v1.2 update too.