### PR TITLE
Fix `additionalProperties`' separation problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -219,18 +219,15 @@ export namespace LlmSchemaV3Composer {
     predicate: (schema: ILlmSchemaV3) => boolean;
     schema: ILlmSchemaV3.IObject;
   }): [ILlmSchemaV3.IObject | null, ILlmSchemaV3.IObject | null] => {
-    if (
-      !!props.schema.additionalProperties ||
-      Object.keys(props.schema.properties ?? {}).length === 0
-    )
-      return [props.schema, null];
     const llm = {
       ...props.schema,
       properties: {} as Record<string, ILlmSchemaV3>,
+      additionalProperties: props.schema.additionalProperties,
     } satisfies ILlmSchemaV3.IObject;
     const human = {
       ...props.schema,
       properties: {} as Record<string, ILlmSchemaV3>,
+      additionalProperties: props.schema.additionalProperties,
     } satisfies ILlmSchemaV3.IObject;
     for (const [key, value] of Object.entries(props.schema.properties ?? {})) {
       const [x, y] = separateStation({
@@ -252,8 +249,12 @@ export namespace LlmSchemaV3Composer {
       human.additionalProperties = dy ?? false;
     }
     return [
-      Object.keys(llm.properties).length === 0 ? null : shrinkRequired(llm),
-      Object.keys(human.properties).length === 0 ? null : shrinkRequired(human),
+      !!Object.keys(llm.properties).length || !!llm.additionalProperties
+        ? shrinkRequired(llm)
+        : null,
+      !!Object.keys(human.properties).length || !!human.additionalProperties
+        ? shrinkRequired(human)
+        : null,
     ];
   };
 

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -427,6 +427,7 @@ export namespace LlmSchemaV3_1Composer {
     const llm = {
       ...props.schema,
       properties: {} as Record<string, ILlmSchemaV3_1>,
+      additionalProperties: props.schema.additionalProperties,
     } satisfies ILlmSchemaV3_1.IObject;
     const human = {
       ...props.schema,
@@ -454,8 +455,12 @@ export namespace LlmSchemaV3_1Composer {
       human.additionalProperties = dy ?? false;
     }
     return [
-      Object.keys(llm.properties).length === 0 ? null : shrinkRequired(llm),
-      Object.keys(human.properties).length === 0 ? null : shrinkRequired(human),
+      !!Object.keys(llm.properties).length || !!llm.additionalProperties
+        ? shrinkRequired(llm)
+        : null,
+      !!Object.keys(human.properties).length || human.additionalProperties
+        ? shrinkRequired(human)
+        : null,
     ];
   };
 

--- a/test/features/llm/validate_llm_parameters_separate_object_additionalProperties.ts
+++ b/test/features/llm/validate_llm_parameters_separate_object_additionalProperties.ts
@@ -59,44 +59,68 @@ const validate_llm_parameters_separate_object_additionalProperties = <
           : s.description?.includes("@contentMediaType") === true),
       parameters: schema as any,
     });
-  const member: ILlmSchema.IParameters<Model> = schema(
+  const params: ILlmSchema.IParameters<Model> = schema(
     model,
     constraint,
-  )(typia.json.schemas<[IWrapper<IMember>]>());
-  const upload: ILlmSchema.IParameters<Model> = schema(
-    model,
-    constraint,
-  )(typia.json.schemas<[IWrapper<IFileUpload>]>());
-  const combined: ILlmSchema.IParameters<Model> = schema(
-    model,
-    constraint,
-  )(typia.json.schemas<[IWrapper<ICombined>]>());
-
-  TestValidator.equals("member")(separator(member))({
-    llm: member,
-    human: null,
-  });
-  TestValidator.equals("upload")(separator(upload))({
-    llm: null,
-    human: upload,
-  });
-  TestValidator.equals("combined")(separator(combined))({
-    llm: member,
-    human: upload,
+  )(typia.json.schemas<[IParameters]>());
+  TestValidator.equals(model)(separator(params))({
+    llm: schema(
+      model,
+      constraint,
+    )(
+      typia.json.schemas<
+        [
+          {
+            input: {
+              email: string;
+              hobbies: Record<
+                string,
+                {
+                  id: string;
+                  name: string;
+                }
+              >;
+            };
+          },
+        ]
+      >(),
+    ),
+    human: schema(
+      model,
+      constraint,
+    )(
+      typia.json.schemas<
+        [
+          {
+            input: {
+              hobbies: Record<
+                string,
+                {
+                  thumbnail: string &
+                    tags.Format<"uri"> &
+                    tags.ContentMediaType<"image/*">;
+                }
+              >;
+            };
+          },
+        ]
+      >(),
+    ),
   });
 };
 
-interface IWrapper<T> {
-  data: T;
+interface IParameters {
+  input: IMember;
 }
 interface IMember {
-  id: number;
+  email: string;
+  hobbies: Record<string, IHobby>;
+}
+interface IHobby {
+  id: string;
   name: string;
+  thumbnail: string & tags.Format<"uri"> & tags.ContentMediaType<"image/*">;
 }
-interface IFileUpload {
-  file: string & tags.Format<"uri"> & tags.ContentMediaType<"image/png">;
-}
-interface ICombined extends IMember, IFileUpload {}
 
 const schema =
   <Model extends ILlmSchema.Model>(model: Model, constraint: boolean) =>


### PR DESCRIPTION
This pull request includes several changes to the `@samchon/openapi` package and its associated TypeScript files. The changes focus on version updates, improving the handling of additional properties in schemas, and refining test parameters.

Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `2.0.2` to `2.0.3`.

Schema handling improvements:
* [`src/composers/llm/LlmSchemaV3Composer.ts`](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L222-R230): Added handling for `additionalProperties` in the `llm` and `human` objects, and adjusted the return conditions to account for the presence of `additionalProperties`. [[1]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L222-R230) [[2]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L255-R257)
* [`src/composers/llm/LlmSchemaV3_1Composer.ts`](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R430): Similar changes to `LlmSchemaV3Composer`, added handling for `additionalProperties` and adjusted return conditions. [[1]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R430) [[2]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L457-R463)

Test parameter refinements:
* [`test/features/llm/validate_llm_parameters_separate_object_additionalProperties.ts`](diffhunk://#diff-747b292444e490d81310ee4970e6f30cd2bbd400cc7c405235a01a335c8652e3L62-L99): Refactored the test parameters to use `IParameters` instead of `IWrapper`, and updated the test schema definitions to reflect the changes in schema handling.