### PR TITLE
`OpenApi.IOperation["x-samchon-human"]` blocking LLM function composition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -441,6 +441,16 @@ export namespace OpenApi {
      * Flag for indicating this operation is deprecated.
      */
     deprecated?: boolean;
+
+    /**
+     * Flag for indicating this operation is human-only.
+     *
+     * If this property value is `true`, {@link HttpLlm.application}
+     * function will not convert this operation schema into the LLM function
+     * calling schema that is represented by the {@link IHttpLlmFunction}
+     * interface.
+     */
+    "x-samchon-human"?: boolean;
   }
   export namespace IOperation {
     /**

--- a/src/composers/HttpLlmApplicationComposer.ts
+++ b/src/composers/HttpLlmApplicationComposer.ts
@@ -15,16 +15,17 @@ export namespace HttpLlmComposer {
     options: IHttpLlmApplication.IOptions<Model>;
   }): IHttpLlmApplication<Model> => {
     // COMPOSE FUNCTIONS
-    const errors: IHttpLlmApplication.IError[] = props.migrate.errors.map(
-      (e) => ({
+    const errors: IHttpLlmApplication.IError[] = props.migrate.errors
+      .filter((e) => e.operation()["x-samchon-human"] !== true)
+      .map((e) => ({
         method: e.method,
         path: e.path,
         messages: e.messages,
         operation: () => e.operation(),
         route: () => undefined,
-      }),
-    );
+      }));
     const functions: IHttpLlmFunction<Model>[] = props.migrate.routes
+      .filter((e) => e.operation()["x-samchon-human"] !== true)
       .map((route, i) => {
         if (route.method === "head") {
           errors.push({

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -240,6 +240,17 @@ export namespace LlmSchemaV3Composer {
       if (x !== null) llm.properties[key] = x;
       if (y !== null) human.properties[key] = y;
     }
+    if (
+      typeof props.schema.additionalProperties === "object" &&
+      props.schema.additionalProperties !== null
+    ) {
+      const [dx, dy] = separateStation({
+        predicate: props.predicate,
+        schema: props.schema.additionalProperties,
+      });
+      llm.additionalProperties = dx ?? false;
+      human.additionalProperties = dy ?? false;
+    }
     return [
       Object.keys(llm.properties).length === 0 ? null : shrinkRequired(llm),
       Object.keys(human.properties).length === 0 ? null : shrinkRequired(human),

--- a/test/features/llm/test_http_llm_application_human.ts
+++ b/test/features/llm/test_http_llm_application_human.ts
@@ -1,0 +1,29 @@
+import { TestValidator } from "@nestia/e2e";
+import { HttpLlm, IHttpLlmApplication, OpenApi } from "@samchon/openapi";
+
+import swagger from "../../swagger.json";
+
+export const test_http_llm_application = (): void => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpLlmApplication<"3.0"> = HttpLlm.application({
+    model: "3.0",
+    document,
+    options: {},
+  });
+
+  const humanSwagger: typeof swagger = JSON.parse(JSON.stringify(swagger));
+  (
+    humanSwagger.paths["/{index}/{level}/{optimal}/body"]
+      .post as OpenApi.IOperation
+  )["x-samchon-human"] = true;
+  const humanDocument: OpenApi.IDocument = OpenApi.convert(humanSwagger as any);
+  const humanApplication: IHttpLlmApplication<"3.0"> = HttpLlm.application({
+    model: "3.0",
+    document: humanDocument,
+    options: {},
+  });
+
+  TestValidator.equals("length")(application.functions.length)(
+    humanApplication.functions.length + 1,
+  );
+};


### PR DESCRIPTION
This pull request introduces several enhancements and fixes, primarily focusing on adding support for human-only operations and improving the handling of additional properties in schemas. The most important changes include updating the package version, adding a new flag for human-only operations, filtering out human-only operations in the application composer, handling additional properties in schema composers, and adding tests for human-only operations.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `2.0.1` to `2.0.2`.

### New Feature - Human-only Operations:
* [`src/OpenApi.ts`](diffhunk://#diff-77f34fd23e2eddbd1b3ebc491255409ecceb4df2c22af81356d4788b4379efbcR444-R453): Added a new flag `x-samchon-human` to indicate human-only operations, preventing them from being converted into LLM function calling schemas.
* [`src/composers/HttpLlmApplicationComposer.ts`](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL18-R28): Updated the composer to filter out operations marked as human-only using the `x-samchon-human` flag.

### Schema Handling:
* [`src/composers/llm/LlmSchemaV3Composer.ts`](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R243-R253): Enhanced the schema composer to handle additional properties when they are defined as objects.

### Testing:
* [`test/features/llm/test_http_llm_application_human.ts`](diffhunk://#diff-979714d140245d8c8aec9b820daebd536cc06fcc98b976eaf84fdbdb58cb228cR1-R29): Added tests to validate the handling of human-only operations by comparing the number of functions in regular and human-only applications.