### PR TITLE
Make `constraint` option to be default `true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.0.0-dev.20241130",
+  "version": "2.0.0-dev.20241130-2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/converters/LlmSchemaConverter.ts
+++ b/src/converters/LlmSchemaConverter.ts
@@ -67,11 +67,11 @@ const DEFAULT_CONFIGS = {
     reference: false,
   } satisfies ILlamaSchema.IConfig,
   "3.0": {
-    constraint: false,
+    constraint: true,
     recursive: 3,
   } satisfies ILlmSchemaV3.IConfig,
   "3.1": {
-    constraint: false,
+    constraint: true,
     reference: false,
   } satisfies ILlmSchemaV3_1.IConfig,
 };

--- a/src/structures/ILlmSchemaV3.ts
+++ b/src/structures/ILlmSchemaV3.ts
@@ -464,12 +464,13 @@ export namespace ILlmSchemaV3 {
      * written to the {@link ILlmSchemaV3.__IAttribute.description} property
      * as a comment string like `"@format uuid"`.
      *
-     * This is because the some LLM model's function calling understands the constraint
-     * properties when the function parameter types are simple, however it occurs
-     * some errors when the parameter types are complex.
+     * This is because some LLM schema model like {@link IGeminiSchema}
+     * has banned such constraint, because their LLM cannot understand the
+     * constraint properties and occur the hallucination.
      *
-     * Therefore, considering the complexity of your parameter types, determine
-     * which is better, to allow the constraint properties or not.
+     * Therefore, considering your LLM model's performance, capability,
+     * and the complexity of your parameter types, determine which is better,
+     * to allow the constraint properties or not.
      *
      * - {@link ILlmSchemaV3.INumber.minimum}
      * - {@link ILlmSchemaV3.INumber.maximum}
@@ -484,7 +485,7 @@ export namespace ILlmSchemaV3 {
      * - {@link ILlmSchemaV3.IArray.maxItems}
      * - {@link ILlmSchemaV3.IArray.unique}
      *
-     * @default false
+     * @default true
      */
     constraint: boolean;
 

--- a/src/structures/ILlmSchemaV3_1.ts
+++ b/src/structures/ILlmSchemaV3_1.ts
@@ -507,12 +507,13 @@ export namespace ILlmSchemaV3_1 {
      * written to the {@link ILlmSchemaV3_1.__IAttribute.description} property
      * as a comment string like `"@format uuid"`.
      *
-     * This is because the some LLM model's function calling understands the constraint
-     * properties when the function parameter types are simple, however it occurs
-     * some errors when the parameter types are complex.
+     * This is because some LLM schema model like {@link IChatGptSchema}
+     * has banned such constraint, because their LLM cannot understand the
+     * constraint properties and occur the hallucination.
      *
-     * Therefore, considering the complexity of your parameter types, determine
-     * which is better, to allow the constraint properties or not.
+     * Therefore, considering your LLM model's performance, capability,
+     * and the complexity of your parameter types, determine which is better,
+     * to allow the constraint properties or not.
      *
      * - {@link ILlmSchemaV3_1.INumber.minimum}
      * - {@link ILlmSchemaV3_1.INumber.maximum}
@@ -527,7 +528,7 @@ export namespace ILlmSchemaV3_1 {
      * - {@link ILlmSchemaV3_1.IArray.maxItems}
      * - {@link ILlmSchemaV3_1.IArray.unique}
      *
-     * @default false
+     * @default true
      */
     constraint: boolean;
 


### PR DESCRIPTION
This pull request includes several changes to the `@samchon/openapi` package, focusing on updating versioning, modifying configurations, and improving documentation for LLM schema models.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.0.0-dev.20241130` to `2.0.0-dev.20241130-2`.

### Configuration Changes:
* [`src/converters/LlmSchemaConverter.ts`](diffhunk://#diff-c5ee611714455cd0c4c7cce6e365a54713d134c5fd21e86fc3eda642e1687d31L70-R74): Changed the `constraint` property to `true` for both `3.0` and `3.1` configurations in the `DEFAULT_CONFIGS` object.

### Documentation and Default Value Updates:
* [`src/structures/ILlmSchemaV3.ts`](diffhunk://#diff-a83bad0fda93321814c4ce21df194a9e142cf63a291737fbedee22d69536bd42L467-R473): Updated the documentation to reflect the correct behavior of LLM schema models like `IGeminiSchema` and changed the default value of the `constraint` property to `true`. [[1]](diffhunk://#diff-a83bad0fda93321814c4ce21df194a9e142cf63a291737fbedee22d69536bd42L467-R473) [[2]](diffhunk://#diff-a83bad0fda93321814c4ce21df194a9e142cf63a291737fbedee22d69536bd42L487-R488)
* [`src/structures/ILlmSchemaV3_1.ts`](diffhunk://#diff-72e41eeadd5016cdfe8a554caae2e2bb215b4b929ff01b52fa5f79efd14bd3abL510-R516): Updated the documentation to reflect the correct behavior of LLM schema models like `IChatGptSchema` and changed the default value of the `constraint` property to `true`. [[1]](diffhunk://#diff-72e41eeadd5016cdfe8a554caae2e2bb215b4b929ff01b52fa5f79efd14bd3abL510-R516) [[2]](diffhunk://#diff-72e41eeadd5016cdfe8a554caae2e2bb215b4b929ff01b52fa5f79efd14bd3abL530-R531)