### PR TITLE
Limit `IHttpLlmFunction.description` length under 1,024.

### DIFF
--- a/examples/function-calling/arguments/claude.sale.input.json
+++ b/examples/function-calling/arguments/claude.sale.input.json
@@ -1,13 +1,11 @@
 {
   "section_code": "general",
-  "status": null,
   "opened_at": null,
   "closed_at": null,
   "content": {
     "title": "Surface Pro 9",
     "format": "md",
     "body": "The Surface Pro 9 is a versatile 2-in-1 device that combines the power of a laptop with the flexibility of a tablet. It features advanced technology, making it suitable for both professional and personal use.\n\n- \"Unleash Your Creativity Anywhere\": The Surface Pro 9 is designed for those who need power and portability, making it perfect for creative professionals and students alike.\n- \"The Ultimate 2-in-1 Experience\": With its detachable keyboard and touchscreen capabilities, the Surface Pro 9 adapts to your needs, whether you're working, studying, or relaxing.\n- \"Stay Connected with 5G\": Experience lightning-fast internet speeds and seamless connectivity, no matter where you are.\n- \"Power Meets Flexibility\": The Surface Pro 9 combines the performance of a laptop with the convenience of a tablet, making it the ideal device for multitasking.\n\nIn summary, the Surface Pro 9 stands out as a powerful and flexible device, perfect for users who require both performance and portability. With its advanced features and sleek design, it is an excellent choice for anyone looking to enhance their productivity and creativity. Whether for work or play, the Surface Pro 9 is ready to meet your needs.",
-    "files": [],
     "thumbnails": [
       {
         "name": "microsoft-surface-pro-9-thumbnail-1",
@@ -24,7 +22,8 @@
         "extension": "jpeg",
         "url": "https://serpapi.com/searches/673d3a37e45f3316ecd8ab3e/images/1be25e6e2b1fb7505946d975aac683f8826bcb8c509672de4a5f8c71f149fdef.jpeg"
       }
-    ]
+    ],
+    "files": []
   },
   "channels": [
     {
@@ -36,11 +35,18 @@
       ]
     }
   ],
+  "tags": [
+    "surface",
+    "laptop",
+    "tablet",
+    "2-in-1",
+    "microsoft"
+  ],
   "units": [
     {
       "name": "Surface Pro 9 Entity",
-      "primary": true,
       "required": true,
+      "primary": true,
       "options": [
         {
           "type": "select",
@@ -93,7 +99,7 @@
       ],
       "stocks": [
         {
-          "name": "Surface Pro 9 (i3/8GB/128GB)",
+          "name": "i3/8GB/128GB",
           "price": {
             "nominal": 1000000,
             "real": 899000
@@ -115,7 +121,7 @@
           ]
         },
         {
-          "name": "Surface Pro 9 (i3/16GB/256GB)",
+          "name": "i3/16GB/256GB",
           "price": {
             "nominal": 1200000,
             "real": 1099000
@@ -137,7 +143,7 @@
           ]
         },
         {
-          "name": "Surface Pro 9 (i3/16GB/512GB)",
+          "name": "i3/16GB/512GB",
           "price": {
             "nominal": 1400000,
             "real": 1299000
@@ -159,7 +165,7 @@
           ]
         },
         {
-          "name": "Surface Pro 9 (i5/16GB/256GB)",
+          "name": "i5/16GB/256GB",
           "price": {
             "nominal": 1500000,
             "real": 1399000
@@ -181,7 +187,7 @@
           ]
         },
         {
-          "name": "Surface Pro 9 (i5/32GB/512GB)",
+          "name": "i5/32GB/512GB",
           "price": {
             "nominal": 1800000,
             "real": 1699000
@@ -203,7 +209,7 @@
           ]
         },
         {
-          "name": "Surface Pro 9 (i7/16GB/512GB)",
+          "name": "i7/16GB/512GB",
           "price": {
             "nominal": 1800000,
             "real": 1699000
@@ -225,7 +231,7 @@
           ]
         },
         {
-          "name": "Surface Pro 9 (i7/32GB/512GB)",
+          "name": "i7/32GB/512GB",
           "price": {
             "nominal": 2000000,
             "real": 1899000
@@ -250,8 +256,8 @@
     },
     {
       "name": "Warranty Program",
-      "primary": false,
       "required": false,
+      "primary": false,
       "options": [],
       "stocks": [
         {
@@ -267,8 +273,8 @@
     },
     {
       "name": "Magnetic Keyboard",
-      "primary": false,
       "required": false,
+      "primary": false,
       "options": [],
       "stocks": [
         {
@@ -282,15 +288,5 @@
         }
       ]
     }
-  ],
-  "tags": [
-    "Surface",
-    "Pro",
-    "9",
-    "Microsoft",
-    "2-in-1",
-    "Tablet",
-    "Laptop",
-    "Windows"
   ]
 }

--- a/examples/function-calling/schemas/claude.sale.schema.json
+++ b/examples/function-calling/schemas/claude.sale.schema.json
@@ -327,15 +327,15 @@
                 },
                 "minItems": 1
               },
-              "required": {
-                "title": "Whether the unit is required or not",
-                "description": "Whether the unit is required or not.\n\nWhen the unit is required, the customer must select the unit. If do not\nselect, customer can't buy it.\n\nFor example, if there's a sale \"Macbook Set\" and one of the unit is the\n\"Main Body\", is it possible to buy the \"Macbook Set\" without the\n\"Main Body\" unit? This property is for that case.",
-                "type": "boolean"
-              },
               "name": {
                 "title": "Representative name of the unit",
                 "description": "Representative name of the unit.",
                 "type": "string"
+              },
+              "required": {
+                "title": "Whether the unit is required or not",
+                "description": "Whether the unit is required or not.\n\nWhen the unit is required, the customer must select the unit. If do not\nselect, customer can't buy it.\n\nFor example, if there's a sale \"Macbook Set\" and one of the unit is the\n\"Main Body\", is it possible to buy the \"Macbook Set\" without the\n\"Main Body\" unit? This property is for that case.",
+                "type": "boolean"
               },
               "primary": {
                 "title": "Whether the unit is primary or not",
@@ -346,8 +346,8 @@
             "required": [
               "options",
               "stocks",
-              "required",
               "name",
+              "required",
               "primary"
             ]
           },
@@ -364,7 +364,6 @@
       },
       "required": [
         "section_code",
-        "status",
         "opened_at",
         "closed_at",
         "content",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/test/features/issues/test_issue_104_upgrade_v20_allOf.ts
+++ b/test/features/issues/test_issue_104_upgrade_v20_allOf.ts
@@ -23,6 +23,18 @@ export const test_issue_104_upgrade_v20_allOf = async (): Promise<void> => {
   TestValidator.predicate("allOf")(
     () => JSON.stringify(document).indexOf("#/definitions") === -1,
   );
+  for (const collection of Object.values(document.paths ?? {}))
+    for (const operation of Object.values(collection))
+      if (typia.is<OpenApi.IOperation>(operation)) {
+        const length: number =
+          (operation.summary?.length ? operation.summary.length + 3 : 0) +
+          (operation.description?.length ?? 0);
+        if (length <= 1_024 || operation.description === undefined) continue;
+        operation.description = operation.description.slice(
+          0,
+          operation.description.length - (length - 1_024),
+        );
+      }
 
   const app: IHttpLlmApplication<"claude"> = HttpLlm.application({
     model: "claude",

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_additionalProperties.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_additionalProperties.ts
@@ -10,7 +10,7 @@ export const test_chatgpt_function_calling_additionalProperties =
       name: "enrollPerson",
       description: "Enroll a person to the restaurant reservation list.",
       collection: typia.json.schemas<[{ input: IPerson }]>(),
-      validate: typia.createValidate<[{ input: IPerson }]>(),
+      validate: typia.createValidate<{ input: IPerson }>(),
       texts: [
         {
           role: "assistant",

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_description_length.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_description_length.ts
@@ -1,0 +1,39 @@
+import typia from "typia";
+
+import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
+
+export const test_chatgpt_function_calling_description_length = async () => {
+  await ChatGptFunctionCaller.test({
+    config: {
+      reference: true,
+    },
+    name: "testLength",
+    description: "가".repeat(1_024),
+    collection: typia.json.schemas<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
+      },
+      {
+        role: "user",
+        content: USER_MESSAGE,
+      },
+    ],
+    handleCompletion: async (input) => {
+      typia.assert<IPerson>(input);
+    },
+  });
+};
+
+interface IPerson {
+  name: string;
+  age: number;
+}
+
+const SYSTEM_MESSAGE =
+  "You are a helpful customer support assistant. Use the supplied tools to assist the user.";
+
+const USER_MESSAGE =
+  "Just enroll a person whose name and age values 'John Doe' and 42 years old.";

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_example.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_example.ts
@@ -12,7 +12,7 @@ export const test_chatgpt_function_calling_example = () =>
     name: "enrollPerson",
     description: "Enroll a person to the restaurant reservation list.",
     collection: typia.json.schemas<[{ input: IPerson }]>(),
-    validate: typia.createValidate<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_name_length.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_name_length.ts
@@ -1,0 +1,39 @@
+import typia from "typia";
+
+import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
+
+export const test_chatgpt_function_calling_name_length = async () => {
+  await ChatGptFunctionCaller.test({
+    config: {
+      reference: true,
+    },
+    name: "A".repeat(64),
+    description: "Enroll a person information.",
+    collection: typia.json.schemas<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
+      },
+      {
+        role: "user",
+        content: USER_MESSAGE,
+      },
+    ],
+    handleCompletion: async (input) => {
+      typia.assert<IPerson>(input);
+    },
+  });
+};
+
+interface IPerson {
+  name: string;
+  age: number;
+}
+
+const SYSTEM_MESSAGE =
+  "You are a helpful customer support assistant. Use the supplied tools to assist the user.";
+
+const USER_MESSAGE =
+  "Just enroll a person whose name and age values 'John Doe' and 42 years old.";

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_optional.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_optional.ts
@@ -12,7 +12,7 @@ export const test_chatgpt_function_calling_optional = () =>
     name: "registerMember",
     description: "Register a membership.",
     collection: typia.json.schemas<[{ input: IMember; note?: string }]>(),
-    validate: typia.createValidate<[{ input: IMember; note?: string }]>(),
+    validate: typia.createValidate<{ input: IMember; note?: string }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_recursive.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_recursive.ts
@@ -12,7 +12,7 @@ export const test_chatgpt_function_calling_recursive = () =>
     name: "composeCategories",
     description: "Compose categories from the input.",
     collection: typia.json.schemas<[{ input: IShoppingCategory[] }]>(),
-    validate: typia.createValidate<[{ input: IShoppingCategory[] }]>(),
+    validate: typia.createValidate<{ input: IShoppingCategory[] }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_union.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_union.ts
@@ -12,7 +12,7 @@ export const test_chatgpt_function_calling_union = (): Promise<void> =>
     name: "draw",
     description: "Draw a shape with following geometry.",
     collection: typia.json.schemas<[{ input: Shape }]>(),
-    validate: typia.createValidate<[{ input: Shape }]>(),
+    validate: typia.createValidate<{ input: Shape }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/claude/test_claude_function_calling_additionalProperties.ts
+++ b/test/features/llm/claude/test_claude_function_calling_additionalProperties.ts
@@ -11,7 +11,7 @@ export const test_claude_function_calling_additionalProperties =
       name: "enrollPerson",
       description: "Enroll a person to the restaurant reservation list.",
       collection: typia.json.schemas<[{ input: IPerson }]>(),
-      validate: typia.createValidate<[{ input: IPerson }]>(),
+      validate: typia.createValidate<{ input: IPerson }>(),
       texts: [
         {
           role: "assistant",

--- a/test/features/llm/claude/test_claude_function_calling_default.ts
+++ b/test/features/llm/claude/test_claude_function_calling_default.ts
@@ -13,7 +13,7 @@ export const test_claude_function_calling_default = () =>
     name: "enrollPerson",
     description: "Enroll a person to the restaurant reservation list.",
     collection: typia.json.schemas<[{ input: IPerson }]>(),
-    validate: typia.createValidate<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/claude/test_claude_function_calling_example.ts
+++ b/test/features/llm/claude/test_claude_function_calling_example.ts
@@ -13,7 +13,7 @@ export const test_claude_function_calling_example = () =>
     name: "enrollPerson",
     description: "Enroll a person to the restaurant reservation list.",
     collection: typia.json.schemas<[{ input: IPerson }]>(),
-    validate: typia.createValidate<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/claude/test_claude_function_calling_optional.ts
+++ b/test/features/llm/claude/test_claude_function_calling_optional.ts
@@ -13,7 +13,7 @@ export const test_claude_function_calling_optional = () =>
     name: "registerMember",
     description: "Register a membership.",
     collection: typia.json.schemas<[{ input: IMember; note?: string }]>(),
-    validate: typia.createValidate<[{ input: IMember; note?: string }]>(),
+    validate: typia.createValidate<{ input: IMember; note?: string }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/claude/test_claude_function_calling_recursive.ts
+++ b/test/features/llm/claude/test_claude_function_calling_recursive.ts
@@ -13,7 +13,7 @@ export const test_claude_function_calling_recursive = () =>
     name: "composeCategories",
     description: "Compose categories from the input.",
     collection: typia.json.schemas<[{ input: IShoppingCategory[] }]>(),
-    validate: typia.createValidate<[{ input: IShoppingCategory[] }]>(),
+    validate: typia.createValidate<{ input: IShoppingCategory[] }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/claude/test_claude_function_calling_tags.ts
+++ b/test/features/llm/claude/test_claude_function_calling_tags.ts
@@ -13,7 +13,7 @@ export const test_claude_function_calling_tags = (): Promise<void> =>
     name: "reserve",
     description: "Reserve some opening time.",
     collection: typia.json.schemas<[{ input: OpeningTime }]>(),
-    validate: typia.createValidate<[{ input: OpeningTime }]>(),
+    validate: typia.createValidate<{ input: OpeningTime }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/claude/test_claude_function_calling_union.ts
+++ b/test/features/llm/claude/test_claude_function_calling_union.ts
@@ -13,7 +13,7 @@ export const test_claude_function_calling_union = (): Promise<void> =>
     name: "draw",
     description: "Draw a shape with following geometry.",
     collection: typia.json.schemas<[{ input: Shape }]>(),
-    validate: typia.createValidate<[{ input: Shape }]>(),
+    validate: typia.createValidate<{ input: Shape }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/gemini/test_gemini_function_calling_default.ts
+++ b/test/features/llm/gemini/test_gemini_function_calling_default.ts
@@ -9,7 +9,7 @@ export const test_gemini_function_calling_default = () =>
     name: "enrollPerson",
     description: "Enroll a person to the restaurant reservation list.",
     collection: typia.json.schemas<[{ input: IPerson }]>(),
-    validate: typia.createValidate<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/gemini/test_gemini_function_calling_example.ts
+++ b/test/features/llm/gemini/test_gemini_function_calling_example.ts
@@ -12,7 +12,7 @@ export const test_gemini_function_calling_example = (): Promise<void> =>
     name: "enrollPerson",
     description: "Enroll a person to the restaurant reservation list.",
     collection: typia.json.schemas<[{ input: IPerson }]>(),
-    validate: typia.createValidate<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/gemini/test_gemini_function_calling_optional.ts
+++ b/test/features/llm/gemini/test_gemini_function_calling_optional.ts
@@ -9,7 +9,7 @@ export const test_gemini_function_calling_optional = () =>
     name: "registerMember",
     description: "Register a membership.",
     collection: typia.json.schemas<[{ input: IMember; note?: string }]>(),
-    validate: typia.createValidate<[{ input: IMember; note?: string }]>(),
+    validate: typia.createValidate<{ input: IMember; note?: string }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/llama/test_llama_function_calling_additionalProperties.ts
+++ b/test/features/llm/llama/test_llama_function_calling_additionalProperties.ts
@@ -11,7 +11,7 @@ export const test_llama_function_calling_additionalProperties =
       name: "enrollPerson",
       description: "Enroll a person to the restaurant reservation list.",
       collection: typia.json.schemas<[{ input: IPerson }]>(),
-      validate: typia.createValidate<[{ input: IPerson }]>(),
+      validate: typia.createValidate<{ input: IPerson }>(),
       texts: [
         {
           role: "assistant",

--- a/test/features/llm/llama/test_llama_function_calling_default.ts
+++ b/test/features/llm/llama/test_llama_function_calling_default.ts
@@ -10,7 +10,7 @@ export const test_llama_function_calling_default = () =>
     name: "enrollPerson",
     description: "Enroll a person to the restaurant reservation list.",
     collection: typia.json.schemas<[{ input: IPerson }]>(),
-    validate: typia.createValidate<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/llama/test_llama_function_calling_example.ts
+++ b/test/features/llm/llama/test_llama_function_calling_example.ts
@@ -10,7 +10,7 @@ export const test_llama_function_calling_example = () =>
     name: "enrollPerson",
     description: "Enroll a person to the restaurant reservation list.",
     collection: typia.json.schemas<[{ input: IPerson }]>(),
-    validate: typia.createValidate<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/llama/test_llama_function_calling_nullable.ts
+++ b/test/features/llm/llama/test_llama_function_calling_nullable.ts
@@ -13,7 +13,7 @@ export const test_llama_function_calling_nullable = (): Promise<void> =>
     name: "drawPolygon",
     description: "Draw a polygon with given geometry.",
     collection: typia.json.schemas<[{ input: IPolygon }]>(),
-    validate: typia.createValidate<[{ input: IPolygon }]>(),
+    validate: typia.createValidate<{ input: IPolygon }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/llama/test_llama_function_calling_optional.ts
+++ b/test/features/llm/llama/test_llama_function_calling_optional.ts
@@ -13,7 +13,7 @@ export const test_llama_function_calling_optional = () =>
     name: "registerMember",
     description: "Register a membership.",
     collection: typia.json.schemas<[{ input: IMember; note?: string }]>(),
-    validate: typia.createValidate<[{ input: IMember; note?: string }]>(),
+    validate: typia.createValidate<{ input: IMember; note?: string }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/llama/test_llama_function_calling_recursive.ts
+++ b/test/features/llm/llama/test_llama_function_calling_recursive.ts
@@ -10,7 +10,7 @@ export const test_llama_function_calling_recursive = () =>
     name: "composeCategories",
     description: "Compose categories from the input.",
     collection: typia.json.schemas<[{ input: IShoppingCategory[] }]>(),
-    validate: typia.createValidate<[{ input: IShoppingCategory[] }]>(),
+    validate: typia.createValidate<{ input: IShoppingCategory[] }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/llama/test_llama_function_calling_tags.ts
+++ b/test/features/llm/llama/test_llama_function_calling_tags.ts
@@ -10,7 +10,7 @@ export const test_llama_function_calling_tags = (): Promise<void> =>
     name: "reserve",
     description: "Reserve some opening time.",
     collection: typia.json.schemas<[{ input: OpeningTime }]>(),
-    validate: typia.createValidate<[{ input: OpeningTime }]>(),
+    validate: typia.createValidate<{ input: OpeningTime }>(),
     texts: [
       {
         role: "assistant",

--- a/test/features/llm/llama/test_llama_function_calling_union.ts
+++ b/test/features/llm/llama/test_llama_function_calling_union.ts
@@ -13,7 +13,7 @@ export const test_llama_function_calling_union = (): Promise<void> =>
     name: "draw",
     description: "Draw a shape with following geometry.",
     collection: typia.json.schemas<[{ input: Shape }]>(),
-    validate: typia.createValidate<[{ input: Shape }]>(),
+    validate: typia.createValidate<{ input: Shape }>(),
     texts: [
       {
         role: "assistant",


### PR DESCRIPTION
As OpenAI (ChatGPT) does not allow over 1,024 length description property on the tool calling's function definition, `@samchon/openapi` also blocks it on the `IHttpLlmApplication` composing process.

In the same way, `typia.llm.application<App, Model>()` and `typia.llm.applicationOfValidate<App, Model>()` functions will block the 1,024 length over description too.

-----------------

This pull request includes several changes to improve the handling of descriptions and validation in the `HttpLlmApplicationComposer` and related test files, as well as updates to JSON schema files. The most important changes include the addition of description length validation, reordering of JSON schema properties, and updates to test cases.

### Improvements to description handling and validation:

* [`src/composers/HttpLlmApplicationComposer.ts`](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffR177-R198): Added logic to handle operation descriptions, ensuring they are properly formatted and do not exceed 1024 characters. If the description is too long, an error is added to `props.errors`. [[1]](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffR177-R198) [[2]](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL189-R212) [[3]](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL204) [[4]](diffhunk://#diff-f527381cefd42fdd7de3e60a19289402d8ce0f8bf1f64442f5469e84cf68d9ffL220-R242)

### Updates to JSON schema files:

* [`examples/function-calling/schemas/claude.sale.schema.json`](diffhunk://#diff-cc50a42f8e4e6da316641688140045294f43b3cdcaddee30f2b242e72260a2d7L330-R339): Reordered the `required` property for units to ensure it appears after the `name` property. [[1]](diffhunk://#diff-cc50a42f8e4e6da316641688140045294f43b3cdcaddee30f2b242e72260a2d7L330-R339) [[2]](diffhunk://#diff-cc50a42f8e4e6da316641688140045294f43b3cdcaddee30f2b242e72260a2d7L349-R350) [[3]](diffhunk://#diff-cc50a42f8e4e6da316641688140045294f43b3cdcaddee30f2b242e72260a2d7L367)

### Test case updates:

* [`test/features/llm/chatgpt/test_chatgpt_function_calling_description_length.ts`](diffhunk://#diff-3468b3e3eaca64577dc1ec4fc4492e07f1eee7f10c77dea0cc36fe6d7db71673R1-R39): Added a new test case to validate that descriptions do not exceed 1024 characters.
* [`test/features/llm/chatgpt/test_chatgpt_function_calling_name_length.ts`](diffhunk://#diff-bd95ca07b7ca3f34a2ad3357a191a91b05a85e3ed64cc3be75ff984416a7debfR1-R39): Added a new test case to validate function names with a maximum length of 64 characters.
* Updated various test cases to correct the validation function call:
  * `test/features/llm/chatgpt/test_chatgpt_function_calling_additionalProperties.ts`
  * `test/features/llm/chatgpt/test_chatgpt_function_calling_example.ts`
  * `test/features/llm/chatgpt/test_chatgpt_function_calling_optional.ts`
  * `test/features/llm/chatgpt/test_chatgpt_function_calling_recursive.ts`
  * `test/features/llm/chatgpt/test_chatgpt_function_calling_union.ts`
  * `test/features/llm/claude/test_claude_function_calling_additionalProperties.ts`

### Other changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version number from `2.3.4` to `2.4.0`.