### PR TITLE
Remove `ILlmFunction.strict` property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/structures/ILlmFunction.ts
+++ b/src/structures/ILlmFunction.ts
@@ -47,15 +47,6 @@ export interface ILlmFunction<Model extends ILlmSchema.Model> {
   output?: ILlmSchema.ModelSchema[Model];
 
   /**
-   * Whether the function schema types are strict or not.
-   *
-   * Newly added specification to "OpenAI" at 2024-08-07.
-   *
-   * @reference https://openai.com/index/introducing-structured-outputs-in-the-api/
-   */
-  strict: true;
-
-  /**
    * Description of the function.
    *
    * For reference, the `description` is very important property to teach

--- a/test/features/llm/test_llm_merge_parameters.ts
+++ b/test/features/llm/test_llm_merge_parameters.ts
@@ -5,7 +5,6 @@ export const test_llm_merge_parameters = (): void => {
   TestValidator.equals("atomics")(
     HttpLlm.mergeParameters({
       function: {
-        strict: true,
         name: "test",
         parameters: {
           type: "object",

--- a/test/utils/LlamaFunctionCaller.ts
+++ b/test/utils/LlamaFunctionCaller.ts
@@ -66,6 +66,8 @@ export namespace LlamaFunctionCaller {
             },
           },
         ],
+        tool_choice: "required",
+        parallel_tool_calls: false,
       });
 
     const toolCalls: OpenAI.ChatCompletionMessageToolCall[] = [


### PR DESCRIPTION
It must not be enforced by me, but determined by user.

-------------------------

This pull request includes several updates to the `@samchon/openapi` package, including a version bump, removal of a strict schema type, and additions to test utilities. The most important changes are summarized below:

Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `2.0.4` to `2.1.0`.

Schema Changes:
* [`src/structures/ILlmFunction.ts`](diffhunk://#diff-25c6cbd1c80f38bb0f80a4a8abbe94cbfa3c66b7e99c4d65ebc41d05f9efc4eeL49-L57): Removed the `strict` property from the `ILlmFunction` interface.

Test Updates:
* [`test/features/llm/test_llm_merge_parameters.ts`](diffhunk://#diff-6daab0cf17e6922b72fcb00feb1297adc7329c3d9a8c34afebf5fc343ded2d93L8): Removed the `strict` property from the test parameters in `test_llm_merge_parameters` function.
* [`test/utils/LlamaFunctionCaller.ts`](diffhunk://#diff-40d3fe01369e17e8f8ebd3ea16da96860765ebfa8e32ee68a157e6418766a8adR69-R70): Added `tool_choice` and `parallel_tool_calls` properties to the `LlamaFunctionCaller` namespace.It must not be enforced by me, but determined by user.