### PR TITLE
Website publishing

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,26 @@
+name: website
+on: 
+  push: 
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'website/**'
+      - 'package.json'
+jobs:
+  website:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Install dependencies
+        run: npm install
+      - name: Build TypeDoc
+        run: npm run typedoc && npm run typedoc -- --json website/public/api/openapi.json
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        with:
+          branch: gh-pages
+          folder: ./website/public

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ examples/converted/
 lib/
 models/
 node_modules/
+website/public/api/
 
 package-lock.json
 pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ flowchart
 [![npm version](https://img.shields.io/npm/v/@samchon/openapi.svg)](https://www.npmjs.com/package/@samchon/openapi)
 [![Downloads](https://img.shields.io/npm/dm/@samchon/openapi.svg)](https://www.npmjs.com/package/@samchon/openapi)
 [![Build Status](https://github.com/samchon/openapi/workflows/build/badge.svg)](https://github.com/samchon/openapi/actions?query=workflow%3Abuild)
-[![API Documents](https://img.shields.io/badge/API-Documents-forestgreen)](https://nestia.io/api/modules/_samchon_openapi.html)
+[![API Documents](https://img.shields.io/badge/API-Documents-forestgreen)](https://samchon.github.io/api/)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
 
 OpenAPI definitions, converters and LLM function calling application composer.
@@ -32,19 +32,19 @@ OpenAPI definitions, converters and LLM function calling application composer.
   3. [OpenAPI v3.1](https://github.com/samchon/openapi/blob/master/src/OpenApiV3_1.ts)
   4. [**OpenAPI v3.1 emended**](https://github.com/samchon/openapi/blob/master/src/OpenApi.ts)
 
-`@samchon/openapi` also provides LLM (Large Language Model) function calling application composer from the OpenAPI document with many strategies. With the [`HttpLlm`](https://nestia.io/api/modules/_samchon_openapi.HttpLlm.html) module, you can perform the LLM function calling extremely easily just by delivering the OpenAPI (Swagger) document.
+`@samchon/openapi` also provides LLM (Large Language Model) function calling application composer from the OpenAPI document with many strategies. With the [`HttpLlm`](https://samchon.github.io/api/modules/HttpLlm.html) module, you can perform the LLM function calling extremely easily just by delivering the OpenAPI (Swagger) document.
 
-  - [`HttpLlm.application()`](https://nestia.io/api/functions/_samchon_openapi.HttpLlm.application.html)
-  - [`IHttpLlmApplication<Model>`](https://nestia.io/api/interfaces/_samchon_openapi.IHttpLlmApplication-1.html)
-  - [`IHttpLlmFunction<Model>`](https://nestia.io/api/interfaces/_samchon_openapi.IHttpLlmFunction-1.html)
+  - [`HttpLlm.application()`](https://samchon.github.io/api/functions/HttpLlm.application.html)
+  - [`IHttpLlmApplication<Model>`](https://samchon.github.io/api/interfaces/IHttpLlmApplication-1.html)
+  - [`IHttpLlmFunction<Model>`](https://samchon.github.io/api/interfaces/IHttpLlmFunction-1.html)
   - Supported schemas
-    - [`IChatGptSchema`](https://nestia.io/api/types/_samchon_openapi.IChatGptSchema-1.html): OpenAI ChatGPT
-    - [`IClaudeSchema`](https://nestia.io/api/types/_samchon_openapi.IClaudeSchema-1.html): Anthropic Claude
-    - [`IGeminiSchema`](https://nestia.io/api/types/_samchon_openapi.IGeminiSchema-1.html): Google Gemini
-    - [`ILlamaSchema`](https://nestia.io/api/types/_samchon_openapi.ILlamaSchema-1.html): Meta Llama
+    - [`IChatGptSchema`](https://samchon.github.io/api/types/IChatGptSchema-1.html): OpenAI ChatGPT
+    - [`IClaudeSchema`](https://samchon.github.io/api/types/IClaudeSchema-1.html): Anthropic Claude
+    - [`IGeminiSchema`](https://samchon.github.io/api/types/IGeminiSchema-1.html): Google Gemini
+    - [`ILlamaSchema`](https://samchon.github.io/api/types/ILlamaSchema-1.html): Meta Llama
   - Midldle layer schemas
-    - [`ILlmSchemaV3`](https://nestia.io/api/types/_samchon_openapi.ILlmSchemaV3-1.html): middle layer based on OpenAPI v3.0 specification
-    - [`ILlmSchemaV3_1`](https://nestia.io/api/types/_samchon_openapi.ILlmSchemaV3_1-1.html): middle layer based on OpenAPI v3.1 specification
+    - [`ILlmSchemaV3`](https://samchon.github.io/api/types/ILlmSchemaV3-1.html): middle layer based on OpenAPI v3.0 specification
+    - [`ILlmSchemaV3_1`](https://samchon.github.io/api/types/ILlmSchemaV3_1-1.html): middle layer based on OpenAPI v3.1 specification
 
 > https://github.com/user-attachments/assets/01604b53-aca4-41cb-91aa-3faf63549ea6
 >
@@ -225,21 +225,21 @@ LLM function calling application from OpenAPI document.
 
 `@samchon/openapi` provides LLM (Large Language Model) function calling application from the "emended OpenAPI v3.1 document". Therefore, if you have any HTTP backend server and succeeded to build an OpenAPI document, you can easily make the A.I. chatbot application.
 
-In the A.I. chatbot, LLM will select proper function to remotely call from the conversations with user, and fill arguments of the function automatically. If you actually execute the function call through the [`HttpLlm.execute()`](https://nestia.io/api/functions/_samchon_openapi.HttpLlm.execute.html) function, it is the "LLM function call."
+In the A.I. chatbot, LLM will select proper function to remotely call from the conversations with user, and fill arguments of the function automatically. If you actually execute the function call through the [`HttpLlm.execute()`](https://samchon.github.io/api/functions/HttpLlm.execute.html) function, it is the "LLM function call."
 
 Let's enjoy the fantastic LLM function calling feature very easily with `@samchon/openapi`.
 
   - Application
-    - [`HttpLlm.application()`](https://nestia.io/api/functions/_samchon_openapi.HttpLlm.application.html)
-    - [`IHttpLlmApplication`](https://nestia.io/api/interfaces/_samchon_openapi.IHttpLlmApplication-1.html)
-    - [`IHttpLlmFunction`](https://nestia.io/api/interfaces/_samchon_openapi.IHttpLlmFunction-1.html)
+    - [`HttpLlm.application()`](https://samchon.github.io/api/functions/HttpLlm.application.html)
+    - [`IHttpLlmApplication`](https://samchon.github.io/api/interfaces/IHttpLlmApplication-1.html)
+    - [`IHttpLlmFunction`](https://samchon.github.io/api/interfaces/IHttpLlmFunction-1.html)
   - Schemas
-    - [`IChatGptSchema`](https://nestia.io/api/types/_samchon_openapi.IChatGptSchema-1.html): OpenAI ChatGPT
-    - [`IClaudeSchema`](https://nestia.io/api/types/_samchon_openapi.IClaudeSchema-1.html): Anthropic Claude
-    - [`IGeminiSchema`](https://nestia.io/api/types/_samchon_openapi.IGeminiSchema-1.html): Google Gemini
-    - [`ILlamaSchema`](https://nestia.io/api/types/_samchon_openapi.ILlamaSchema-1.html): Meta Llama
-    - [`ILlmSchemaV3`](https://nestia.io/api/types/_samchon_openapi.ILlmSchemaV3-1.html): middle layer based on OpenAPI v3.0 specification
-    - [`ILlmSchemaV3_1`](https://nestia.io/api/types/_samchon_openapi.ILlmSchemaV3_1-1.html): middle layer based on OpenAPI v3.1 specification
+    - [`IChatGptSchema`](https://samchon.github.io/api/types/IChatGptSchema-1.html): OpenAI ChatGPT
+    - [`IClaudeSchema`](https://samchon.github.io/api/types/IClaudeSchema-1.html): Anthropic Claude
+    - [`IGeminiSchema`](https://samchon.github.io/api/types/IGeminiSchema-1.html): Google Gemini
+    - [`ILlamaSchema`](https://samchon.github.io/api/types/ILlamaSchema-1.html): Meta Llama
+    - [`ILlmSchemaV3`](https://samchon.github.io/api/types/ILlmSchemaV3-1.html): middle layer based on OpenAPI v3.0 specification
+    - [`ILlmSchemaV3_1`](https://samchon.github.io/api/types/ILlmSchemaV3_1-1.html): middle layer based on OpenAPI v3.1 specification
   - Type Checkers
     - [`ChatGptTypeChecker`](https://github.com/samchon/openapi/blob/master/src/utils/ChatGptTypeChecker.ts)
     - [`ClaudeTypeChecker`](https://github.com/samchon/openapi/blob/master/src/utils/ClaudeTypeChecker.ts)
@@ -250,7 +250,7 @@ Let's enjoy the fantastic LLM function calling feature very easily with `@samcho
 
 > [!NOTE]
 >
-> You also can compose [`ILlmApplication`](https://nestia.io/api/interfaces/_samchon_openapi.ILlmApplication-1.html) from a class type with `typia`.
+> You also can compose [`ILlmApplication`](https://samchon.github.io/api/interfaces/ILlmApplication-1.html) from a class type with `typia`.
 >
 > https://typia.io/docs/llm/application
 >
@@ -275,7 +275,7 @@ Actual function call execution is by yourself.
 
 LLM (Large Language Model) providers like OpenAI selects a proper function to call from the conversations with users, and fill arguments of it. However, function calling feature supported by LLM providers do not perform the function call execution. The actual execution responsibility is on you.
 
-In `@samchon/openapi`, you can execute the LLM function calling by [`HttpLlm.execute()`](https://nestia.io/api/functions/_samchon_openapi.HttpLlm.execute.html) (or [`HttpLlm.propagate()`](https://nestia.io/api/functions/_samchon_openapi.HttpLlm.propagate.html)) function. Here is an example code executing the LLM function calling through the [`HttpLlm.execute()`](https://nestia.io/api/functions/_samchon_openapi.HttpLlm.execute.html) function. As you can see, to execute the LLM function call, you have to deliver these information:
+In `@samchon/openapi`, you can execute the LLM function calling by [`HttpLlm.execute()`](https://samchon.github.io/api/functions/HttpLlm.execute.html) (or [`HttpLlm.propagate()`](https://samchon.github.io/api/functions/HttpLlm.propagate.html)) function. Here is an example code executing the LLM function calling through the [`HttpLlm.execute()`](https://samchon.github.io/api/functions/HttpLlm.execute.html) function. As you can see, to execute the LLM function call, you have to deliver these information:
 
   - Connection info to the HTTP server
   - Application of the LLM function calling
@@ -382,7 +382,7 @@ Arguments from both Human and LLM sides.
 
 When composing parameter arguments through the LLM (Large Language Model) function calling, there can be a case that some parameters (or nested properties) must be composed not by LLM, but by Human. File uploading feature, or sensitive information like secret key (password) cases are the representative examples.
 
-In that case, you can configure the LLM function calling schemas to exclude such Human side parameters (or nested properties) by `IHttpLlmApplication.options.separate` property. Instead, you have to merge both Human and LLM composed parameters into one by calling the [`HttpLlm.mergeParameters()`](https://nestia.io/api/functions/_samchon_openapi.HttpLlm.mergeParameters.html) before the LLM function call execution of [`HttpLlm.execute()`](https://nestia.io/api/functions/_samchon_openapi.HttpLlm.execute.html) function.
+In that case, you can configure the LLM function calling schemas to exclude such Human side parameters (or nested properties) by `IHttpLlmApplication.options.separate` property. Instead, you have to merge both Human and LLM composed parameters into one by calling the [`HttpLlm.mergeParameters()`](https://samchon.github.io/api/functions/HttpLlm.mergeParameters.html) before the LLM function call execution of [`HttpLlm.execute()`](https://samchon.github.io/api/functions/HttpLlm.execute.html) function.
 
 Here is the example code separating the file uploading feature from the LLM function calling schema, and combining both Human and LLM composed parameters into one before the LLM function call execution.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",
@@ -11,7 +11,8 @@
     "build:main": "rimraf lib && tsc && rollup -c",
     "build:test": "rimraf bin && tsc -p test/tsconfig.json",
     "dev": "npm run build:test -- --watch",
-    "test": "node bin/test"
+    "test": "node bin/test",
+    "typedoc": "typedoc --plugin typedoc-github-theme --theme typedoc-github-theme"
   },
   "keywords": [
     "swagger",
@@ -40,7 +41,7 @@
   "bugs": {
     "url": "https://github.com/samchon/openapi/issues"
   },
-  "homepage": "https://nestia.io/api/modules/_samchon_openapi.html",
+  "homepage": "https://samchon.github.io/openapi/api",
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
     "@google/generative-ai": "^0.21.0",
@@ -73,6 +74,8 @@
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
     "tstl": "^3.0.0",
+    "typedoc": "^0.27.6",
+    "typedoc-github-theme": "^0.2.1",
     "typescript": "~5.7.2",
     "typescript-transform-paths": "^3.5.2",
     "typia": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.4.3",
+  "version": "2.4.2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,4 +2,5 @@
   "$schema": "https://typedoc.org/schema.json",
   "tsconfig": "tsconfig.json",
   "entryPoints": ["src/index.ts"],
+  "out": "./website/public/api",
 }

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -1,0 +1,41 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>@samchon/openapi</title>
+  </head>
+  <body>
+    <h2>@samchon/openapi</h2>
+    <hr/>
+    <h3>
+      <a href="https://github.com/samchon/openapi">Github Repository</a>
+    </h3>
+    <h3>
+      <a href="./api/">API Documents</a>
+    </h3>
+    <br/>
+
+    <h2>Demonstration Cases</h2>
+    <hr/>
+    <h3>Shopping Chat</h3>
+    <iframe 
+      src="https://www.youtube.com/embed/m47p4iJ90Ms?si=cvgfckN25GJhjLTB" 
+      title="Shopping A.I. Chatbot built with Nestia" 
+      width="100%" 
+      height="600" 
+      frameborder="0" 
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" 
+      allowfullscreen
+    ></iframe>
+    <br/><br/>
+    <h3>BBS Chat</h3>
+    <iframe 
+      src="https://www.youtube.com/embed/pdsplQyok8k?si=geL7DH5CWcC8qlz_" 
+      title="Shopping A.I. Chatbot built with Typia" 
+      width="100%" 
+      height="600" 
+      frameborder="0" 
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" 
+      allowfullscreen 
+    ></iframe>
+  </body>
+</html>


### PR DESCRIPTION
This pull request includes several changes to automate the website deployment process and update documentation links. The most important changes include adding a GitHub Actions workflow for website deployment, updating API documentation links in the `README.md` file, and adding TypeDoc configurations and dependencies.

### Automation and Deployment:
* [`.github/workflows/website.yml`](diffhunk://#diff-c7731b29de71fca225e1dfac88ebe31975a4cd9759ab13e91d86eeadafbddc10R1-R26): Added a new GitHub Actions workflow to automate the deployment of the website on changes to specific files in the `master` branch. The workflow installs dependencies, builds TypeDoc, and deploys to the `gh-pages` branch.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23): Updated all API documentation links to point to the new GitHub Pages URL (`https://samchon.github.io/api/`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R47) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L228-R242) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L253-R253) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L278-R278) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L385-R385)

### TypeDoc Configuration:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R15): Added TypeDoc and TypeDoc GitHub theme dependencies and scripts for generating documentation. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R15) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R77-R78)
* [`typedoc.json`](diffhunk://#diff-6169a21f84f4d19da38a12219c19778338487973f106b9dad94370e66e1c8c1aR5): Configured TypeDoc to output documentation to `./website/public/api`.

### Website Content:
* [`website/public/index.html`](diffhunk://#diff-a3a517a60cf4924acd29ad304dd43b39cd32d06a667aedc9538889ee2c7ee91bR1-R41): Added a new HTML file for the website's main page, including links to the GitHub repository and API documents, as well as embedded YouTube demonstration videos.