### PR TITLE
Fix parameters separator for empty object case.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/llm/ChatGptSchemaComposer.ts
+++ b/src/composers/llm/ChatGptSchemaComposer.ts
@@ -260,6 +260,13 @@ export namespace ChatGptSchemaComposer {
     predicate: (schema: IChatGptSchema) => boolean;
     schema: IChatGptSchema.IObject;
   }): [IChatGptSchema.IObject | null, IChatGptSchema.IObject | null] => {
+    // EMPTY OBJECT
+    if (
+      Object.keys(props.schema.properties ?? {}).length === 0 &&
+      !!props.schema.additionalProperties === false
+    )
+      return [props.schema, null];
+
     const llm = {
       ...props.schema,
       properties: {} as Record<string, IChatGptSchema>,
@@ -268,6 +275,7 @@ export namespace ChatGptSchemaComposer {
       ...props.schema,
       properties: {} as Record<string, IChatGptSchema>,
     } satisfies IChatGptSchema.IObject;
+
     for (const [key, value] of Object.entries(props.schema.properties ?? {})) {
       const [x, y] = separateStation({
         $defs: props.$defs,

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -219,6 +219,13 @@ export namespace LlmSchemaV3Composer {
     predicate: (schema: ILlmSchemaV3) => boolean;
     schema: ILlmSchemaV3.IObject;
   }): [ILlmSchemaV3.IObject | null, ILlmSchemaV3.IObject | null] => {
+    // EMPTY OBJECT
+    if (
+      Object.keys(props.schema.properties ?? {}).length === 0 &&
+      !!props.schema.additionalProperties === false
+    )
+      return [props.schema, null];
+
     const llm = {
       ...props.schema,
       properties: {} as Record<string, ILlmSchemaV3>,
@@ -229,6 +236,7 @@ export namespace LlmSchemaV3Composer {
       properties: {} as Record<string, ILlmSchemaV3>,
       additionalProperties: props.schema.additionalProperties,
     } satisfies ILlmSchemaV3.IObject;
+
     for (const [key, value] of Object.entries(props.schema.properties ?? {})) {
       const [x, y] = separateStation({
         predicate: props.predicate,

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -424,6 +424,13 @@ export namespace LlmSchemaV3_1Composer {
     predicate: (schema: ILlmSchemaV3_1) => boolean;
     schema: ILlmSchemaV3_1.IObject;
   }): [ILlmSchemaV3_1.IObject | null, ILlmSchemaV3_1.IObject | null] => {
+    // EMPTY OBJECT
+    if (
+      Object.keys(props.schema.properties ?? {}).length === 0 &&
+      !!props.schema.additionalProperties === false
+    )
+      return [props.schema, null];
+
     const llm = {
       ...props.schema,
       properties: {} as Record<string, ILlmSchemaV3_1>,
@@ -433,6 +440,7 @@ export namespace LlmSchemaV3_1Composer {
       ...props.schema,
       properties: {} as Record<string, ILlmSchemaV3_1>,
     } satisfies ILlmSchemaV3_1.IObject;
+
     for (const [key, value] of Object.entries(props.schema.properties ?? {})) {
       const [x, y] = separateStation({
         $defs: props.$defs,

--- a/test/features/llm/validate_llm_schema_separate_object_empty.ts
+++ b/test/features/llm/validate_llm_schema_separate_object_empty.ts
@@ -1,0 +1,64 @@
+import { TestValidator } from "@nestia/e2e";
+import {
+  ILlmSchema,
+  IOpenApiSchemaError,
+  IResult,
+  OpenApi,
+  OpenApiTypeChecker,
+} from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_chatgpt_schema_separate_object_empty = (): void =>
+  validate_llm_schema_separate_object_empty("chatgpt");
+
+export const test_claude_schema_separate_object_empty = (): void =>
+  validate_llm_schema_separate_object_empty("claude");
+
+export const test_gemini_schema_separate_object_empty = (): void =>
+  validate_llm_schema_separate_object_empty("gemini");
+
+export const test_llama_schema_separate_object_empty = (): void =>
+  validate_llm_schema_separate_object_empty("llama");
+
+export const test_llm_v30_schema_separate_object_empty = (): void =>
+  validate_llm_schema_separate_object_empty("3.0");
+
+export const test_llm_v31_schema_separate_object_empty = (): void =>
+  validate_llm_schema_separate_object_empty("3.1");
+
+const validate_llm_schema_separate_object_empty = <
+  Model extends ILlmSchema.Model,
+>(
+  model: Model,
+): void => {
+  TestValidator.equals("separated")(
+    LlmSchemaComposer.separateParameters(model)({
+      predicate: ((schema: OpenApi.IJsonSchema) =>
+        OpenApiTypeChecker.isInteger(schema)) as any,
+      parameters: schema(model)(typia.json.schemas<[{}]>()) as any,
+    }),
+  )({
+    llm: schema(model)(typia.json.schemas<[{}]>()) as any,
+    human: null,
+  });
+};
+
+const schema =
+  <Model extends ILlmSchema.Model>(model: Model) =>
+  (collection: IJsonSchemaCollection): ILlmSchema.IParameters<Model> => {
+    const result: IResult<
+      ILlmSchema.IParameters<Model>,
+      IOpenApiSchemaError
+    > = LlmSchemaComposer.parameters(model)({
+      components: collection.components,
+      schema: typia.assert<
+        OpenApi.IJsonSchema.IObject | OpenApi.IJsonSchema.IReference
+      >(collection.schemas[0]),
+      config: LlmSchemaComposer.defaultConfig(
+        model,
+      ) satisfies ILlmSchema.IConfig<Model> as any,
+    }) as IResult<ILlmSchema.IParameters<Model>, IOpenApiSchemaError>;
+    if (result.success === false) throw new Error("Invalid schema");
+    return result.value;
+  };

--- a/test/utils/ChatGptFunctionCaller.ts
+++ b/test/utils/ChatGptFunctionCaller.ts
@@ -58,10 +58,11 @@ export namespace ChatGptFunctionCaller {
               name: props.name,
               description: props.description,
               parameters: parameters.value as Record<string, any>,
-              strict: true,
             },
           },
         ],
+        tool_choice: "required",
+        parallel_tool_calls: false,
       });
 
     const toolCalls: OpenAI.ChatCompletionMessageToolCall[] =

--- a/test/utils/ClaudeFunctionCaller.ts
+++ b/test/utils/ClaudeFunctionCaller.ts
@@ -63,6 +63,10 @@ export namespace ClaudeFunctionCaller {
           input_schema: parameters.value as any,
         },
       ],
+      tool_choice: {
+        type: "any",
+        disable_parallel_tool_use: true,
+      },
     });
 
     const toolCalls: Anthropic.ToolUseBlock[] = completion.content.filter(


### PR DESCRIPTION
This pull request includes several changes to the `@samchon/openapi` package, focusing on schema composition and validation logic. The changes introduce new checks for empty objects and add new test cases to validate these changes.

Schema composition improvements:

* [`src/composers/llm/ChatGptSchemaComposer.ts`](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR263-R269): Added logic to handle empty objects in the `separateParameters` method. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR263-R269) [[2]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR278)
* [`src/composers/llm/LlmSchemaV3Composer.ts`](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R222-R228): Added logic to handle empty objects in the `separateParameters` method. [[1]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R222-R228) [[2]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R239)
* [`src/composers/llm/LlmSchemaV3_1Composer.ts`](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R427-R433): Added logic to handle empty objects in the `separateParameters` method. [[1]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R427-R433) [[2]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R443)

Testing enhancements:

* [`test/features/llm/validate_llm_schema_separate_object_empty.ts`](diffhunk://#diff-e7bf84cebf096e7b0559e71e0a71a802091e8f81bece68e5ad6217418412d03cR1-R64): Added new test cases to validate the handling of empty objects in various schema versions.

Package version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `2.0.3` to `2.0.4`.