### PR TITLE
Fix `IHttpLlmFunction.seperated` composing bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/HttpLlmApplicationComposer.ts
+++ b/src/composers/HttpLlmApplicationComposer.ts
@@ -196,7 +196,7 @@ export namespace HttpLlmComposer {
       additionalProperties: false,
       required: properties.map(([k]) => k),
     } as any as ILlmSchema.ModelParameters[Model];
-    if (Object.keys($defs).length)
+    if (LlmSchemaComposer.isDefs(props.model))
       (parameters as any as IChatGptSchema.IParameters).$defs = $defs;
     const operation: OpenApi.IOperation = props.route.operation();
 

--- a/src/composers/LlmSchemaComposer.ts
+++ b/src/composers/LlmSchemaComposer.ts
@@ -34,6 +34,13 @@ export namespace LlmSchemaComposer {
   export const separateParameters = <Model extends ILlmSchema.Model>(
     model: Model,
   ) => SEPARATE_PARAMETERS[model];
+
+  /**
+   * @internal
+   */
+  export const isDefs = <Model extends ILlmSchema.Model>(
+    model: Model,
+  ): boolean => IS_DEFS[model]();
 }
 
 const PARAMETERS_CASTERS = {
@@ -94,4 +101,16 @@ const TYPE_CHECKERS = {
   llama: LlamaTypeChecker,
   "3.0": LlmTypeCheckerV3,
   "3.1": LlmTypeCheckerV3_1,
+};
+
+/**
+ * @internal
+ */
+const IS_DEFS = {
+  chatgpt: () => ChatGptSchemaComposer.IS_DEFS,
+  claude: () => ClaudeSchemaComposer.IS_DEFS,
+  gemini: () => GeminiSchemaComposer.IS_DEFS,
+  llama: () => LlamaSchemaComposer.IS_DEFS,
+  "3.0": () => LlmSchemaV3Composer.IS_DEFS,
+  "3.1": () => LlmSchemaV3_1Composer.IS_DEFS,
 };

--- a/src/composers/llm/ChatGptSchemaComposer.ts
+++ b/src/composers/llm/ChatGptSchemaComposer.ts
@@ -10,6 +10,11 @@ import { OpenApiTypeChecker } from "../../utils/OpenApiTypeChecker";
 import { LlmSchemaV3_1Composer } from "./LlmSchemaV3_1Composer";
 
 export namespace ChatGptSchemaComposer {
+  /**
+   * @internal
+   */
+  export const IS_DEFS = true;
+
   export const parameters = (props: {
     config: IChatGptSchema.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/ClaudeSchemaComposer.ts
+++ b/src/composers/llm/ClaudeSchemaComposer.ts
@@ -6,6 +6,11 @@ import { IResult } from "../../typings/IResult";
 import { LlmSchemaV3_1Composer } from "./LlmSchemaV3_1Composer";
 
 export namespace ClaudeSchemaComposer {
+  /**
+   * @internal
+   */
+  export const IS_DEFS = true;
+
   export const parameters = (props: {
     config: IClaudeSchema.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/GeminiSchemaComposer.ts
+++ b/src/composers/llm/GeminiSchemaComposer.ts
@@ -12,6 +12,11 @@ import { LlmParametersFinder } from "./LlmParametersComposer";
 import { LlmSchemaV3Composer } from "./LlmSchemaV3Composer";
 
 export namespace GeminiSchemaComposer {
+  /**
+   * @internal
+   */
+  export const IS_DEFS = false;
+
   export const parameters = (props: {
     config: IGeminiSchema.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/LlamaSchemaComposer.ts
+++ b/src/composers/llm/LlamaSchemaComposer.ts
@@ -6,6 +6,11 @@ import { IResult } from "../../typings/IResult";
 import { LlmSchemaV3_1Composer } from "./LlmSchemaV3_1Composer";
 
 export namespace LlamaSchemaComposer {
+  /**
+   * @internal
+   */
+  export const IS_DEFS = true;
+
   export const parameters = (props: {
     config: ILlamaSchema.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -10,6 +10,11 @@ import { OpenApiTypeChecker } from "../../utils/OpenApiTypeChecker";
 import { LlmParametersFinder } from "./LlmParametersComposer";
 
 export namespace LlmSchemaV3Composer {
+  /**
+   * @internal
+   */
+  export const IS_DEFS = false;
+
   export const parameters = (props: {
     config: ILlmSchemaV3.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -10,6 +10,11 @@ import { JsonDescriptionUtil } from "../../utils/internal/JsonDescriptionUtil";
 import { LlmParametersFinder } from "./LlmParametersComposer";
 
 export namespace LlmSchemaV3_1Composer {
+  /**
+   * @internal
+   */
+  export const IS_DEFS = true;
+
   export const parameters = (props: {
     config: ILlmSchemaV3_1.IConfig;
     components: OpenApi.IComponents;

--- a/test/examples/chatgpt-structured-output.ts
+++ b/test/examples/chatgpt-structured-output.ts
@@ -1,0 +1,72 @@
+import OpenAI from "openai";
+import typia, { IValidation, tags } from "typia";
+
+interface IMember {
+  email: string & tags.Format<"email">;
+  name: string;
+  age: number;
+  hobbies: string[];
+  joined_at: string & tags.Format<"date">;
+}
+
+const step = async (
+  failure?: IValidation.IFailure | undefined,
+): Promise<IValidation<IMember>> => {
+  const client: OpenAI = new OpenAI({
+    apiKey: "<YOUR_OPENAI_API_KEY>",
+  });
+  const completion: OpenAI.ChatCompletion =
+    await client.chat.completions.create({
+      model: "gpt-4o",
+      messages: [
+        {
+          role: "user",
+          content: [
+            "I am a new member of the community.",
+            "",
+            "My name is John Doe, and I am 25 years old.",
+            "I like playing basketball and reading books,",
+            "and joined to this community at 2022-01-01.",
+          ].join("\n"),
+        },
+        ...(failure
+          ? [
+              {
+                role: "system",
+                content: [
+                  "You A.I. agent had taken a mistak that",
+                  "returing wrong typed structured data.",
+                  "",
+                  "Here is the detailed list of type errors.",
+                  "Review and correct them at the next step.",
+                  "",
+                  "```json",
+                  JSON.stringify(failure.errors, null, 2),
+                  "```",
+                ].join("\n"),
+              } satisfies OpenAI.ChatCompletionSystemMessageParam,
+            ]
+          : []),
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "member",
+          schema: typia.llm.parameters<IMember, "chatgpt">() as any,
+        },
+      },
+    });
+  const member: IMember = JSON.parse(completion.choices[0].message.content!);
+  return typia.validate(member);
+};
+
+const main = async (): Promise<void> => {
+  let result: IValidation<IMember> | undefined = undefined;
+  for (let i: number = 0; i < 3; ++i) {
+    if (result && result.success === true) break;
+    result = await step(result);
+  }
+  console.log(result);
+};
+
+main().catch(console.error);

--- a/test/features/llm/validate_llm_application_separate.ts
+++ b/test/features/llm/validate_llm_application_separate.ts
@@ -1,0 +1,72 @@
+import { TestValidator } from "@nestia/e2e";
+import {
+  HttpLlm,
+  IHttpLlmApplication,
+  ILlmSchema,
+  OpenApi,
+  OpenApiV3,
+  OpenApiV3_1,
+  SwaggerV2,
+} from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import { Singleton } from "tstl";
+import typia from "typia";
+
+export const test_chatgpt_application_separate = async (): Promise<void> => {
+  await validate_llm_application_separate("chatgpt", false);
+  await validate_llm_application_separate("chatgpt", true);
+};
+
+export const test_claude_application_separate = async (): Promise<void> => {
+  await validate_llm_application_separate("claude", false);
+  await validate_llm_application_separate("claude", true);
+};
+
+export const test_gemini_application_separate = async (): Promise<void> => {
+  await validate_llm_application_separate("gemini", false);
+};
+
+export const test_llama_application_separate = async (): Promise<void> => {
+  await validate_llm_application_separate("llama", false);
+  await validate_llm_application_separate("llama", true);
+};
+
+export const test_llm_v30_application_separate = async (): Promise<void> => {
+  await validate_llm_application_separate("3.0", false);
+  await validate_llm_application_separate("3.0", true);
+};
+
+export const test_llm_v31_application_separate = async (): Promise<void> => {
+  await validate_llm_application_separate("3.1", false);
+  await validate_llm_application_separate("3.1", true);
+};
+
+const validate_llm_application_separate = async <
+  Model extends ILlmSchema.Model,
+>(
+  model: Model,
+  constraint: boolean,
+): Promise<void> => {
+  const application: IHttpLlmApplication<Model> = HttpLlm.application({
+    model,
+    document: await document.get(),
+    options: {
+      separate: (schema: any) =>
+        LlmSchemaComposer.typeChecker(model).isString(schema as any) &&
+        (schema as any)["x-wrtn-secret-key"] !== undefined,
+      constraint: constraint as any,
+    } as any,
+  });
+  for (const func of application.functions)
+    TestValidator.equals("separated")(!!func.separated)(true);
+};
+
+const document = new Singleton(async (): Promise<OpenApi.IDocument> => {
+  const swagger:
+    | SwaggerV2.IDocument
+    | OpenApiV3.IDocument
+    | OpenApiV3_1.IDocument = await fetch(
+    "https://wrtnio.github.io/connectors/swagger/swagger.json",
+  ).then((r) => r.json());
+  return OpenApi.convert(typia.assert(swagger));
+});


### PR DESCRIPTION
This pull request includes several changes to the codebase to enhance functionality and improve internal handling of schema definitions. The most important changes include version updates, new internal methods, and new test files.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.3.1` to `2.3.2`.

### Internal Methods and Schema Handling:
* [`src/composers/HttpLlmApplicationComposer.ts`](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL199-R199): Modified the condition to check if `props.model` has definitions using the new `LlmSchemaComposer.isDefs` method.
* [`src/composers/LlmSchemaComposer.ts`](diffhunk://#diff-058da3c4ceb4aa02b198488eef3b8dd547d7c0f0ee2b2355e1d104527b1d597dR37-R43): Added a new internal method `isDefs` to check if a model has definitions and a corresponding constant `IS_DEFS` with model-specific implementations. [[1]](diffhunk://#diff-058da3c4ceb4aa02b198488eef3b8dd547d7c0f0ee2b2355e1d104527b1d597dR37-R43) [[2]](diffhunk://#diff-058da3c4ceb4aa02b198488eef3b8dd547d7c0f0ee2b2355e1d104527b1d597dR105-R116)
* Various files under `src/composers/llm/`: Added the `IS_DEFS` constant to multiple schema composer namespaces (`ChatGptSchemaComposer`, `ClaudeSchemaComposer`, `GeminiSchemaComposer`, `LlamaSchemaComposer`, `LlmSchemaV3Composer`, `LlmSchemaV3_1Composer`). [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR13-R17) [[2]](diffhunk://#diff-09e976921cbf7ded8e1667800e245195ac7a939f7640fdd806acedcb69f91d65R9-R13) [[3]](diffhunk://#diff-4e9da1f0bdac90742383f58756d5fe60a9d5de3293d24f67f6015f9e88d54759R15-R19) [[4]](diffhunk://#diff-5b7ae0e3be666c887786a4fdb4dfc30b7f0505900ff35bca89338d2f9d3ec0b6R9-R13) [[5]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R13-R17) [[6]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R13-R17)

### New Test Files:
* [`test/examples/chatgpt-structured-output.ts`](diffhunk://#diff-b6aa402b43d5bf720cc1066fd45855620dce8165992c360ceb6277c6a7a050b5R1-R72): Added a new test file for structured output from ChatGPT, including a function to validate member data using OpenAI's API and `typia`.
* [`test/features/llm/validate_llm_application_separate.ts`](diffhunk://#diff-70061dbbc01e0ae563a4355b583be83364562da8228afab31d543e2c970d1e11R1-R72): Added a new test file to validate LLM applications separately for different models, including `chatgpt`, `claude`, `gemini`, `llama`, `3.0`, and `3.1`.