### PR TITLE
`HttpLlm.appliation()` escapes some special characters.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/HttpLlmApplicationComposer.ts
+++ b/src/composers/HttpLlmApplicationComposer.ts
@@ -172,7 +172,7 @@ export namespace HttpLlmComposer {
     ];
 
     // FUNTION NAME
-    const name: string = props.route.accessor.join("_");
+    const name: string = emend(props.route.accessor.join("_"));
     const isNameVariable: boolean = /^[a-zA-Z0-9_-]+$/.test(name);
     const isNameStartsWithNumber: boolean = /^[0-9]/.test(name[0] ?? "");
     if (isNameVariable === false)
@@ -231,3 +231,9 @@ export namespace HttpLlmComposer {
     };
   };
 }
+
+const emend = (str: string): string => {
+  for (const ch of FORBIDDEN) str = str.split(ch).join("_");
+  return str;
+};
+const FORBIDDEN = ["$", "%", "."];


### PR DESCRIPTION
ChatGPT allows only `/^[a-zA-Z0-9_-]+$/` characters in the tool calling function name. By the way, `$` and `%` characters are often shown in the URL path.

For such special characters, this PR replaces them to `_` character to successfully composing LLM function calling application from the OpenAPI document.

-----------

This pull request includes changes to the `package.json` file and the `HttpLlmApplicationComposer.ts` file to update the version number and improve the handling of function names. The most important changes are:

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.3.0` to `2.3.1`.

Function name handling improvements:

* [`src/composers/HttpLlmApplicationComposer.ts`](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL175-R175): Modified the function name assignment to use the new `emend` function, which replaces forbidden characters with underscores.
* [`src/composers/HttpLlmApplicationComposer.ts`](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffR234-R239): Added the `emend` function and the `FORBIDDEN` array to handle forbidden characters in function names.