### PR TITLE
Export `ILlmSchema`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ OpenAPI definitions, converters and LLM function calling application composer.
   - [`IHttpLlmFunction<Schema>`](https://github.com/samchon/openapi/blob/master/src/structures/ILlmFunction.ts)
   - Supported schemas
     - ✔️[`IChatGptSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IChatGptSchema.ts): OpenAI ChatGPT
+    - ✍️`IClaudeSchema`: Anthropic Claude
     - ✔️[`IGeminiSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IGeminiSchema.ts): Google Gemini
     - ✍️`ILlamaSchema`: Meta (Facebook) Llama
-    - ✍️`IClaudeSchema`: Anthropic Claude
-    - ✔️[`ILlmSchemaV3`](https://github.com/samchon/openapi/blob/master/src/structures/ILlmSchemaV3.ts): middle layer of OpenAPI v3.0
-    - ✔️[`ILlmSchemaV3_1`](https://github.com/samchon/openapi/blob/master/src/structures/ILlmSchemaV3_1.ts): middle layer of OpenAPI v3.1
+  - Midldle layer schemas
+    - ✔️[`ILlmSchemaV3`](https://github.com/samchon/openapi/blob/master/src/structures/ILlmSchemaV3.ts): middle layer based on OpenAPI v3.0 specification
+    - ✔️[`ILlmSchemaV3_1`](https://github.com/samchon/openapi/blob/master/src/structures/ILlmSchemaV3_1.ts): middle layer based on OpenAPI v3.1 specification
 
 > [!TIP]
 >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.0.0-dev.20241123-5",
+  "version": "2.0.0-dev.20241124",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/converters/LlmSchemaConverter.ts
+++ b/src/converters/LlmSchemaConverter.ts
@@ -42,7 +42,6 @@ const PARAMETERS_CASTERS = {
   "3.1": (props: {
     components: OpenApi.IComponents;
     schema: OpenApi.IJsonSchema.IObject;
-    $defs: Record<string, ILlmSchemaV3_1>;
     config: ILlmSchemaV3_1.IConfig;
   }) =>
     LlmConverterV3_1.parameters({
@@ -53,7 +52,6 @@ const PARAMETERS_CASTERS = {
   chatgpt: (props: {
     components: OpenApi.IComponents;
     schema: OpenApi.IJsonSchema.IObject;
-    $defs: Record<string, IChatGptSchema>;
     config: IChatGptSchema.IConfig;
   }) =>
     ChatGptConverter.parameters({

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export * from "./structures/ILlmFunction";
 
 export * from "./structures/IChatGptSchema";
 export * from "./structures/IGeminiSchema";
+export * from "./structures/ILlmSchema";
 export * from "./structures/ILlmSchemaV3";
 export * from "./structures/ILlmSchemaV3_1";
 


### PR DESCRIPTION
This pull request includes updates to the OpenAPI definitions, converters, and versioning, as well as some adjustments to the exported modules. The most important changes include reordering and adding schema definitions in the `README.md`, updating the package version, and modifying the `LlmSchemaConverter` and `index.ts` files.

Updates to schema definitions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R51): Reordered and added `IClaudeSchema` and middle layer schemas for OpenAPI v3.0 and v3.1.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from "2.0.0-dev.20241123-5" to "2.0.0-dev.20241124".

Adjustments to converters:

* [`src/converters/LlmSchemaConverter.ts`](diffhunk://#diff-c5ee611714455cd0c4c7cce6e365a54713d134c5fd21e86fc3eda642e1687d31L45): Removed `$defs` from the parameters for both `ILlmSchemaV3_1` and `IChatGptSchema`. [[1]](diffhunk://#diff-c5ee611714455cd0c4c7cce6e365a54713d134c5fd21e86fc3eda642e1687d31L45) [[2]](diffhunk://#diff-c5ee611714455cd0c4c7cce6e365a54713d134c5fd21e86fc3eda642e1687d31L56)

Exported modules:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R33): Added export for `ILlmSchema`.