### PR TITLE
Fix `gemini` schema's `oneOf` detection logic.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.0.0-dev.20241129",
+  "version": "2.0.0-dev.20241129-4",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/converters/ChatGptConverter.ts
+++ b/src/converters/ChatGptConverter.ts
@@ -21,6 +21,7 @@ export namespace ChatGptConverter {
           reference: props.config.reference,
           constraint: false,
         },
+        validate: validate(props.errors),
       });
     if (params === null) return null;
     for (const key of Object.keys(params.$defs))
@@ -44,19 +45,7 @@ export namespace ChatGptConverter {
         reference: props.config.reference,
         constraint: false,
       },
-      validate: (schema, accessor) => {
-        if (
-          OpenApiTypeChecker.isObject(schema) &&
-          !!schema.additionalProperties
-        ) {
-          if (props.errors)
-            props.errors.push(
-              `${accessor}.additionalProperties: ChatGPT does not allow additionalProperties, the dynamic key typed object.`,
-            );
-          return false;
-        }
-        return true;
-      },
+      validate: validate(props.errors),
     });
     if (schema === null) return null;
     for (const key of Object.keys(props.$defs))
@@ -64,6 +53,22 @@ export namespace ChatGptConverter {
         props.$defs[key] = transform(props.$defs[key]);
     return transform(schema);
   };
+
+  const validate =
+    (errors: string[] | undefined) =>
+    (schema: OpenApi.IJsonSchema, accessor: string): boolean => {
+      if (
+        OpenApiTypeChecker.isObject(schema) &&
+        !!schema.additionalProperties
+      ) {
+        if (errors)
+          errors.push(
+            `${accessor}.additionalProperties: ChatGPT does not allow additionalProperties, the dynamic key typed object.`,
+          );
+        return false;
+      }
+      return true;
+    };
 
   const transform = (schema: ILlmSchemaV3_1): IChatGptSchema => {
     const union: Array<IChatGptSchema> = [];

--- a/src/converters/LlmConverterV3_1.ts
+++ b/src/converters/LlmConverterV3_1.ts
@@ -13,6 +13,7 @@ export namespace LlmConverterV3_1 {
     schema: OpenApi.IJsonSchema.IObject | OpenApi.IJsonSchema.IReference;
     errors?: string[];
     accessor?: string;
+    validate?: (input: OpenApi.IJsonSchema, accessor: string) => boolean;
   }): ILlmSchemaV3_1.IParameters | null => {
     const entity: OpenApi.IJsonSchema.IObject | null =
       LlmParametersFinder.find(props);

--- a/test/features/llm/gemini/test_gemini_schema_enum.ts
+++ b/test/features/llm/gemini/test_gemini_schema_enum.ts
@@ -1,0 +1,25 @@
+import { TestValidator } from "@nestia/e2e";
+import { LlmSchemaConverter } from "@samchon/openapi/lib/converters/LlmSchemaConverter";
+import typia, { IJsonSchemaCollection, tags } from "typia";
+
+export const test_gemini_schema_enum = (): void => {
+  const collection: IJsonSchemaCollection =
+    typia.json.schemas<
+      [
+        0 | 1 | 2,
+        (number & {}) | 1.2 | 2.3 | 3.4,
+        (number & tags.Type<"int32">) | 1 | 2 | 3,
+        "one" | "two" | "three",
+      ]
+    >();
+  for (const schema of collection.schemas) {
+    const errors: string[] = [];
+    const gemini = LlmSchemaConverter.schema("gemini")({
+      config: LlmSchemaConverter.defaultConfig("gemini"),
+      components: collection.components,
+      schema,
+      errors,
+    });
+    TestValidator.equals("success")(!!gemini)(true);
+  }
+};

--- a/test/features/llm/gemini/test_gemini_schema_nullable.ts
+++ b/test/features/llm/gemini/test_gemini_schema_nullable.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import { LlmSchemaConverter } from "@samchon/openapi/lib/converters/LlmSchemaConverter";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_gemini_schema_nullable = (): void => {
+  const collection: IJsonSchemaCollection = typia.json.schemas<
+    [
+      0 | 1 | 2 | 3 | null,
+      (number & {}) | 1.2 | 2.3 | 3.4 | null,
+      {
+        id: string | null;
+        value: number;
+      } | null,
+      Array<number> | null,
+      Array<{
+        nested: Array<{
+          id: string | null;
+        }>;
+        nullable: Array<string | null>;
+      }>,
+      {
+        first: ToJsonNull;
+        second: ToJsonNull | null;
+      },
+      {
+        first: ToJsonNull | null;
+        second: ToJsonNull | null;
+        third?: ToJsonNull | null;
+      },
+    ]
+  >();
+  for (const schema of collection.schemas) {
+    const errors: string[] = [];
+    const gemini = LlmSchemaConverter.schema("gemini")({
+      config: LlmSchemaConverter.defaultConfig("gemini"),
+      components: collection.components,
+      schema,
+      errors,
+    });
+    TestValidator.equals("success")(!!gemini)(true);
+  }
+};
+
+interface ToJsonNull {
+  toJSON: () => null;
+}


### PR DESCRIPTION
This pull request includes several changes to the `@samchon/openapi` package, focusing on improving schema validation and adding new test cases for the Gemini converter. The most important changes include updating the package version, enhancing the validation logic in `ChatGptConverter` and `GeminiConverter`, and adding new test cases for schema validation.

### Version Update:
* Updated the package version in `package.json` to `2.0.0-dev.20241129-4`.

### Validation Enhancements:
* [`src/converters/ChatGptConverter.ts`](diffhunk://#diff-53ae686b13f3841defc9fcac8d94ad132673c71ce2a09949b33b248a5cea812fR24): Added a new `validate` function to handle schema validation and updated the existing validation logic to use this function. [[1]](diffhunk://#diff-53ae686b13f3841defc9fcac8d94ad132673c71ce2a09949b33b248a5cea812fR24) [[2]](diffhunk://#diff-53ae686b13f3841defc9fcac8d94ad132673c71ce2a09949b33b248a5cea812fL47-L65)
* [`src/converters/GeminiConverter.ts`](diffhunk://#diff-e4f4435dfbb182de0938bc08d73c4a7a0eb27061a48a26d37d9210b593c28de1R51-R84): Added validation logic for handling nullable cases and enum cases within the schema.
* [`src/converters/LlmConverterV3_1.ts`](diffhunk://#diff-7d3dcba4a3902aedfe05b05c6651dc26c66b22134a9c5260da132fe0f9a26a0aR16): Introduced an optional `validate` function in the `LlmConverterV3_1` namespace to enhance schema validation.

### Test Cases:
* Added a new test case `test_gemini_schema_enum` to validate enum schemas in `test/features/llm/gemini/test_gemini_schema_enum.ts`.
* Added a new test case `test_gemini_schema_nullable` to validate nullable schemas in `test/features/llm/gemini/test_gemini_schema_nullable.ts`.

### Utility Imports:
* [`src/converters/GeminiConverter.ts`](diffhunk://#diff-e4f4435dfbb182de0938bc08d73c4a7a0eb27061a48a26d37d9210b593c28de1R5): Imported `MapUtil` to assist with schema transformation logic.