### PR TITLE
`ILlmFunction.ISeparated.llm` to be not null.

### DIFF
--- a/src/composers/llm/ChatGptSchemaComposer.ts
+++ b/src/composers/llm/ChatGptSchemaComposer.ts
@@ -200,7 +200,13 @@ export namespace ChatGptSchemaComposer {
     });
     if (llm === null || human === null)
       return {
-        llm: llm as IChatGptSchema.IParameters | null,
+        llm: (llm as IChatGptSchema.IParameters | null) ?? {
+          type: "object",
+          properties: {} as Record<string, IChatGptSchema>,
+          required: [],
+          additionalProperties: false,
+          $defs: {},
+        },
         human: human as IChatGptSchema.IParameters | null,
       };
     const output: ILlmFunction.ISeparated<"chatgpt"> = {

--- a/src/composers/llm/ClaudeSchemaComposer.ts
+++ b/src/composers/llm/ClaudeSchemaComposer.ts
@@ -45,8 +45,9 @@ export namespace ClaudeSchemaComposer {
   export const separateParameters = (props: {
     predicate: (schema: IClaudeSchema) => boolean;
     parameters: IClaudeSchema.IParameters;
-  }): ILlmFunction.ISeparated<"claude"> =>
-    LlmSchemaV3_1Composer.separateParameters(
-      props,
-    ) as any as ILlmFunction.ISeparated<"claude">;
+  }): ILlmFunction.ISeparated<"claude"> => {
+    const separated: ILlmFunction.ISeparated<"3.1"> =
+      LlmSchemaV3_1Composer.separateParameters(props);
+    return separated as any as ILlmFunction.ISeparated<"claude">;
+  };
 }

--- a/src/composers/llm/GeminiSchemaComposer.ts
+++ b/src/composers/llm/GeminiSchemaComposer.ts
@@ -109,13 +109,16 @@ export namespace GeminiSchemaComposer {
   export const separateParameters = (props: {
     predicate: (schema: IGeminiSchema) => boolean;
     parameters: IGeminiSchema.IParameters;
-  }): ILlmFunction.ISeparated<"gemini"> =>
-    LlmSchemaV3Composer.separateParameters(
-      props as {
-        predicate: (schema: ILlmSchemaV3) => boolean;
-        parameters: ILlmSchemaV3.IParameters;
-      },
-    ) as any as ILlmFunction.ISeparated<"gemini">;
+  }): ILlmFunction.ISeparated<"gemini"> => {
+    const separated: ILlmFunction.ISeparated<"3.0"> =
+      LlmSchemaV3Composer.separateParameters(
+        props as {
+          predicate: (schema: ILlmSchemaV3) => boolean;
+          parameters: ILlmSchemaV3.IParameters;
+        },
+      );
+    return separated as any as ILlmFunction.ISeparated<"gemini">;
+  };
 }
 
 const isOneOf =

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -170,7 +170,15 @@ export namespace LlmSchemaV3Composer {
       predicate: props.predicate,
       schema: props.parameters,
     });
-    return { llm, human } as ILlmFunction.ISeparated<"3.0">;
+    return {
+      llm: (llm as ILlmSchemaV3.IParameters | null) ?? {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+        required: [],
+      },
+      human: human as ILlmSchemaV3.IParameters | null,
+    };
   };
 
   const separateStation = (props: {

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -339,7 +339,13 @@ export namespace LlmSchemaV3_1Composer {
     });
     if (llm === null || human === null)
       return {
-        llm: llm as ILlmSchemaV3_1.IParameters | null,
+        llm: (llm as ILlmSchemaV3_1.IParameters | null) ?? {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+          required: [],
+          $defs: {},
+        },
         human: human as ILlmSchemaV3_1.IParameters | null,
       };
     const output: ILlmFunction.ISeparated<"3.1"> = {

--- a/src/structures/IHttpLlmFunction.ts
+++ b/src/structures/IHttpLlmFunction.ts
@@ -216,8 +216,11 @@ export namespace IHttpLlmFunction {
   export interface ISeparated<Model extends ILlmSchema.Model> {
     /**
      * Parameters that would be composed by the LLM.
+     *
+     * Even though no property exists in the LLM side, the `llm` property
+     * would have at least empty object type.
      */
-    llm: ILlmSchema.ModelParameters[Model] | null;
+    llm: ILlmSchema.ModelParameters[Model];
 
     /**
      * Parameters that would be composed by the human.

--- a/src/structures/ILlmFunction.ts
+++ b/src/structures/ILlmFunction.ts
@@ -84,8 +84,11 @@ export namespace ILlmFunction {
   export interface ISeparated<Model extends ILlmSchema.Model> {
     /**
      * Parameters that would be composed by the LLM.
+     *
+     * Even though no property exists in the LLM side, the `llm` property
+     * would have at least empty object type.
      */
-    llm: ILlmSchema.ModelParameters[Model] | null;
+    llm: ILlmSchema.ModelParameters[Model];
 
     /**
      * Parameters that would be composed by the human.

--- a/test/features/llm/validate_llm_parameters_separate_array.ts
+++ b/test/features/llm/validate_llm_parameters_separate_array.ts
@@ -63,7 +63,13 @@ const validate_llm_parameters_separate_array = <Model extends ILlmSchema.Model>(
     human: null,
   });
   TestValidator.equals("upload")(separator(upload))({
-    llm: null,
+    llm: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+      required: [],
+      $defs: {},
+    },
     human: upload,
   });
   TestValidator.equals("combined")(separator(combined))({

--- a/test/features/llm/validate_llm_parameters_separate_nested.ts
+++ b/test/features/llm/validate_llm_parameters_separate_nested.ts
@@ -65,7 +65,13 @@ const validate_llm_parameters_separate_nested = <
     human: null,
   });
   TestValidator.equals("upload")(separator(upload))({
-    llm: null,
+    llm: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+      required: [],
+      $defs: {},
+    },
     human: upload,
   });
   TestValidator.equals("combined")(separator(combined))({

--- a/test/features/llm/validate_llm_parameters_separate_object.ts
+++ b/test/features/llm/validate_llm_parameters_separate_object.ts
@@ -65,7 +65,13 @@ const validate_llm_parameters_separate_object = <
     human: null,
   });
   TestValidator.equals("upload")(separator(upload))({
-    llm: null,
+    llm: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+      required: [],
+      $defs: {},
+    },
     human: upload,
   });
   TestValidator.equals("combined")(separator(combined))({

--- a/test/features/llm/validate_llm_parameters_separate_ref.ts
+++ b/test/features/llm/validate_llm_parameters_separate_ref.ts
@@ -58,7 +58,13 @@ const validate_llm_parameters_separate_ref = <
     human: null,
   });
   TestValidator.equals("upload")(separator(upload))({
-    llm: null,
+    llm: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+      required: [],
+      $defs: {},
+    },
     human: upload,
   });
   TestValidator.equals("combined")({

--- a/test/features/llm/validate_llm_schema_separate_string.ts
+++ b/test/features/llm/validate_llm_schema_separate_string.ts
@@ -74,7 +74,13 @@ const validate_llm_schema_separate_string = <Model extends ILlmSchema.Model>(
     human: null,
   });
   TestValidator.equals("upload")(separator(upload))({
-    llm: null,
+    llm: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+      required: [],
+      $defs: {},
+    },
     human: upload,
   });
 };


### PR DESCRIPTION
Even though no property exists in the LLM side (properties exist only in the Human side), the `ILlmFunction.ISeparated.llm` property value should be not null for covenience.

This PR enforces the `ILlmFunction.ISeparated.llm` not to be `null`.