### PR TITLE
Close samchon/typia#1447: `format` `int32` like numeric restriction.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.4.0-dev.20241230",
+  "version": "2.4.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.3.1",
+  "version": "2.4.0-dev.20241229",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.4.0-dev.20241229",
+  "version": "2.4.0-dev.20241230",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -697,6 +697,11 @@ export namespace OpenApi {
       default?: number;
 
       /**
+       * Format restriction.
+       */
+      format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+
+      /**
        * Minimum value restriction.
        *
        * @type int64
@@ -747,6 +752,18 @@ export namespace OpenApi {
        * Default value.
        */
       default?: number;
+
+      /**
+       * Format restriction.
+       */
+      format?:
+        | "int32"
+        | "uint32"
+        | "int64"
+        | "uint64"
+        | "float"
+        | "double"
+        | (string & {});
 
       /**
        * Minimum value restriction.

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -699,7 +699,7 @@ export namespace OpenApi {
       /**
        * Format restriction.
        */
-      format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+      format?: "int32" | "int64" | (string & {});
 
       /**
        * Minimum value restriction.
@@ -756,14 +756,7 @@ export namespace OpenApi {
       /**
        * Format restriction.
        */
-      format?:
-        | "int32"
-        | "uint32"
-        | "int64"
-        | "uint64"
-        | "float"
-        | "double"
-        | (string & {});
+      format?: "int32" | "int64" | "float" | "double" | (string & {});
 
       /**
        * Minimum value restriction.

--- a/src/OpenApiV3.ts
+++ b/src/OpenApiV3.ts
@@ -196,6 +196,7 @@ export namespace OpenApiV3 {
        * @exclusiveMinimum 0
        */
       multipleOf?: number;
+      format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number | null;
@@ -205,6 +206,14 @@ export namespace OpenApiV3 {
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
+      format?:
+        | "int32"
+        | "uint32"
+        | "int64"
+        | "uint64"
+        | "float"
+        | "double"
+        | (string & {});
     }
     export interface IString extends __ISignificant<"string"> {
       default?: string | null;

--- a/src/OpenApiV3.ts
+++ b/src/OpenApiV3.ts
@@ -196,7 +196,7 @@ export namespace OpenApiV3 {
        * @exclusiveMinimum 0
        */
       multipleOf?: number;
-      format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+      format?: "int32" | "int64" | (string & {});
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number | null;
@@ -206,14 +206,7 @@ export namespace OpenApiV3 {
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
-      format?:
-        | "int32"
-        | "uint32"
-        | "int64"
-        | "uint64"
-        | "float"
-        | "double"
-        | (string & {});
+      format?: "int32" | "int64" | "float" | "double" | (string & {});
     }
     export interface IString extends __ISignificant<"string"> {
       default?: string | null;

--- a/src/OpenApiV3_1.ts
+++ b/src/OpenApiV3_1.ts
@@ -191,8 +191,8 @@ export namespace OpenApiV3_1 {
     export interface IMixed
       extends IConstant,
         Omit<IBoolean, "type" | "default" | "enum">,
-        Omit<INumber, "type" | "default" | "enum">,
-        Omit<IString, "type" | "default" | "enum">,
+        Omit<INumber, "type" | "default" | "enum" | "format">,
+        Omit<IString, "type" | "default" | "enum" | "format">,
         Omit<IArray, "type">,
         Omit<IObject, "type">,
         IOneOf,
@@ -210,6 +210,37 @@ export namespace OpenApiV3_1 {
       >;
       default?: any[] | null;
       enum?: any[];
+      format?:
+        | "binary"
+        | "byte"
+        | "password"
+        | "regex"
+        | "uuid"
+        | "email"
+        | "hostname"
+        | "idn-email"
+        | "idn-hostname"
+        | "iri"
+        | "iri-reference"
+        | "ipv4"
+        | "ipv6"
+        | "uri"
+        | "uri-reference"
+        | "uri-template"
+        | "url"
+        | "date-time"
+        | "date"
+        | "time"
+        | "duration"
+        | "json-pointer"
+        | "relative-json-pointer"
+        | "int32"
+        | "uint32"
+        | "int64"
+        | "uint64"
+        | "float"
+        | "double"
+        | (string & {});
     }
 
     export interface IConstant extends __IAttribute {
@@ -231,6 +262,7 @@ export namespace OpenApiV3_1 {
        * @exclusiveMinimum 0
        */
       multipleOf?: number;
+      format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number | null;
@@ -240,6 +272,14 @@ export namespace OpenApiV3_1 {
       exclusiveMinimum?: number | boolean;
       exclusiveMaximum?: number | boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
+      format?:
+        | "int32"
+        | "uint32"
+        | "int64"
+        | "uint64"
+        | "float"
+        | "double"
+        | (string & {});
     }
     export interface IString extends __ISignificant<"string"> {
       contentMediaType?: string;

--- a/src/OpenApiV3_1.ts
+++ b/src/OpenApiV3_1.ts
@@ -235,9 +235,7 @@ export namespace OpenApiV3_1 {
         | "json-pointer"
         | "relative-json-pointer"
         | "int32"
-        | "uint32"
         | "int64"
-        | "uint64"
         | "float"
         | "double"
         | (string & {});
@@ -262,7 +260,7 @@ export namespace OpenApiV3_1 {
        * @exclusiveMinimum 0
        */
       multipleOf?: number;
-      format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+      format?: "int32" | "int64" | (string & {});
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number | null;
@@ -272,14 +270,7 @@ export namespace OpenApiV3_1 {
       exclusiveMinimum?: number | boolean;
       exclusiveMaximum?: number | boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
-      format?:
-        | "int32"
-        | "uint32"
-        | "int64"
-        | "uint64"
-        | "float"
-        | "double"
-        | (string & {});
+      format?: "int32" | "int64" | "float" | "double" | (string & {});
     }
     export interface IString extends __ISignificant<"string"> {
       contentMediaType?: string;

--- a/src/SwaggerV2.ts
+++ b/src/SwaggerV2.ts
@@ -146,7 +146,7 @@ export namespace SwaggerV2 {
        * @exclusiveMinimum 0
        */
       multipleOf?: number;
-      format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+      format?: "int32" | "int64" | (string & {});
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number | null;
@@ -156,14 +156,7 @@ export namespace SwaggerV2 {
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
-      format?:
-        | "int32"
-        | "uint32"
-        | "int64"
-        | "uint64"
-        | "float"
-        | "double"
-        | (string & {});
+      format?: "int32" | "int64" | "float" | "double" | (string & {});
     }
     export interface IString extends __ISignificant<"string"> {
       default?: string | null;

--- a/src/SwaggerV2.ts
+++ b/src/SwaggerV2.ts
@@ -146,6 +146,7 @@ export namespace SwaggerV2 {
        * @exclusiveMinimum 0
        */
       multipleOf?: number;
+      format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
     }
     export interface INumber extends __ISignificant<"number"> {
       default?: number | null;
@@ -155,6 +156,14 @@ export namespace SwaggerV2 {
       exclusiveMinimum?: boolean;
       exclusiveMaximum?: boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
+      format?:
+        | "int32"
+        | "uint32"
+        | "int64"
+        | "uint64"
+        | "float"
+        | "double"
+        | (string & {});
     }
     export interface IString extends __ISignificant<"string"> {
       default?: string | null;

--- a/src/converters/OpenApiV3_1Emender.ts
+++ b/src/converters/OpenApiV3_1Emender.ts
@@ -348,7 +348,7 @@ export namespace OpenApiV3_1Emender {
               },
             });
           for (const type of schema.type)
-            if (type === "boolean" || type === "number" || type === "string")
+            if (type === "boolean")
               visit({
                 ...schema,
                 ...{
@@ -374,6 +374,41 @@ export namespace OpenApiV3_1Emender {
                       : undefined,
                 },
                 type: type as any,
+                format:
+                  schema.format && INTEGER_FORMATS.includes(schema.format)
+                    ? schema.format
+                    : undefined,
+              });
+            else if (type === "number")
+              visit({
+                ...schema,
+                ...{
+                  enum:
+                    schema.enum?.length && schema.enum.filter((e) => e !== null)
+                      ? schema.enum.filter((x) => typeof x === type)
+                      : undefined,
+                },
+                type: type as any,
+                format:
+                  schema.format && NUMBER_FORMATS.includes(schema.format)
+                    ? schema.format
+                    : undefined,
+              });
+            else if (type === "string")
+              visit({
+                ...schema,
+                ...{
+                  enum:
+                    schema.enum?.length && schema.enum.filter((e) => e !== null)
+                      ? schema.enum.filter((x) => typeof x === type)
+                      : undefined,
+                },
+                type: type as any,
+                format:
+                  schema.format &&
+                  NUMBER_FORMATS.includes(schema.format) === false
+                    ? schema.format
+                    : undefined,
               });
             else visit({ ...schema, type: type as any });
         }
@@ -422,6 +457,7 @@ export namespace OpenApiV3_1Emender {
                   exclusiveMinimum: undefined,
                   exclusiveMaximum: undefined,
                   multipleOf: undefined,
+                  format: undefined,
                 } satisfies OpenApiV3_1.IJsonSchema.IInteger as any),
               } satisfies OpenApi.IJsonSchema.IConstant);
           else
@@ -691,3 +727,6 @@ export namespace OpenApiV3_1Emender {
       Array.isArray((schema as OpenApiV3_1.IJsonSchema.IMixed).type);
   }
 }
+
+const INTEGER_FORMATS = ["int32", "int64", "uint32", "uint64"];
+const NUMBER_FORMATS = [...INTEGER_FORMATS, "float", "double"];

--- a/src/structures/ILlmSchemaV3.ts
+++ b/src/structures/ILlmSchemaV3.ts
@@ -106,6 +106,11 @@ export namespace ILlmSchemaV3 {
     enum?: Array<number | null>;
 
     /**
+     * Format restriction.
+     */
+    format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+
+    /**
      * Minimum value restriction.
      *
      * @type int64
@@ -161,6 +166,18 @@ export namespace ILlmSchemaV3 {
      * Enumeration values.
      */
     enum?: Array<number | null>;
+
+    /**
+     * Format restriction.
+     */
+    format?:
+      | "int32"
+      | "uint32"
+      | "int64"
+      | "uint64"
+      | "float"
+      | "double"
+      | (string & {});
 
     /**
      * Minimum value restriction.

--- a/src/structures/ILlmSchemaV3.ts
+++ b/src/structures/ILlmSchemaV3.ts
@@ -108,7 +108,7 @@ export namespace ILlmSchemaV3 {
     /**
      * Format restriction.
      */
-    format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+    format?: "int32" | "int64" | (string & {});
 
     /**
      * Minimum value restriction.
@@ -170,14 +170,7 @@ export namespace ILlmSchemaV3 {
     /**
      * Format restriction.
      */
-    format?:
-      | "int32"
-      | "uint32"
-      | "int64"
-      | "uint64"
-      | "float"
-      | "double"
-      | (string & {});
+    format?: "int32" | "int64" | "float" | "double" | (string & {});
 
     /**
      * Minimum value restriction.

--- a/src/structures/ILlmSchemaV3_1.ts
+++ b/src/structures/ILlmSchemaV3_1.ts
@@ -129,7 +129,7 @@ export namespace ILlmSchemaV3_1 {
     /**
      * Format restriction.
      */
-    format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+    format?: "int32" | "int64" | (string & {});
 
     /**
      * Minimum value restriction.
@@ -186,14 +186,7 @@ export namespace ILlmSchemaV3_1 {
     /**
      * Format restriction.
      */
-    format?:
-      | "int32"
-      | "uint32"
-      | "int64"
-      | "uint64"
-      | "float"
-      | "double"
-      | (string & {});
+    format?: "int32" | "int64" | "float" | "double" | (string & {});
 
     /**
      * Minimum value restriction.

--- a/src/structures/ILlmSchemaV3_1.ts
+++ b/src/structures/ILlmSchemaV3_1.ts
@@ -127,6 +127,11 @@ export namespace ILlmSchemaV3_1 {
     default?: number;
 
     /**
+     * Format restriction.
+     */
+    format?: "int32" | "uint32" | "int64" | "uint64" | (string & {});
+
+    /**
      * Minimum value restriction.
      *
      * @type int64
@@ -177,6 +182,18 @@ export namespace ILlmSchemaV3_1 {
      * Default value.
      */
     default?: number;
+
+    /**
+     * Format restriction.
+     */
+    format?:
+      | "int32"
+      | "uint32"
+      | "int64"
+      | "uint64"
+      | "float"
+      | "double"
+      | (string & {});
 
     /**
      * Minimum value restriction.

--- a/src/utils/OpenApiContraintShifter.ts
+++ b/src/utils/OpenApiContraintShifter.ts
@@ -39,6 +39,7 @@ export namespace OpenApiContraintShifter {
       | "exclusiveMaximum"
       | "multipleOf"
       | "default"
+      | "format"
     >,
   >(
     v: Schema,
@@ -50,6 +51,7 @@ export namespace OpenApiContraintShifter {
     | "exclusiveMaximum"
     | "multipleOf"
     | "default"
+    | "format"
   > => {
     const tags: string[] = [];
     if (v.minimum !== undefined) {
@@ -75,6 +77,10 @@ export namespace OpenApiContraintShifter {
     if (v.default !== undefined) {
       tags.push(`@default ${v.default}`);
       delete v.default;
+    }
+    if (v.format !== undefined) {
+      tags.push(`@format ${v.format}`);
+      delete v.format;
     }
     v.description = writeTagWithDescription({
       description: v.description,

--- a/test/controllers/AppController.ts
+++ b/test/controllers/AppController.ts
@@ -87,7 +87,7 @@ export class AppController {
       query,
       body: {
         ...body,
-        file: `http://localhost:3000/files/${Date.now()}.raw`,
+        file: `http://localhost:3001/files/${Date.now()}.raw`,
       },
     };
   }

--- a/test/executable/execute.ts
+++ b/test/executable/execute.ts
@@ -37,7 +37,7 @@ const main = async (): Promise<void> => {
   // actual execution is by yourself
   const article = await HttpLlm.execute({
     connection: {
-      host: "http://localhost:3000",
+      host: "http://localhost:3001",
     },
     application,
     function: func,

--- a/test/index.ts
+++ b/test/index.ts
@@ -13,7 +13,7 @@ const main = async (): Promise<void> => {
   // PREPARE SERVER
   const app = await NestFactory.create(AppModule, { logger: false });
   app.useGlobalFilters(new AppFilter(app.getHttpAdapter()));
-  await app.listen(3_000);
+  await app.listen(3_001);
 
   // DO TEST
   const include: string[] = TestGlobal.getArguments("include");
@@ -24,7 +24,7 @@ const main = async (): Promise<void> => {
     extension: __filename.substring(__filename.length - 2),
     parameters: () => [
       {
-        host: `http://localhost:3000`,
+        host: `http://localhost:3001`,
       },
     ],
     onComplete: (exec) => {


### PR DESCRIPTION
This pull request includes several changes to add format restrictions, update versioning, and modify server configurations. The most important changes are summarized below:

### Format Restrictions

* Added `format` property to various schemas in `OpenApi`, `OpenApiV3`, `OpenApiV3_1`, `SwaggerV2`, `ILlmSchemaV3`, and `ILlmSchemaV3_1` namespaces to include options like `"int32"`, `"uint32"`, `"int64"`, `"uint64"`, `"float"`, `"double"`, and other string formats. [[1]](diffhunk://#diff-77f34fd23e2eddbd1b3ebc491255409ecceb4df2c22af81356d4788b4379efbcR699-R703) [[2]](diffhunk://#diff-77f34fd23e2eddbd1b3ebc491255409ecceb4df2c22af81356d4788b4379efbcR756-R767) [[3]](diffhunk://#diff-6aa34a8c7b2707907658c6d0c4e829ff022e937feafb2787fd6f675a51c2953dR199) [[4]](diffhunk://#diff-6aa34a8c7b2707907658c6d0c4e829ff022e937feafb2787fd6f675a51c2953dR209-R216) [[5]](diffhunk://#diff-d3268150ddf804e0ea54064a1739ec07c0146bdc44681547f796697065beeffdL194-R195) [[6]](diffhunk://#diff-d3268150ddf804e0ea54064a1739ec07c0146bdc44681547f796697065beeffdR213-R243) [[7]](diffhunk://#diff-d3268150ddf804e0ea54064a1739ec07c0146bdc44681547f796697065beeffdR265) [[8]](diffhunk://#diff-d3268150ddf804e0ea54064a1739ec07c0146bdc44681547f796697065beeffdR275-R282) [[9]](diffhunk://#diff-c150dea885c1758f34af4be174ddaabd63dff142325e92a138312b8ee4c7475dR149) [[10]](diffhunk://#diff-c150dea885c1758f34af4be174ddaabd63dff142325e92a138312b8ee4c7475dR159-R166) [[11]](diffhunk://#diff-a83bad0fda93321814c4ce21df194a9e142cf63a291737fbedee22d69536bd42R108-R112) [[12]](diffhunk://#diff-a83bad0fda93321814c4ce21df194a9e142cf63a291737fbedee22d69536bd42R170-R181) [[13]](diffhunk://#diff-72e41eeadd5016cdfe8a554caae2e2bb215b4b929ff01b52fa5f79efd14bd3abR129-R133) [[14]](diffhunk://#diff-72e41eeadd5016cdfe8a554caae2e2bb215b4b929ff01b52fa5f79efd14bd3abR186-R197)

### Version Update

* Updated the package version in `package.json` from `2.3.1` to `2.4.0-dev.20241229`.

### Server Configuration

* Changed the server port in test files from `3000` to `3001` to avoid port conflicts. [[1]](diffhunk://#diff-db6ebfb9faa3e22ab262b1198a60f74e5bf4f5046dc6e4c2913dc3d100332a37L90-R90) [[2]](diffhunk://#diff-d16c9f552416324c46abb206e1556799230ed104cfcaaecf1a6a6615da9402ecL40-R40) [[3]](diffhunk://#diff-177d97aec07fd5b22f04049b34d74939b1d8364a7a83e8fb69ee3ee8695105fbL16-R16) [[4]](diffhunk://#diff-177d97aec07fd5b22f04049b34d74939b1d8364a7a83e8fb69ee3ee8695105fbL27-R27)

### Utility Changes

* Included `format` in the `OpenApiContraintShifter` utility to handle the new format restrictions. [[1]](diffhunk://#diff-7b7f464fc3f8bcfd53c588a989f8b5c20a5402bbebe1ae4a227b08d39d5d90bcR42) [[2]](diffhunk://#diff-7b7f464fc3f8bcfd53c588a989f8b5c20a5402bbebe1ae4a227b08d39d5d90bcR54) [[3]](diffhunk://#diff-7b7f464fc3f8bcfd53c588a989f8b5c20a5402bbebe1ae4a227b08d39d5d90bcR81-R84)

### Schema Emender

* Updated the `OpenApiV3_1Emender` to handle new format restrictions and added constants for integer and number formats. [[1]](diffhunk://#diff-0d6baac3e1dd36c89a3e4e967c85bc6c10f6b24917feff764e460250b78d9e72L351-R351) [[2]](diffhunk://#diff-0d6baac3e1dd36c89a3e4e967c85bc6c10f6b24917feff764e460250b78d9e72R377-R411) [[3]](diffhunk://#diff-0d6baac3e1dd36c89a3e4e967c85bc6c10f6b24917feff764e460250b78d9e72R460) [[4]](diffhunk://#diff-0d6baac3e1dd36c89a3e4e967c85bc6c10f6b24917feff764e460250b78d9e72R730-R732)