### PR TITLE
missing esm module build

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "prettier": "^3.2.5",
     "rimraf": "^5.0.5",
     "rollup": "^4.18.1",
+    "rollup-plugin-auto-external": "^2.0.0",
     "source-map-support": "^0.5.21",
     "tinyglobby": "^0.2.10",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "rimraf": "^5.0.5",
     "rollup": "^4.18.1",
     "source-map-support": "^0.5.21",
+    "tinyglobby": "^0.2.10",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
     "tstl": "^3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,9 @@
 const typescript = require("@rollup/plugin-typescript");
 const terser = require("@rollup/plugin-terser");
+const { globSync } = require("tinyglobby");
 
 module.exports = {
-  input: "./src/index.ts",
+  input: globSync("./src/**/*.ts"),
   output: {
     dir: "lib",
     format: "esm",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 const typescript = require("@rollup/plugin-typescript");
 const terser = require("@rollup/plugin-terser");
+const autoExternal = require("rollup-plugin-auto-external");
 const { globSync } = require("tinyglobby");
 
 module.exports = {
@@ -13,6 +14,7 @@ module.exports = {
     preserveModulesRoot: "src",
   },
   plugins: [
+    autoExternal(),
     typescript({
       tsconfig: "tsconfig.json",
       module: "ES2020",


### PR DESCRIPTION
This pull request includes updates to the build configuration and dependencies to improve the build process.

This needs esm build for typia

Dependency updates:
* Added `tinyglobby` version `^0.2.10` to the `package.json` file.

Build configuration updates:
* Modified `rollup.config.js` to use `tinyglobby` for input file globbing instead of a single entry point.