### PR TITLE
Also erase `IHttpLlmFunction.strict` property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,6 @@ const main = async (): Promise<void> => {
             name: func.name,
             description: func.description,
             parameters: func.parameters as Record<string, any>,
-            strict: true,
           },
         },
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.2.0",
+  "version": "2.1.1",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "3.0.0",
+  "version": "2.2.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/HttpLlmApplicationComposer.ts
+++ b/src/composers/HttpLlmApplicationComposer.ts
@@ -190,7 +190,6 @@ export namespace HttpLlmComposer {
       method: props.route.method as "get",
       path: props.route.path,
       name: props.route.accessor.join("_"),
-      strict: true,
       parameters,
       separated: props.options.separate
         ? (LlmSchemaComposer.separateParameters(props.model)({

--- a/src/structures/IHttpLlmFunction.ts
+++ b/src/structures/IHttpLlmFunction.ts
@@ -100,15 +100,6 @@ export interface IHttpLlmFunction<Model extends ILlmSchema.Model> {
   name: string;
 
   /**
-   * Whether the function schema types are strict or not.
-   *
-   * Newly added specification to "OpenAI" at 2024-08-07.
-   *
-   * @reference https://openai.com/index/introducing-structured-outputs-in-the-api/
-   */
-  strict: true;
-
-  /**
    * List of parameter types.
    *
    * If you've configured {@link IHttpLlmApplication.IOptions.keyword} as `true`,

--- a/test/examples/chatgpt-function-call-to-sale-create.ts
+++ b/test/examples/chatgpt-function-call-to-sale-create.ts
@@ -64,7 +64,6 @@ const main = async (): Promise<void> => {
             name: func.name,
             description: func.description,
             parameters: func.parameters as Record<string, any>,
-            strict: true,
           },
         },
       ],


### PR DESCRIPTION
This pull request includes several changes to the `@samchon/openapi` package, primarily focusing on removing the `strict` property from various files and updating the package version.

### Removal of `strict` property:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L350): Removed the `strict` property from the function call parameters.
* [`src/composers/HttpLlmApplicationComposer.ts`](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL193): Removed the `strict` property from the HTTP route configuration.
* [`src/structures/IHttpLlmFunction.ts`](diffhunk://#diff-40aad91cda9d576516527b8ece8e58e9f4ad7779a1c6830cb7d92408fcfa32cbL102-L110): Removed the `strict` property from the `IHttpLlmFunction` interface.
* [`test/examples/chatgpt-function-call-to-sale-create.ts`](diffhunk://#diff-d102770e546dd2e3fd825610266df937c9b6f96bb43d03c6a570207f86053bf0L67): Removed the `strict` property from the function call parameters.

### Package version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `2.1.0` to `3.0.0`.