### PR TITLE
Closes samchon/typia#1366: add discord server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ flowchart
 [![npm version](https://img.shields.io/npm/v/@samchon/openapi.svg)](https://www.npmjs.com/package/@samchon/openapi)
 [![Downloads](https://img.shields.io/npm/dm/@samchon/openapi.svg)](https://www.npmjs.com/package/@samchon/openapi)
 [![Build Status](https://github.com/samchon/openapi/workflows/build/badge.svg)](https://github.com/samchon/openapi/actions?query=workflow%3Abuild)
+[![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
 
 OpenAPI definitions, converters and LLM function calling application composer.
 


### PR DESCRIPTION
related issue: samchon/typia#1366

This pull request includes a small change to the `README.md` file. The change adds a Discord badge to the list of badges in the file.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23): Added a Discord badge with a link to the Discord server.