### PR TITLE
Make ChatGPT strict mode configurable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/LlmSchemaComposer.ts
+++ b/src/composers/LlmSchemaComposer.ts
@@ -66,6 +66,7 @@ const SEPARATE_PARAMETERS = {
 const DEFAULT_CONFIGS = {
   chatgpt: {
     reference: false,
+    strict: false,
   } satisfies IChatGptSchema.IConfig,
   claude: {
     reference: false,

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -165,7 +165,7 @@ export namespace LlmSchemaV3Composer {
       predicate: props.predicate,
       schema: props.parameters,
     });
-    return { llm, human };
+    return { llm, human } as ILlmFunction.ISeparated<"3.0">;
   };
 
   const separateStation = (props: {

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -230,7 +230,7 @@ export namespace LlmSchemaV3_1Composer {
           ...input,
           properties: properties as Record<string, ILlmSchemaV3_1>,
           additionalProperties,
-          required: Object.keys(properties),
+          required: input.required ?? [],
         });
       } else if (OpenApiTypeChecker.isArray(input)) {
         const items: IResult<ILlmSchemaV3_1, IOpenApiSchemaError> = schema({
@@ -345,6 +345,7 @@ export namespace LlmSchemaV3_1Composer {
             key.endsWith(".Llm"),
           ),
         ),
+        additionalProperties: false,
       },
       human: {
         ...human,
@@ -353,6 +354,7 @@ export namespace LlmSchemaV3_1Composer {
             key.endsWith(".Human"),
           ),
         ),
+        additionalProperties: false,
       },
     };
     for (const key of Object.keys(props.parameters.$defs))

--- a/src/structures/ILlmSchemaV3.ts
+++ b/src/structures/ILlmSchemaV3.ts
@@ -60,7 +60,17 @@ export namespace ILlmSchemaV3 {
    *
    * @reference https://platform.openai.com/docs/guides/structured-outputs
    */
-  export type IParameters = IObject;
+  export interface IParameters extends Omit<IObject, "additionalProperties"> {
+    /**
+     * Additional properties' info.
+     *
+     * The `additionalProperties` means the type schema info of the additional
+     * properties that are not listed in the {@link properties}.
+     *
+     * By the way, it is not allowed in the parameters level.
+     */
+    additionalProperties: false;
+  }
 
   /**
    * Boolean type schema info.

--- a/src/structures/ILlmSchemaV3_1.ts
+++ b/src/structures/ILlmSchemaV3_1.ts
@@ -78,11 +78,21 @@ export namespace ILlmSchemaV3_1 {
    *
    * @reference https://platform.openai.com/docs/guides/structured-outputs
    */
-  export interface IParameters extends IObject {
+  export interface IParameters extends Omit<IObject, "additionalProperties"> {
     /**
      * Collection of the named types.
      */
     $defs: Record<string, ILlmSchemaV3_1>;
+
+    /**
+     * Additional properties' info.
+     *
+     * The `additionalProperties` means the type schema info of the additional
+     * properties that are not listed in the {@link properties}.
+     *
+     * By the way, it is not allowed in the parameters level.
+     */
+    additionalProperties: false;
   }
 
   /**

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_additionalProperties.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_additionalProperties.ts
@@ -1,0 +1,70 @@
+import fs from "fs";
+import typia, { tags } from "typia";
+
+import { TestGlobal } from "../../../TestGlobal";
+import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
+
+export const test_chatgpt_function_calling_additionalProperties =
+  (): Promise<void> =>
+    ChatGptFunctionCaller.test({
+      name: "enrollPerson",
+      description: "Enroll a person to the restaurant reservation list.",
+      collection: typia.json.schemas<[{ input: IPerson }]>(),
+      validate: typia.createValidate<[{ input: IPerson }]>(),
+      texts: [
+        {
+          role: "assistant",
+          content: SYSTEM_MESSAGE,
+        },
+        {
+          role: "user",
+          content: USER_MESSAGE,
+        },
+      ],
+      handleParameters: async (parameters) => {
+        if (process.argv.includes("--file"))
+          await fs.promises.writeFile(
+            `${TestGlobal.ROOT}/examples/function-calling/schemas/chatgpt.additionalProperties.schema.json`,
+            JSON.stringify(parameters, null, 2),
+            "utf8",
+          );
+      },
+      handleCompletion: async (input) => {
+        typia.assert<IPerson>(input);
+        if (process.argv.includes("--file"))
+          await fs.promises.writeFile(
+            `${TestGlobal.ROOT}/examples/function-calling/arguments/chatgpt.additionalProperties.input.json`,
+            JSON.stringify(input, null, 2),
+            "utf8",
+          );
+      },
+    });
+
+interface IPerson {
+  /**
+   * The name of the person.
+   */
+  name: string;
+
+  /**
+   * The age of the person.
+   */
+  age: number & tags.Type<"uint32">;
+
+  /**
+   * Additional informations about the person.
+   */
+  etc: Record<string, string>;
+}
+
+const SYSTEM_MESSAGE =
+  "You are a helpful customer support assistant. Use the supplied tools to assist the user.";
+
+const USER_MESSAGE = `
+  Just enroll a person with below information:
+
+    - name: John Doe
+    - age: 42
+    - hobby: Soccer
+    - job: Scientist
+`;

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_optional.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_optional.ts
@@ -1,0 +1,69 @@
+import fs from "fs";
+import typia from "typia";
+
+import { TestGlobal } from "../../../TestGlobal";
+import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
+
+export const test_chatgpt_function_calling_optional = () =>
+  ChatGptFunctionCaller.test({
+    config: {
+      reference: false,
+    },
+    name: "registerMember",
+    description: "Register a membership.",
+    collection: typia.json.schemas<[{ input: IMember; note?: string }]>(),
+    validate: typia.createValidate<[{ input: IMember; note?: string }]>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
+      },
+      {
+        role: "user",
+        content: USER_MESSAGE,
+      },
+    ],
+    handleParameters: async (parameters) => {
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/schemas/chatgpt.optional.schema.json`,
+          JSON.stringify(parameters, null, 2),
+          "utf8",
+        );
+    },
+    handleCompletion: async (input) => {
+      typia.assert<IMember>(input);
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/arguments/chatgpt.optional.input.json`,
+          JSON.stringify(input, null, 2),
+          "utf8",
+        );
+    },
+  });
+
+/**
+ * Membership information.
+ */
+interface IMember {
+  /**
+   * Name of the member.
+   */
+  name: string;
+
+  /**
+   * Age of the member.
+   */
+  age: number;
+
+  /**
+   * Hobby of the member.
+   */
+  hobby?: string;
+}
+
+const SYSTEM_MESSAGE =
+  "You are a helpful customer support assistant. Use the supplied tools to assist the user.";
+
+const USER_MESSAGE =
+  "Just enroll a membership whose name is John Doe and age is 30.";

--- a/test/features/llm/chatgpt/test_chatgpt_schema_additionalProperties.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_schema_additionalProperties.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import { ChatGptSchemaComposer } from "@samchon/openapi/lib/composers/llm/ChatGptSchemaComposer";
+import typia from "typia";
+
+export const test_chatgpt_schema_additionalProperties = (): void => {
+  interface IMember {
+    name: string;
+    age: number;
+    hobby: Record<string, string>;
+  }
+  const collection = typia.json.schemas<[IMember]>();
+  for (const strict of [false, true]) {
+    const result = ChatGptSchemaComposer.schema({
+      config: {
+        reference: false,
+        strict,
+      },
+      $defs: {},
+      components: collection.components,
+      schema: collection.schemas[0],
+    });
+    TestValidator.equals("success")(result.success)(!strict);
+  }
+};

--- a/test/features/llm/chatgpt/test_chatgpt_schema_optional.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_schema_optional.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import { ChatGptSchemaComposer } from "@samchon/openapi/lib/composers/llm/ChatGptSchemaComposer";
+import typia from "typia";
+
+export const test_chatgpt_schema_optional = (): void => {
+  interface IMember {
+    name: string;
+    age: number;
+    hobby?: string;
+  }
+  const collection = typia.json.schemas<[IMember]>();
+  for (const strict of [false, true]) {
+    const result = ChatGptSchemaComposer.schema({
+      config: {
+        reference: false,
+        strict,
+      },
+      $defs: {},
+      components: collection.components,
+      schema: collection.schemas[0],
+    });
+    TestValidator.equals("success")(result.success)(!strict);
+  }
+};

--- a/test/features/llm/claude/test_claude_function_calling_optional.ts
+++ b/test/features/llm/claude/test_claude_function_calling_optional.ts
@@ -1,0 +1,70 @@
+import fs from "fs";
+import typia from "typia";
+
+import { TestGlobal } from "../../../TestGlobal";
+import { ClaudeFunctionCaller } from "../../../utils/ClaudeFunctionCaller";
+
+export const test_claude_function_calling_optional = () =>
+  ClaudeFunctionCaller.test({
+    model: "claude",
+    config: {
+      reference: false,
+    },
+    name: "registerMember",
+    description: "Register a membership.",
+    collection: typia.json.schemas<[{ input: IMember; note?: string }]>(),
+    validate: typia.createValidate<[{ input: IMember; note?: string }]>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
+      },
+      {
+        role: "user",
+        content: USER_MESSAGE,
+      },
+    ],
+    handleParameters: async (parameters) => {
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/schemas/claude.optional.schema.json`,
+          JSON.stringify(parameters, null, 2),
+          "utf8",
+        );
+    },
+    handleCompletion: async (input) => {
+      typia.assert<IMember>(input);
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/arguments/claude.optional.input.json`,
+          JSON.stringify(input, null, 2),
+          "utf8",
+        );
+    },
+  });
+
+/**
+ * Membership information.
+ */
+interface IMember {
+  /**
+   * Name of the member.
+   */
+  name: string;
+
+  /**
+   * Age of the member.
+   */
+  age: number;
+
+  /**
+   * Hobby of the member.
+   */
+  hobby?: string;
+}
+
+const SYSTEM_MESSAGE =
+  "You are a helpful customer support assistant. Use the supplied tools to assist the user.";
+
+const USER_MESSAGE =
+  "Just enroll a membership whose name is John Doe and age is 30.";

--- a/test/features/llm/gemini/test_gemini_function_calling_optional.ts
+++ b/test/features/llm/gemini/test_gemini_function_calling_optional.ts
@@ -1,0 +1,66 @@
+import fs from "fs";
+import typia from "typia";
+
+import { TestGlobal } from "../../../TestGlobal";
+import { GeminiFunctionCaller } from "../../../utils/GeminiFunctionCaller";
+
+export const test_gemini_function_calling_optional = () =>
+  GeminiFunctionCaller.test({
+    name: "registerMember",
+    description: "Register a membership.",
+    collection: typia.json.schemas<[{ input: IMember; note?: string }]>(),
+    validate: typia.createValidate<[{ input: IMember; note?: string }]>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
+      },
+      {
+        role: "user",
+        content: USER_MESSAGE,
+      },
+    ],
+    handleParameters: async (parameters) => {
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/schemas/gemini.optional.schema.json`,
+          JSON.stringify(parameters, null, 2),
+          "utf8",
+        );
+    },
+    handleCompletion: async (input) => {
+      typia.assert<IMember>(input);
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/arguments/gemini.optional.input.json`,
+          JSON.stringify(input, null, 2),
+          "utf8",
+        );
+    },
+  });
+
+/**
+ * Membership information.
+ */
+interface IMember {
+  /**
+   * Name of the member.
+   */
+  name: string;
+
+  /**
+   * Age of the member.
+   */
+  age: number;
+
+  /**
+   * Hobby of the member.
+   */
+  hobby?: string;
+}
+
+const SYSTEM_MESSAGE =
+  "You are a helpful customer support assistant. Use the supplied tools to assist the user.";
+
+const USER_MESSAGE =
+  "Just enroll a membership whose name is John Doe and age is 30.";

--- a/test/features/llm/llama/test_llama_function_calling_optional.ts
+++ b/test/features/llm/llama/test_llama_function_calling_optional.ts
@@ -1,0 +1,70 @@
+import fs from "fs";
+import typia from "typia";
+
+import { TestGlobal } from "../../../TestGlobal";
+import { LlamaFunctionCaller } from "../../../utils/LlamaFunctionCaller";
+
+export const test_llama_function_calling_optional = () =>
+  LlamaFunctionCaller.test({
+    model: "llama",
+    config: {
+      reference: false,
+    },
+    name: "registerMember",
+    description: "Register a membership.",
+    collection: typia.json.schemas<[{ input: IMember; note?: string }]>(),
+    validate: typia.createValidate<[{ input: IMember; note?: string }]>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
+      },
+      {
+        role: "user",
+        content: USER_MESSAGE,
+      },
+    ],
+    handleParameters: async (parameters) => {
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/schemas/llama.optional.schema.json`,
+          JSON.stringify(parameters, null, 2),
+          "utf8",
+        );
+    },
+    handleCompletion: async (input) => {
+      typia.assert<IMember>(input);
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/arguments/llama.optional.input.json`,
+          JSON.stringify(input, null, 2),
+          "utf8",
+        );
+    },
+  });
+
+/**
+ * Membership information.
+ */
+interface IMember {
+  /**
+   * Name of the member.
+   */
+  name: string;
+
+  /**
+   * Age of the member.
+   */
+  age: number;
+
+  /**
+   * Hobby of the member.
+   */
+  hobby?: string;
+}
+
+const SYSTEM_MESSAGE =
+  "You are a helpful customer support assistant. Use the supplied tools to assist the user.";
+
+const USER_MESSAGE =
+  "Just enroll a membership whose name is John Doe and age is 30.";

--- a/test/features/llm/validate_llm_parameters_separate_object_additionalProperties.ts
+++ b/test/features/llm/validate_llm_parameters_separate_object_additionalProperties.ts
@@ -8,13 +8,18 @@ import {
 import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 import typia, { IJsonSchemaCollection, tags } from "typia";
 
+export const test_chatgpt_parameters_separate_object_additionalProperties =
+  (): void =>
+    validate_llm_parameters_separate_object_additionalProperties(
+      "chatgpt",
+      false,
+    );
+
 export const test_claude_parameters_separate_object_additionalProperties =
   (): void =>
-    TestValidator.error("ChatGPT does not support additionalProperties")(() =>
-      validate_llm_parameters_separate_object_additionalProperties(
-        "claude",
-        true,
-      ),
+    validate_llm_parameters_separate_object_additionalProperties(
+      "claude",
+      true,
     );
 
 export const test_gemini_parameters_separate_object_additionalProperties =

--- a/test/features/llm/validate_llm_schema_additionalProperties.ts
+++ b/test/features/llm/validate_llm_schema_additionalProperties.ts
@@ -8,13 +8,13 @@ import {
 import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 import typia, { IJsonSchemaCollection } from "typia";
 
-export const test_chatgpt_parameters_additionalProperties = (): void =>
-  validate_llm_parameters_additionalProperties("chatgpt");
+export const test_chatgpt_schema_additionalProperties = (): void =>
+  validate_llm_schema_additionalProperties("chatgpt");
 
-export const test_gemini_parameters_additionalProperties = (): void =>
-  validate_llm_parameters_additionalProperties("gemini");
+export const test_gemini_schema_additionalProperties = (): void =>
+  validate_llm_schema_additionalProperties("gemini");
 
-const validate_llm_parameters_additionalProperties = <
+const validate_llm_schema_additionalProperties = <
   Model extends "chatgpt" | "gemini",
 >(
   model: Model,
@@ -33,9 +33,10 @@ const validate_llm_parameters_additionalProperties = <
     IOpenApiSchemaError
   > = LlmSchemaComposer.parameters(model)({
     accessor: "$input",
-    config: LlmSchemaComposer.defaultConfig(
-      model,
-    ) satisfies ILlmSchema.IConfig<Model> as any,
+    config: {
+      ...LlmSchemaComposer.defaultConfig(model),
+      strict: true,
+    } satisfies ILlmSchema.IConfig<Model> as any,
     components: collection.components,
     schema: typia.assert<
       OpenApi.IJsonSchema.IReference | OpenApi.IJsonSchema.IObject

--- a/test/utils/ChatGptFunctionCaller.ts
+++ b/test/utils/ChatGptFunctionCaller.ts
@@ -99,8 +99,9 @@ export namespace ChatGptFunctionCaller {
         parallel_tool_calls: false,
       });
 
-    const toolCalls: OpenAI.ChatCompletionMessageToolCall[] =
-      completion.choices[0].message.tool_calls ?? [];
+    const toolCalls: OpenAI.ChatCompletionMessageToolCall[] = completion.choices
+      .map((c) => c.message.tool_calls ?? [])
+      .flat();
     if (toolCalls.length === 0)
       throw new Error("ChatGPT has not called any function.");
 

--- a/test/utils/LlamaFunctionCaller.ts
+++ b/test/utils/LlamaFunctionCaller.ts
@@ -106,24 +106,9 @@ export namespace LlamaFunctionCaller {
         parallel_tool_calls: false,
       });
 
-    const toolCalls: OpenAI.ChatCompletionMessageToolCall[] = [
-      ...(completion.choices[0].message.tool_calls ?? []),
-      // ...completion.choices
-      //   .map((c) => c.message.content)
-      //   .filter((str) => str !== null)
-      //   .filter((str) => str.startsWith(`<function=${props.name}>`))
-      //   .map(
-      //     (str) =>
-      //       ({
-      //         id: v4(),
-      //         type: "function",
-      //         function: {
-      //           name: props.name,
-      //           arguments: str.substring(`<function="${props.name}>`.length),
-      //         },
-      //       }) satisfies OpenAI.ChatCompletionMessageToolCall,
-      //   ),
-    ];
+    const toolCalls: OpenAI.ChatCompletionMessageToolCall[] = completion.choices
+      .map((c) => c.message.tool_calls ?? [])
+      .flat();
     if (toolCalls.length === 0)
       throw new Error("Llama has not called any function.");
 


### PR DESCRIPTION
As I've understood that ChatGPT's strict mode is not perfect, and found much better way by giving validation feedback with `typia.validate<T>()` function, I've changed the ChatGPT strict mode to be configurable, and also changed ChatGPT function calling (or structured output) composition strategy.

From now on, ChatGPT schema also supports the optional properties and dynamic key typed object unless the strict mode configured.

> Advised by @AcrylicShrimp