### PR TITLE
`IHttpLlmFunction.name`'s maximum length limit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/HttpLlm.ts
+++ b/src/HttpLlm.ts
@@ -98,7 +98,8 @@ export namespace HttpLlm {
       options: {
         ...LlmSchemaComposer.defaultConfig(props.model),
         separate: props.options?.separate ?? null,
-      },
+        maxLength: props.options?.maxLength ?? null,
+      } as any as IHttpLlmApplication.IOptions<Model>,
     });
   };
 

--- a/src/structures/IHttpLlmApplication.ts
+++ b/src/structures/IHttpLlmApplication.ts
@@ -95,7 +95,23 @@ export interface IHttpLlmApplication<Model extends ILlmSchema.Model> {
   options: IHttpLlmApplication.IOptions<Model>;
 }
 export namespace IHttpLlmApplication {
-  export import IOptions = ILlmApplication.IOptions;
+  /**
+   * Options for the HTTP LLM application schema composition.
+   */
+  export type IOptions<Model extends ILlmSchema.Model> =
+    ILlmApplication.IOptions<Model> & {
+      /**
+       * Maximum length of function name.
+       *
+       * When a function name is longer than this value, it will be truncated.
+       *
+       * If not possible to truncate due to the duplication, the function name
+       * would be modified to randomly generated (UUID v4).
+       *
+       * @default 64
+       */
+      maxLength?: number;
+    };
 
   /**
    * Error occurred in the composition.

--- a/src/structures/IHttpLlmFunction.ts
+++ b/src/structures/IHttpLlmFunction.ts
@@ -96,6 +96,8 @@ export interface IHttpLlmFunction<Model extends ILlmSchema.Model> {
    * > - Example 2
    * >   - endpoint: `GET /shoppings/sellers/sales/:saleId/reviews/:reviewId/comments/:id
    * >   - accessor: `shoppings.sellers.sales.reviews.getBySaleIdAndReviewIdAndCommentId`
+   *
+   * @maxLength 64
    */
   name: string;
 

--- a/src/structures/ILlmFunction.ts
+++ b/src/structures/ILlmFunction.ts
@@ -25,6 +25,8 @@ import { ILlmSchema } from "./ILlmSchema";
 export interface ILlmFunction<Model extends ILlmSchema.Model> {
   /**
    * Representative name of the function.
+   *
+   * @maxLength 64
    */
   name: string;
 

--- a/test/features/llm/test_http_llm_application_funtion_name_length.ts
+++ b/test/features/llm/test_http_llm_application_funtion_name_length.ts
@@ -1,0 +1,25 @@
+import { TestValidator } from "@nestia/e2e";
+import { HttpLlm, IHttpLlmApplication, OpenApi } from "@samchon/openapi";
+
+export const test_http_llm_application_funtion_name_length =
+  async (): Promise<void> => {
+    const document: OpenApi.IDocument = OpenApi.convert(
+      await fetch(
+        "https://wrtnio.github.io/connectors/swagger/swagger.json",
+      ).then((res) => res.json()),
+    );
+    const application: IHttpLlmApplication<"chatgpt"> = HttpLlm.application({
+      model: "chatgpt",
+      document,
+    });
+
+    TestValidator.predicate("overflow")(() =>
+      application.functions.some(
+        (f) => f.route().accessor.join("_").length > 64,
+      ),
+    );
+
+    const names: string[] = application.functions.map((f) => f.name);
+    TestValidator.predicate("length")(() => names.every((s) => s.length <= 64));
+    TestValidator.equals("unique")(true)(new Set(names).size === names.length);
+  };


### PR DESCRIPTION
As ChatGPT does not allow 64 length over function name, this PR shorten it.

---------

This pull request includes several changes aimed at improving the functionality and robustness of the `HttpLlm` module. The main changes include adding a new feature to limit the length of function names, updating type definitions, and adding a new test to validate these changes.

### Key Changes:

**Feature Enhancements:**

* Added a `maxLength` option to limit the length of function names in `HttpLlm` applications. If a function name exceeds this length, it will be truncated or replaced with a UUID if necessary. (`src/HttpLlm.ts`, `src/composers/HttpLlmApplicationComposer.ts`, `src/structures/IHttpLlmApplication.ts`, `src/structures/IHttpLlmFunction.ts`, `src/structures/ILlmFunction.ts`) [[1]](diffhunk://#diff-0c890635e48b22e4dea1926131f2726dff205a7f9f78cb2e29cdc0ddedecb8c8L101-R102) [[2]](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL74-R82) [[3]](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffR236-R288) [[4]](diffhunk://#diff-6e6bececd1bc7bc3c702e37136705a8f14fb4a04438d2cc56b49b8a9dad83e5dL98-R114) [[5]](diffhunk://#diff-40aad91cda9d576516527b8ece8e58e9f4ad7779a1c6830cb7d92408fcfa32cbR99-R100) [[6]](diffhunk://#diff-25c6cbd1c80f38bb0f80a4a8abbe94cbfa3c66b7e99c4d65ebc41d05f9efc4eeR28-R29)

**Testing:**

* Added a new test file `test_http_llm_application_funtion_name_length.ts` to ensure that function names in `HttpLlm` applications do not exceed the specified `maxLength` and are unique. (`test/features/llm/test_http_llm_application_funtion_name_length.ts`)

**Version Update:**

* Updated the version of the `@samchon/openapi` package from `2.3.2` to `2.3.3`. (`package.json`)