### PR TITLE
Fix #127: ChatGPT and Gemini schema had dropped enum typed description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",
@@ -75,7 +75,7 @@
     "tstl": "^3.0.0",
     "typescript": "~5.7.2",
     "typescript-transform-paths": "^3.5.2",
-    "typia": "7.3.0",
+    "typia": "7.6.0",
     "uuid": "^10.0.0"
   },
   "sideEffects": false,

--- a/src/composers/llm/ChatGptSchemaComposer.ts
+++ b/src/composers/llm/ChatGptSchemaComposer.ts
@@ -176,7 +176,7 @@ export namespace ChatGptSchemaComposer {
         ...union[0],
         description: ChatGptTypeChecker.isReference(union[0]!)
           ? undefined
-          : union[0].description,
+          : (union[0].description ?? attribute.description),
       };
     return {
       ...attribute,

--- a/src/utils/internal/OpenApiTypeCheckerBase.ts
+++ b/src/utils/internal/OpenApiTypeCheckerBase.ts
@@ -359,7 +359,7 @@ export namespace OpenApiTypeCheckerBase {
       ) as OpenApi.IJsonSchema[];
       if (filtered.length === 0) return undefined;
       return {
-        ...props,
+        ...props.schema,
         oneOf: filtered
           .map((v) =>
             flatSchema({

--- a/test/features/issues/test_issue_127_enum_description.ts
+++ b/test/features/issues/test_issue_127_enum_description.ts
@@ -1,0 +1,32 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_issue_127_enum_description = (): void => {
+  const collection: IJsonSchemaCollection = typia.json.schemas<[ISomething]>();
+  const chatgpt = LlmSchemaComposer.parameters("chatgpt")({
+    config: LlmSchemaComposer.defaultConfig("chatgpt"),
+    components: collection.components,
+    schema: collection.schemas[0] as OpenApi.IJsonSchema.IReference,
+  });
+  TestValidator.equals("description")(
+    chatgpt.success ? chatgpt.value.properties.value.description : "",
+  )("The description.");
+
+  const gemini = LlmSchemaComposer.parameters("gemini")({
+    config: LlmSchemaComposer.defaultConfig("gemini"),
+    components: collection.components,
+    schema: collection.schemas[0] as OpenApi.IJsonSchema.IReference,
+  });
+  TestValidator.equals("description")(
+    gemini.success ? gemini.value.properties.value.description : "",
+  )("The description.");
+};
+
+interface ISomething {
+  /**
+   * The description.
+   */
+  value: 1 | 2 | 3;
+}


### PR DESCRIPTION
This pull request includes several updates and improvements to the `@samchon/openapi` package, including version updates, bug fixes, and the addition of a new test case.

### Version updates:
* Updated the package version from `2.4.0` to `2.4.1` in `package.json`.
* Updated the `typia` dependency version from `7.3.0` to `7.6.0` in `package.json`.

### Bug fixes:
* Modified `ChatGptSchemaComposer` to use `attribute.description` as a fallback if `union[0].description` is undefined.
* Updated `OpenApiTypeCheckerBase` to spread `props.schema` instead of `props`.

### New test case:
* Added a new test case `test_issue_127_enum_description` to verify the description handling in enum schemas.