### PR TITLE
Fix #121: accessor bug including `#` symbol.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/utils/AccessorUtil.ts
+++ b/src/utils/AccessorUtil.ts
@@ -2,6 +2,6 @@ export namespace AccessorUtil {
   export const reference = (prefix: string): string =>
     prefix
       .split("/")
-      .filter((str) => !!str.length)
+      .filter((str, i) => !!str.length && !(i === 0 && str === "#"))
       .join(".");
 }

--- a/test/features/issues/test_issue_121_reference_accessor.ts
+++ b/test/features/issues/test_issue_121_reference_accessor.ts
@@ -1,0 +1,26 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiTypeChecker } from "@samchon/openapi";
+import typia from "typia";
+
+export const test_issue_121_reference_accessor = (): void => {
+  const collection = typia.json.application<[IMember]>();
+  const accessors: string[] = [];
+  OpenApiTypeChecker.visit({
+    closure: (_schema, acc) => {
+      accessors.push(acc);
+    },
+    components: collection.components,
+    schema: collection.schemas[0],
+  });
+  TestValidator.equals("accessors")(accessors)([
+    "$input.schema",
+    '$input.components.schemas["IMember"]',
+    '$input.components.schemas["IMember"].properties["id"]',
+    '$input.components.schemas["IMember"].properties["age"]',
+  ]);
+};
+
+interface IMember {
+  id: string;
+  age: number;
+}


### PR DESCRIPTION
This pull request includes updates to the `@samchon/openapi` package, improvements to the `AccessorUtil` utility function, and the addition of a new test case for issue 121.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.3.3` to `2.3.4`.

Improvements to `AccessorUtil`:

* [`src/utils/AccessorUtil.ts`](diffhunk://#diff-d71570a73187c7ea5b8cee3df5ac7decf07bdaa04849d24d67fe968cad8f742aL5-R5): Modified the `reference` function to filter out the first element if it is "#" to avoid incorrect references.

New test case:

* [`test/features/issues/test_issue_121_reference_accessor.ts`](diffhunk://#diff-fa3564f8e5eb97a418271919ed000101cdd9503df4b258731f7392adf8652cb8R1-R26): Added a new test case `test_issue_121_reference_accessor` to validate the behavior of the `reference` function with various accessors.