### PR TITLE
Ban `multipart/form-data` type in the LLM

### DIFF
--- a/test/controllers/AppController.ts
+++ b/test/controllers/AppController.ts
@@ -69,9 +69,6 @@ export class AppController {
     };
   }
 
-  /**
-   * @deprecated
-   */
   @TypedRoute.Post(":index/:level/:optimal/multipart")
   public query_multipart(
     @TypedParam("index")
@@ -94,6 +91,9 @@ export class AppController {
     };
   }
 
+  /**
+   * @deprecated
+   */
   @TypedRoute.Get("nothing")
   public nothing(): void {}
 }

--- a/test/features/llm/test_http_llm_function_deprecated.ts
+++ b/test/features/llm/test_http_llm_function_deprecated.ts
@@ -14,8 +14,7 @@ export const test_http_llm_function_deprecated = (): void => {
     keyword: true,
   });
   const func: IHttpLlmFunction | undefined = application.functions.find(
-    (f) =>
-      f.method === "post" && f.path === "/{index}/{level}/{optimal}/multipart",
+    (f) => f.method === "get" && f.path === "/nothing",
   );
   TestValidator.equals("deprecated")(func?.deprecated)(true);
 };

--- a/test/features/llm/test_http_llm_function_multipart.ts
+++ b/test/features/llm/test_http_llm_function_multipart.ts
@@ -1,0 +1,18 @@
+import { TestValidator } from "@nestia/e2e";
+import { HttpLlm, IHttpLlmApplication, OpenApi } from "@samchon/openapi";
+
+import swagger from "../../swagger.json";
+
+export const test_http_llm_function_multipart = (): void => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpLlmApplication = HttpLlm.application(document, {
+    keyword: true,
+  });
+  TestValidator.equals("multipart not suppported")(
+    !!application.errors.find(
+      (e) =>
+        e.method === "post" &&
+        e.path === "/{index}/{level}/{optimal}/multipart",
+    ),
+  )(true);
+};

--- a/test/features/llm/test_llm_schema_recursive_array.ts
+++ b/test/features/llm/test_llm_schema_recursive_array.ts
@@ -1,0 +1,104 @@
+import { TestValidator } from "@nestia/e2e";
+import { HttpLlmConverter } from "@samchon/openapi/lib/converters/HttpLlmConverter";
+
+export const test_llm_schema_recursive_array = (): void => {
+  const schema = HttpLlmConverter.schema({
+    components: {
+      schemas: {
+        Department: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              format: "uuid",
+            },
+            name: {
+              type: "string",
+            },
+            children: {
+              type: "array",
+              items: {
+                $ref: "#/components/schemas/Department",
+              },
+            },
+          },
+          required: ["id", "name", "children"],
+        },
+      },
+    },
+    schema: {
+      $ref: "#/components/schemas/Department",
+    },
+    recursive: 3,
+  });
+  TestValidator.equals("recursive")(schema)({
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        format: "uuid",
+      },
+      name: {
+        type: "string",
+      },
+      children: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              format: "uuid",
+            },
+            name: {
+              type: "string",
+            },
+            children: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                    format: "uuid",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  children: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        id: {
+                          type: "string",
+                          format: "uuid",
+                        },
+                        name: {
+                          type: "string",
+                        },
+                        children: {
+                          type: "array",
+                          items: {},
+                          maxItems: 0,
+                        },
+                      },
+                      required: ["id", "name", "children"],
+                      additionalProperties: false,
+                    },
+                  },
+                },
+                required: ["id", "name", "children"],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ["id", "name", "children"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["id", "name", "children"],
+    additionalProperties: false,
+  });
+};

--- a/test/swagger.json
+++ b/test/swagger.json
@@ -7,7 +7,7 @@
     }
   ],
   "info": {
-    "version": "1.1.1-dev.20241008-2",
+    "version": "1.2.0",
     "title": "@samchon/openapi",
     "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
     "license": {
@@ -53,7 +53,24 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {}
+                  "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "level",
+                    "optimal"
+                  ]
                 }
               }
             }
@@ -117,7 +134,28 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {}
+                  "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    },
+                    "query": {
+                      "$ref": "#/components/schemas/IQuery"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "level",
+                    "optimal",
+                    "query"
+                  ]
                 }
               }
             }
@@ -176,7 +214,28 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {}
+                  "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    },
+                    "body": {
+                      "$ref": "#/components/schemas/IBody"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "level",
+                    "optimal",
+                    "body"
+                  ]
                 }
               }
             }
@@ -251,20 +310,44 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    },
                     "query": {
                       "type": "object",
                       "properties": {
+                        "thumbnail": {
+                          "type": "string",
+                          "format": "uri",
+                          "contentMediaType": "image/*"
+                        },
                         "summary": {
                           "type": "string"
                         }
                       },
                       "required": [
+                        "thumbnail",
                         "summary"
                       ]
+                    },
+                    "body": {
+                      "$ref": "#/components/schemas/IBody"
                     }
                   },
                   "required": [
-                    "query"
+                    "index",
+                    "level",
+                    "optimal",
+                    "query",
+                    "body"
                   ]
                 }
               }
@@ -275,7 +358,6 @@
     },
     "/{index}/{level}/{optimal}/multipart": {
       "post": {
-        "deprecated": true,
         "tags": [],
         "parameters": [
           {
@@ -341,6 +423,20 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    },
+                    "query": {
+                      "$ref": "#/components/schemas/IQuery"
+                    },
                     "body": {
                       "type": "object",
                       "properties": {
@@ -366,6 +462,10 @@
                     }
                   },
                   "required": [
+                    "index",
+                    "level",
+                    "optimal",
+                    "query",
                     "body"
                   ]
                 }
@@ -377,6 +477,7 @@
     },
     "/nothing": {
       "get": {
+        "deprecated": true,
         "tags": [],
         "parameters": [],
         "responses": {


### PR DESCRIPTION
This is duplicated with v2 update (#65), but decided to adapt in the v1.2 update too.