### PR TITLE
Fix `IResult.ISuccess.value`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.0.0-dev.20241202",
+  "version": "2.0.0-dev.20241202-2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/HttpLlmApplicationComposer.ts
+++ b/src/composers/HttpLlmApplicationComposer.ts
@@ -105,7 +105,7 @@ export namespace HttpLlmComposer {
         );
         return null;
       }
-      return result.data as ILlmSchema.ModelSchema[Model];
+      return result.value as ILlmSchema.ModelSchema[Model];
     };
 
     const endpoint: string = `$input.paths[${JSON.stringify(props.route.path)}][${JSON.stringify(props.route.method)}]`;

--- a/src/composers/llm/ChatGptSchemaComposer.ts
+++ b/src/composers/llm/ChatGptSchemaComposer.ts
@@ -27,11 +27,11 @@ export namespace ChatGptSchemaComposer {
         validate,
       });
     if (result.success === false) return result;
-    for (const key of Object.keys(result.data.$defs))
-      result.data.$defs[key] = transform(result.data.$defs[key]);
+    for (const key of Object.keys(result.value.$defs))
+      result.value.$defs[key] = transform(result.value.$defs[key]);
     return {
       success: true,
-      data: transform(result.data) as IChatGptSchema.IParameters,
+      value: transform(result.value) as IChatGptSchema.IParameters,
     };
   };
 
@@ -59,7 +59,7 @@ export namespace ChatGptSchemaComposer {
         props.$defs[key] = transform(props.$defs[key]);
     return {
       success: true,
-      data: transform(result.data),
+      value: transform(result.value),
     };
   };
 

--- a/src/composers/llm/GeminiSchemaComposer.ts
+++ b/src/composers/llm/GeminiSchemaComposer.ts
@@ -27,7 +27,7 @@ export namespace GeminiSchemaComposer {
     if (entity.success === false) return entity;
     return schema({
       ...props,
-      schema: entity.data,
+      schema: entity.value,
     }) as IResult<IGeminiSchema.IParameters, IOpenApiSchemaError>;
   };
 
@@ -74,7 +74,7 @@ export namespace GeminiSchemaComposer {
 
     // SPECIALIZATIONS
     LlmTypeCheckerV3.visit({
-      schema: result.data,
+      schema: result.value,
       closure: (v) => {
         if (v.title !== undefined) {
           if (v.description === undefined) v.description = v.title;

--- a/src/composers/llm/LlmParametersComposer.ts
+++ b/src/composers/llm/LlmParametersComposer.ts
@@ -17,19 +17,19 @@ export namespace LlmParametersFinder {
     const entity: IResult<OpenApi.IJsonSchema, IOpenApiSchemaError> =
       OpenApiTypeChecker.unreference(props);
     if (entity.success === false) return entity;
-    else if (OpenApiTypeChecker.isObject(entity.data) === false)
+    else if (OpenApiTypeChecker.isObject(entity.value) === false)
       return reportError({
         ...props,
         message: "LLM only accepts object type as parameters.",
       });
-    else if (!!entity.data.additionalProperties)
+    else if (!!entity.value.additionalProperties)
       return reportError({
         ...props,
         message: "LLM does not allow additional properties on parameters.",
       });
     return {
       success: true,
-      data: entity.data,
+      value: entity.value,
     };
   };
 

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -31,13 +31,13 @@ export namespace LlmSchemaV3Composer {
 
     const result: IResult<ILlmSchemaV3, IOpenApiSchemaError> = schema({
       ...props,
-      schema: entity.data,
+      schema: entity.value,
     });
     if (result.success === false) return result;
     return {
       success: true,
-      data: {
-        ...(result.data as ILlmSchemaV3.IObject),
+      value: {
+        ...(result.value as ILlmSchemaV3.IObject),
         additionalProperties: false,
       } satisfies ILlmSchemaV3.IParameters,
     };
@@ -117,7 +117,7 @@ export namespace LlmSchemaV3Composer {
         schemas: {},
       },
       downgraded: {},
-    })(escaped.data) as ILlmSchemaV3;
+    })(escaped.value) as ILlmSchemaV3;
     LlmTypeCheckerV3.visit({
       closure: (next) => {
         if (
@@ -153,7 +153,7 @@ export namespace LlmSchemaV3Composer {
     });
     return {
       success: true,
-      data: downgraded,
+      value: downgraded,
     };
   };
 

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -34,13 +34,13 @@ export namespace LlmSchemaV3_1Composer {
     const result: IResult<ILlmSchemaV3_1, IOpenApiSchemaError> = schema({
       ...props,
       $defs,
-      schema: entity.data,
+      schema: entity.value,
     });
     if (result.success === false) return result;
     return {
       success: true,
-      data: {
-        ...(result.data as ILlmSchemaV3_1.IObject),
+      value: {
+        ...(result.value as ILlmSchemaV3_1.IObject),
         additionalProperties: false,
         $defs,
       } satisfies ILlmSchemaV3_1.IParameters,
@@ -149,7 +149,7 @@ export namespace LlmSchemaV3_1Composer {
               accessor: `${props.refAccessor ?? "$def"}[${JSON.stringify(key)}]`,
             });
           if (converted.success === false) return union.push(null); // UNREACHABLE
-          props.$defs[key] = converted.data;
+          props.$defs[key] = converted.value;
           return out();
         } else {
           // DISCARD THE REFERENCE TYPE
@@ -190,7 +190,7 @@ export namespace LlmSchemaV3_1Composer {
                   refAccessor: props.refAccessor,
                   accessor: `${accessor}.properties[${JSON.stringify(key)}]`,
                 });
-              acc[key] = converted.success ? converted.data : null;
+              acc[key] = converted.success ? converted.value : null;
               if (converted.success === false)
                 reasons.push(...converted.error.reasons);
               return acc;
@@ -221,7 +221,7 @@ export namespace LlmSchemaV3_1Composer {
               reasons.push(...converted.error.reasons);
               return null;
             }
-            return converted.data;
+            return converted.value;
           }
           return input.additionalProperties;
         })();
@@ -251,7 +251,7 @@ export namespace LlmSchemaV3_1Composer {
             : (x: ILlmSchemaV3_1.IArray) =>
                 OpenApiContraintShifter.shiftArray(x))({
             ...input,
-            items: items.data,
+            items: items.value,
           }),
         );
       } else if (OpenApiTypeChecker.isString(input))
@@ -293,7 +293,7 @@ export namespace LlmSchemaV3_1Composer {
     else if (union.length === 0)
       return {
         success: true,
-        data: {
+        value: {
           ...attribute,
           type: undefined,
         },
@@ -301,7 +301,7 @@ export namespace LlmSchemaV3_1Composer {
     else if (union.length === 1)
       return {
         success: true,
-        data: {
+        value: {
           ...attribute,
           ...union[0]!,
           description: LlmTypeCheckerV3_1.isReference(union[0]!)
@@ -311,7 +311,7 @@ export namespace LlmSchemaV3_1Composer {
       };
     return {
       success: true,
-      data: {
+      value: {
         ...attribute,
         oneOf: union.map((u) => ({
           ...u!,

--- a/src/typings/IResult.ts
+++ b/src/typings/IResult.ts
@@ -2,7 +2,7 @@ export type IResult<T, E> = IResult.ISuccess<T> | IResult.IFailure<E>;
 export namespace IResult {
   export interface ISuccess<T> {
     success: true;
-    data: T;
+    value: T;
   }
   export interface IFailure<E> {
     success: false;

--- a/src/utils/internal/OpenApiTypeCheckerBase.ts
+++ b/src/utils/internal/OpenApiTypeCheckerBase.ts
@@ -136,7 +136,7 @@ export namespace OpenApiTypeCheckerBase {
       };
     return {
       success: true,
-      data: result,
+      value: result,
     };
   };
 
@@ -169,7 +169,7 @@ export namespace OpenApiTypeCheckerBase {
       };
     return {
       success: true,
-      data: result,
+      value: result,
     };
   };
 

--- a/test/executable/llama-function-calling.ts
+++ b/test/executable/llama-function-calling.ts
@@ -67,7 +67,7 @@ const archive = async (props: {
           model,
           name: props.name,
           description: props.description,
-          parameters: result.data,
+          parameters: result.value,
           texts: props.texts,
         },
         null,

--- a/test/features/llm/validate_llm_parameters_separate_array.ts
+++ b/test/features/llm/validate_llm_parameters_separate_array.ts
@@ -105,5 +105,5 @@ const schema =
       console.log(result.error);
       throw new Error("Invalid schema");
     }
-    return result.data;
+    return result.value;
   };

--- a/test/features/llm/validate_llm_parameters_separate_nested.ts
+++ b/test/features/llm/validate_llm_parameters_separate_nested.ts
@@ -111,5 +111,5 @@ const schema =
       } satisfies ILlmSchema.IConfig<Model> as any,
     }) as IResult<ILlmSchema.IParameters<Model>, IOpenApiSchemaError>;
     if (result.success === false) throw new Error("Invalid schema");
-    return result.data;
+    return result.value;
   };

--- a/test/features/llm/validate_llm_parameters_separate_object.ts
+++ b/test/features/llm/validate_llm_parameters_separate_object.ts
@@ -101,5 +101,5 @@ const schema =
       } satisfies ILlmSchema.IConfig<Model> as any,
     }) as IResult<ILlmSchema.IParameters<Model>, IOpenApiSchemaError>;
     if (result.success === false) throw new Error("Invalid schema");
-    return result.data;
+    return result.value;
   };

--- a/test/features/llm/validate_llm_parameters_separate_object_additionalProperties.ts
+++ b/test/features/llm/validate_llm_parameters_separate_object_additionalProperties.ts
@@ -116,5 +116,5 @@ const schema =
       } satisfies ILlmSchema.IConfig<Model> as any,
     }) as IResult<ILlmSchema.IParameters<Model>, IOpenApiSchemaError>;
     if (result.success === false) throw new Error("Invalid schema");
-    return result.data;
+    return result.value;
   };

--- a/test/features/llm/validate_llm_parameters_separate_ref.ts
+++ b/test/features/llm/validate_llm_parameters_separate_ref.ts
@@ -124,5 +124,5 @@ const schema =
       } satisfies ILlmSchema.IConfig<Model> as any,
     }) as IResult<ILlmSchema.IParameters<Model>, IOpenApiSchemaError>;
     if (result.success === false) throw new Error("Invalid schema");
-    return result.data;
+    return result.value;
   };

--- a/test/features/llm/validate_llm_schema_enum.ts
+++ b/test/features/llm/validate_llm_schema_enum.ts
@@ -33,7 +33,7 @@ const validate_llm_schema_enum = <Model extends "chatgpt" | "gemini" | "3.0">(
   TestValidator.equals("success")(result.success);
   TestValidator.equals("enum")(
     typia.assert<IGeminiSchema.IString>(
-      typia.assert<IGeminiSchema.IObject>(result.success ? result.data : {})
+      typia.assert<IGeminiSchema.IObject>(result.success ? result.value : {})
         .properties.format,
     ).enum,
   )(["html", "md", "txt"]);

--- a/test/features/llm/validate_llm_schema_enum_reference.ts
+++ b/test/features/llm/validate_llm_schema_enum_reference.ts
@@ -56,7 +56,7 @@ const validate_llm_schema_enum_reference = <
     $defs: {},
   }) as IResult<ILlmSchema<Model>, IOpenApiSchemaError>;
   TestValidator.equals("success")(result.success)(true);
-  TestValidator.equals("union")(result.success ? result.data : {})({
+  TestValidator.equals("union")(result.success ? result.value : {})({
     type: "number",
     enum: [3, 4, 5],
   });

--- a/test/features/llm/validate_llm_schema_nullable.ts
+++ b/test/features/llm/validate_llm_schema_nullable.ts
@@ -37,7 +37,7 @@ const validate_llm_schema_nullable = <Model extends ILlmSchema.Model>(
     $defs: {},
   }) as IResult<ILlmSchema<Model>, IOpenApiSchemaError>;
   TestValidator.equals("success")(result.success)(true);
-  TestValidator.equals("nullable")(result.success ? result.data : {})(
+  TestValidator.equals("nullable")(result.success ? result.value : {})(
     expected === "nullable"
       ? ({
           type: "number",

--- a/test/features/llm/validate_llm_schema_oneof.ts
+++ b/test/features/llm/validate_llm_schema_oneof.ts
@@ -41,7 +41,7 @@ const validate_llm_schema_oneof = <Model extends ILlmSchema.Model>(
   }) as IResult<ILlmSchema<Model>, IOpenApiSchemaError>;
   TestValidator.equals("success")(result.success);
   TestValidator.equals(field)(["point", "line", "triangle", "rectangle"])(
-    (result as any)?.data?.[field]?.map((e: any) =>
+    (result as any)?.value?.[field]?.map((e: any) =>
       constant ? e.properties?.type?.const : e.properties?.type?.enum?.[0],
     ),
   );

--- a/test/features/llm/validate_llm_schema_recursive_ref.ts
+++ b/test/features/llm/validate_llm_schema_recursive_ref.ts
@@ -70,7 +70,7 @@ const validate_llm_schema_recursive_ref = <
       required: ["name", "children"],
     },
   })($defs as any);
-  TestValidator.equals("schema")(result.success ? result.data : {})({
+  TestValidator.equals("schema")(result.success ? result.value : {})({
     $ref: "#/$defs/Department",
   });
 };

--- a/test/features/llm/validate_llm_schema_reference_description.ts
+++ b/test/features/llm/validate_llm_schema_reference_description.ts
@@ -93,5 +93,5 @@ const composeSchema =
       } satisfies ILlmSchema.IConfig<Model> as any,
     }) as IResult<ILlmSchema.IParameters<Model>, IOpenApiSchemaError>;
     if (result.success === false) throw new Error("Invalid schema");
-    return result.data;
+    return result.value;
   };

--- a/test/features/llm/validate_llm_schema_separate_string.ts
+++ b/test/features/llm/validate_llm_schema_separate_string.ts
@@ -97,5 +97,5 @@ const schema =
       } satisfies ILlmSchema.IConfig<Model> as any,
     }) as IResult<ILlmSchema.IParameters<Model>, IOpenApiSchemaError>;
     if (result.success === false) throw new Error("Invalid schema");
-    return result.data;
+    return result.value;
   };

--- a/test/utils/ChatGptFunctionCaller.ts
+++ b/test/utils/ChatGptFunctionCaller.ts
@@ -42,7 +42,7 @@ export namespace ChatGptFunctionCaller {
         "Failed to convert the JSON schema to the ChatGPT schema.",
       );
     else if (props.handleParameters)
-      await props.handleParameters(parameters.data);
+      await props.handleParameters(parameters.value);
 
     const client: OpenAI = new OpenAI({
       apiKey: TestGlobal.env.CHATGPT_API_KEY,
@@ -57,7 +57,7 @@ export namespace ChatGptFunctionCaller {
             function: {
               name: props.name,
               description: props.description,
-              parameters: parameters.data as Record<string, any>,
+              parameters: parameters.value as Record<string, any>,
               strict: true,
             },
           },

--- a/test/utils/ClaudeFunctionCaller.ts
+++ b/test/utils/ClaudeFunctionCaller.ts
@@ -47,7 +47,7 @@ export namespace ClaudeFunctionCaller {
         "Failed to convert the JSON schema to the Claude schema.",
       );
     else if (props.handleParameters)
-      await props.handleParameters(parameters.data);
+      await props.handleParameters(parameters.value);
 
     const client: Anthropic = new Anthropic({
       apiKey: TestGlobal.env.CLAUDE_API_KEY,
@@ -60,7 +60,7 @@ export namespace ClaudeFunctionCaller {
         {
           name: props.name,
           description: props.description,
-          input_schema: parameters.data as any,
+          input_schema: parameters.value as any,
         },
       ],
     });

--- a/test/utils/GeminiFunctionCaller.ts
+++ b/test/utils/GeminiFunctionCaller.ts
@@ -44,7 +44,7 @@ export namespace GeminiFunctionCaller {
       throw new Error(
         "Failed to convert the JSON schema to the Gemini schema.",
       );
-    if (props.handleParameters) await props.handleParameters(parameters.data);
+    if (props.handleParameters) await props.handleParameters(parameters.value);
 
     const model: GenerativeModel = new GoogleGenerativeAI(
       TestGlobal.env.GEMINI_API_KEY,
@@ -66,7 +66,7 @@ export namespace GeminiFunctionCaller {
             {
               name: props.name,
               description: props.description,
-              parameters: parameters.data as any,
+              parameters: parameters.value as any,
             },
           ],
         },

--- a/test/utils/LlamaFunctionCaller.ts
+++ b/test/utils/LlamaFunctionCaller.ts
@@ -46,7 +46,7 @@ export namespace LlamaFunctionCaller {
         "Failed to convert the JSON schema to the Claude schema.",
       );
     else if (props.handleParameters)
-      await props.handleParameters(parameters.data);
+      await props.handleParameters(parameters.value);
 
     const client: OpenAI = new OpenAI({
       apiKey: TestGlobal.env.LLAMA_API_KEY,
@@ -62,7 +62,7 @@ export namespace LlamaFunctionCaller {
             function: {
               name: props.name,
               description: props.description,
-              parameters: parameters.data as any,
+              parameters: parameters.value as any,
             },
           },
         ],


### PR DESCRIPTION
This pull request includes a series of changes across multiple files to standardize the usage of the `value` property instead of `data` in result objects. The most important changes involve updates to various schema composers, type definitions, and test files.

### Schema Composers:
* [`src/composers/HttpLlmApplicationComposer.ts`](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL108-R108): Changed `result.data` to `result.value` in the return statement.
* [`src/composers/llm/ChatGptSchemaComposer.ts`](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL30-R34): Replaced `result.data` with `result.value` and updated all references accordingly. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL30-R34) [[2]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL62-R62)
* [`src/composers/llm/GeminiSchemaComposer.ts`](diffhunk://#diff-4e9da1f0bdac90742383f58756d5fe60a9d5de3293d24f67f6015f9e88d54759L30-R30): Updated schema assignment from `entity.data` to `entity.value`. [[1]](diffhunk://#diff-4e9da1f0bdac90742383f58756d5fe60a9d5de3293d24f67f6015f9e88d54759L30-R30) [[2]](diffhunk://#diff-4e9da1f0bdac90742383f58756d5fe60a9d5de3293d24f67f6015f9e88d54759L77-R77)
* [`src/composers/llm/LlmParametersComposer.ts`](diffhunk://#diff-83ad2dd9529aac454c0d2176ce4cfd600db7b37adc25eba45db6ee49ed095ad9L20-R32): Changed checks and return values from `entity.data` to `entity.value`.
* [`src/composers/llm/LlmSchemaV3Composer.ts`](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L34-R40): Modified to use `result.value` instead of `result.data` throughout the file. [[1]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L34-R40) [[2]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L120-R120) [[3]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L156-R156)
* [`src/composers/llm/LlmSchemaV3_1Composer.ts`](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L37-R43): Replaced `result.data` with `result.value` and updated all references accordingly. [[1]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L37-R43) [[2]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L152-R152) [[3]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L193-R193) [[4]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L224-R224) [[5]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L254-R254) [[6]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L296-R304) [[7]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L314-R314)

### Type Definitions:
* [`src/typings/IResult.ts`](diffhunk://#diff-7731a532c1a52aac4d0bcf6c7a86fd0f1cf00b76913c86f905ad2dc53c3f69fcL5-R5): Changed the `ISuccess` interface to use `value` instead of `data`.

### Utility Functions:
* [`src/utils/internal/OpenApiTypeCheckerBase.ts`](diffhunk://#diff-54fbcd5296d8727b0754cf5e0208abefb0bc3e4afc9010cee5ecdd1c2dda3c1fL139-R139): Updated the return value from `result.data` to `result.value`. [[1]](diffhunk://#diff-54fbcd5296d8727b0754cf5e0208abefb0bc3e4afc9010cee5ecdd1c2dda3c1fL139-R139) [[2]](diffhunk://#diff-54fbcd5296d8727b0754cf5e0208abefb0bc3e4afc9010cee5ecdd1c2dda3c1fL172-R172)

### Tests:
* Various test files updated to use `result.value` instead of `result.data` in assertions and return values. [[1]](diffhunk://#diff-b9a9503912b7368ccf22bc165efbf6b1ed97778008f443eb548f9166e5a401a2L70-R70) [[2]](diffhunk://#diff-7cbe9aa3a21ad00ad9cfc88d4fe6b109bcdf623661a5a31bc46ae462c8406b8cL108-R108) [[3]](diffhunk://#diff-f9683d9a23c9ad856a0a1d7f001f5c3e8d22a98939eabd2eda37955208d3aee9L114-R114) [[4]](diffhunk://#diff-c94a1e66e51ad3606baf6927958449ade7c322a41ba103fe8de190c2a1a9ff30L104-R104) [[5]](diffhunk://#diff-747b292444e490d81310ee4970e6f30cd2bbd400cc7c405235a01a335c8652e3L119-R119) [[6]](diffhunk://#diff-c12d80fdee908c372e6b9abbf49db463a19063338aa87240c840a3a23969f28bL127-R127) [[7]](diffhunk://#diff-f0358b1d3d71f771f3c7362251d1b9ffb5dd0d45dcb4e0c03ef0d322aee16c89L36-R36) [[8]](diffhunk://#diff-f08b440cacad60bf3b055e389c66d74b2019585e86ac747994c4aeb0ef00bbe3L59-R59) [[9]](diffhunk://#diff-ba5ae75040d524a057a0bc7bb709c87a79b07507f1ba9891ac00c64a4f328025L40-R40) [[10]](diffhunk://#diff-b591b5f65a4722ae4e2e3adca6c1cced7f101f0a1b085c825bc6eae7b53994a3L44-R44) [[11]](diffhunk://#diff-bc2a7c3910686fd22a856d06f733c324e5ce8ec5eb0c5e5e1f742d99645ba749L73-R73)

These changes ensure consistency and clarity in how result objects are handled across the codebase.The property `data` is not proper for the `Try<T, E>` function;'s return value.