### PR TITLE
Enhance `ChatGptTypeChecker` and `LlmTypeCheckerV3`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/test/features/llm/validate_llm_type_checker_cover_any.ts
+++ b/test/features/llm/validate_llm_type_checker_cover_any.ts
@@ -1,0 +1,63 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema, OpenApi } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_chatgpt_type_checker_cover_any = (): void =>
+  validate_llm_type_checker_cover_any("chatgpt");
+
+export const test_claude_type_checker_cover_any = (): void =>
+  validate_llm_type_checker_cover_any("claude");
+
+export const test_gemini_type_checker_cover_any = (): void =>
+  validate_llm_type_checker_cover_any("gemini");
+
+export const test_llama_type_checker_cover_any = (): void =>
+  validate_llm_type_checker_cover_any("llama");
+
+export const test_llm_v30_type_checker_cover_any = (): void =>
+  validate_llm_type_checker_cover_any("3.0");
+
+export const test_llm_v31_type_checker_cover_any = (): void =>
+  validate_llm_type_checker_cover_any("3.1");
+
+const validate_llm_type_checker_cover_any = <Model extends ILlmSchema.Model>(
+  model: Model,
+) => {
+  const collection: IJsonSchemaCollection = typia.json.schemas<[IBasic]>();
+  const result = LlmSchemaComposer.parameters(model)({
+    config: LlmSchemaComposer.defaultConfig(model) as any,
+    components: collection.components,
+    schema: collection.schemas[0] as OpenApi.IJsonSchema.IReference,
+  });
+  if (result.success === false)
+    throw new Error(`Failed to compose ${model} parameters.`);
+
+  const parameters = result.value;
+  const check = (x: ILlmSchema<Model>, y: ILlmSchema<Model>): boolean =>
+    model === "3.0" || model === "gemini"
+      ? (LlmSchemaComposer.typeChecker(model).covers as any)(x, y)
+      : (LlmSchemaComposer.typeChecker(model).covers as any)({
+          x,
+          y,
+          $defs: (parameters as any).$defs,
+        });
+  TestValidator.equals("any covers (string | null)")(true)(
+    check(
+      parameters.properties.any as ILlmSchema<Model>,
+      parameters.properties.string_or_null as ILlmSchema<Model>,
+    ),
+  );
+  TestValidator.equals("any covers (string | undefined)")(true)(
+    check(
+      parameters.properties.any as ILlmSchema<Model>,
+      parameters.properties.string_or_undefined as ILlmSchema<Model>,
+    ),
+  );
+};
+
+interface IBasic {
+  any: any;
+  string_or_null: null | string;
+  string_or_undefined: string | undefined;
+}

--- a/test/features/llm/validate_llm_type_checker_cover_array.ts
+++ b/test/features/llm/validate_llm_type_checker_cover_array.ts
@@ -1,0 +1,211 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema, OpenApi } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_chatgpt_type_checker_cover_array = (): void =>
+  validate_llm_type_checker_cover_array("chatgpt");
+
+export const test_claude_type_checker_cover_array = (): void =>
+  validate_llm_type_checker_cover_array("claude");
+
+export const test_gemini_type_checker_cover_array = (): void =>
+  validate_llm_type_checker_cover_array("gemini");
+
+export const test_llama_type_checker_cover_array = (): void =>
+  validate_llm_type_checker_cover_array("llama");
+
+export const test_llm_v30_type_checker_cover_array = (): void =>
+  validate_llm_type_checker_cover_array("3.0");
+
+export const test_llm_v31_type_checker_cover_array = (): void =>
+  validate_llm_type_checker_cover_array("3.1");
+
+const validate_llm_type_checker_cover_array = <Model extends ILlmSchema.Model>(
+  model: Model,
+) => {
+  const collection: IJsonSchemaCollection =
+    typia.json.schemas<[Plan2D, Plan3D, Box2D, Box3D]>();
+  const components: OpenApi.IComponents = collection.components as any;
+  const plan2D: OpenApi.IJsonSchema = components.schemas!.Plan2D;
+  const plan3D: OpenApi.IJsonSchema = components.schemas!.Plan3D;
+  const box2D: OpenApi.IJsonSchema = components.schemas!.Box2D;
+  const box3D: OpenApi.IJsonSchema = components.schemas!.Box3D;
+
+  const $defs = {};
+  const check = (x: OpenApi.IJsonSchema, y: OpenApi.IJsonSchema): boolean => {
+    const [a, b] = [x, y].map((schema) => {
+      const result = LlmSchemaComposer.schema(model)({
+        config: LlmSchemaComposer.defaultConfig(model) as any,
+        components: collection.components,
+        schema: schema,
+        $defs,
+      });
+      if (result.success === false)
+        throw new Error(`Failed to compose ${model} schema.`);
+      return result.value;
+    });
+    return model === "3.0" || model === "gemini"
+      ? (LlmSchemaComposer.typeChecker(model).covers as any)(a, b)
+      : (LlmSchemaComposer.typeChecker(model).covers as any)({
+          x: a,
+          y: b,
+          $defs,
+        });
+  };
+
+  TestValidator.equals(model + " Plan3D[] covers Plan2D[]")(true)(
+    check({ type: "array", items: plan3D }, { type: "array", items: plan2D }),
+  );
+  TestValidator.equals(model + " Box3D[] covers Box2D[]")(true)(
+    check({ type: "array", items: box3D }, { type: "array", items: box2D }),
+  );
+  if (model !== "gemini")
+    TestValidator.equals(
+      model + " Array<Plan3D|Box3D> covers Array<Plan2D|Box2D>",
+    )(true)(
+      check(
+        {
+          type: "array",
+          items: {
+            oneOf: [plan3D, box3D],
+          },
+        },
+        {
+          type: "array",
+          items: {
+            oneOf: [plan2D, box2D],
+          },
+        },
+      ),
+    );
+  if (model !== "gemini")
+    TestValidator.equals(model + " (Plan3D|Box3D)[] covers (Plan2D|Box2D)[]")(
+      true,
+    )(
+      check(
+        {
+          oneOf: [
+            { type: "array", items: plan3D },
+            { type: "array", items: box3D },
+          ],
+        },
+        {
+          oneOf: [
+            { type: "array", items: plan2D },
+            { type: "array", items: box2D },
+          ],
+        },
+      ),
+    );
+
+  TestValidator.equals(model + " Plan2D[] can't cover Plan3D[]")(false)(
+    check({ type: "array", items: plan2D }, { type: "array", items: plan3D }),
+  );
+  TestValidator.equals(model + " Box2D[] can't cover Box3D[]")(false)(
+    check({ type: "array", items: box2D }, { type: "array", items: box3D }),
+  );
+  if (model !== "gemini")
+    if (model !== "gemini")
+      TestValidator.equals(
+        "Array<Plan2D|Box2D> can't cover Array<Plan3D|Box3D>",
+      )(false)(
+        check(
+          {
+            type: "array",
+            items: {
+              oneOf: [plan2D, box2D],
+            },
+          },
+          {
+            type: "array",
+            items: {
+              oneOf: [plan3D, box3D],
+            },
+          },
+        ),
+      );
+  if (model !== "gemini")
+    TestValidator.equals(
+      model + " (Plan2D[]|Box2D[]) can't cover (Plan3D[]|Box3D[])",
+    )(false)(
+      check(
+        {
+          oneOf: [
+            { type: "array", items: plan2D },
+            { type: "array", items: box2D },
+          ],
+        },
+        {
+          oneOf: [
+            { type: "array", items: plan3D },
+            { type: "array", items: box3D },
+          ],
+        },
+      ),
+    );
+  if (model !== "gemini")
+    TestValidator.equals(model + " Plan3D[] can't cover (Plan2D|Box2D)[]")(
+      false,
+    )(
+      check(
+        { type: "array", items: plan3D },
+        {
+          oneOf: [
+            { type: "array", items: plan2D },
+            { type: "array", items: box2D },
+          ],
+        },
+      ),
+    );
+  if (model !== "gemini")
+    TestValidator.equals(model + " Box3D[] can't cover Array<Plan2D|Box2D>")(
+      false,
+    )(
+      check(
+        { type: "array", items: box3D },
+        {
+          type: "array",
+          items: {
+            oneOf: [plan2D, box2D],
+          },
+        },
+      ),
+    );
+};
+
+type Plan2D = {
+  center: Point2D;
+  size: Point2D;
+  geometries: Geometry2D[];
+};
+type Plan3D = {
+  center: Point3D;
+  size: Point3D;
+  geometries: Geometry3D[];
+};
+type Geometry3D = {
+  position: Point3D;
+  scale: Point3D;
+};
+type Geometry2D = {
+  position: Point2D;
+  scale: Point2D;
+};
+type Point2D = {
+  x: number;
+  y: number;
+};
+type Point3D = {
+  x: number;
+  y: number;
+  z: number;
+};
+type Box2D = {
+  size: Point2D;
+  nested: Point2D[];
+};
+type Box3D = {
+  size: Point3D;
+  nested: Point3D[];
+};


### PR DESCRIPTION
`ChatGptTypeChecker` had not considered `additionalProperties` case, and `LlmTypeCheckerV3` had not defined the visitor function.

----------------------

This pull request includes several updates to the `ChatGptTypeChecker` and `LlmTypeCheckerV3` namespaces, as well as adding new test cases for type checker validation. The most important changes include enhancements to the handling of additional properties in schemas, the addition of a new `covers` function in `LlmTypeCheckerV3`, and the creation of new test files for validating type checker coverage.

Enhancements to schema handling:

* [`src/utils/ChatGptTypeChecker.ts`](diffhunk://#diff-02e1720e4962c86045d2f1e706769591dc829b804bc7643a2607c41695d172d4L156-R164): Improved handling of additional properties in schemas by adding checks and processing for `additionalProperties` in both object and array schemas. [[1]](diffhunk://#diff-02e1720e4962c86045d2f1e706769591dc829b804bc7643a2607c41695d172d4L156-R164) [[2]](diffhunk://#diff-02e1720e4962c86045d2f1e706769591dc829b804bc7643a2607c41695d172d4L291-R313) [[3]](diffhunk://#diff-02e1720e4962c86045d2f1e706769591dc829b804bc7643a2607c41695d172d4R328)

New `covers` function:

* [`src/utils/LlmTypeCheckerV3.ts`](diffhunk://#diff-3f6a5d654d060e3608b7d273e65698226015a40651229712b9dd9fd187bd16a4R66-R233): Added a new `covers` function that checks if one schema can cover another, including internal helper functions for covering boolean, integer, number, string, array, and object types.

New test cases:

* [`test/features/llm/validate_llm_type_checker_cover_any.ts`](diffhunk://#diff-5a18f832a110fea524964c7961fe1e5827473896d01bda85dc22569cfff29a2aR1-R63): Added test cases to validate the `covers` function for various models including `chatgpt`, `claude`, `gemini`, `llama`, `3.0`, and `3.1`.
* [`test/features/llm/validate_llm_type_checker_cover_array.ts`](diffhunk://#diff-104693cb3f8fe6434f4578b40aeb9dec1981baec48d75ba6742b0bf78ca02375R1-R211): Added test cases to validate the `covers` function for array schemas across different models, ensuring proper coverage checks for nested schemas.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.2.0` to `2.2.1`.