### PR TITLE
Add `IJsonSchemaAttribute`.

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     paths:
+      - README.md
       - 'src/**'
       - 'website/**'
       - 'package.json'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.4.2",
+  "version": "3.0.0-dev.20250211",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "3.0.0-dev.20250211",
+  "version": "2.5.0-dev.20250211",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -6,6 +6,7 @@ import { OpenApiV3Upgrader } from "./converters/OpenApiV3Upgrader";
 import { OpenApiV3_1Emender } from "./converters/OpenApiV3_1Emender";
 import { SwaggerV2Downgrader } from "./converters/SwaggerV2Downgrader";
 import { SwaggerV2Upgrader } from "./converters/SwaggerV2Upgrader";
+import { IJsonSchemaAttribute } from "./structures/IJsonSchemaAttribute";
 
 /**
  * Emended OpenAPI v3.1 definition used by `typia` and `nestia`.
@@ -1106,32 +1107,7 @@ export namespace OpenApi {
     /**
      * Common attributes that can be applied to all types.
      */
-    export interface __IAttribute {
-      /**
-       * Title of the schema.
-       */
-      title?: string;
-
-      /**
-       * Detailed description of the schema.
-       */
-      description?: string;
-
-      /**
-       * Whether the type is deprecated or not.
-       */
-      deprecated?: boolean;
-
-      /**
-       * Example value.
-       */
-      example?: any;
-
-      /**
-       * List of example values as key-value pairs.
-       */
-      examples?: Record<string, any>;
-    }
+    export type __IAttribute = IJsonSchemaAttribute;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from "./SwaggerV2";
 export * from "./OpenApiV3";
 export * from "./OpenApiV3_1";
 
+export * from "./structures/IJsonSchemaAttribute";
 export * from "./utils/OpenApiTypeChecker";
 
 //----

--- a/src/structures/IChatGptSchema.ts
+++ b/src/structures/IChatGptSchema.ts
@@ -1,3 +1,5 @@
+import { IJsonSchemaAttribute } from "./IJsonSchemaAttribute";
+
 /**
  * Type schema info of the ChatGPT.
  *
@@ -279,32 +281,7 @@ export namespace IChatGptSchema {
   /**
    * Common attributes that can be applied to all types.
    */
-  export interface __IAttribute {
-    /**
-     * Title of the schema.
-     */
-    title?: string;
-
-    /**
-     * Detailed description of the schema.
-     */
-    description?: string;
-
-    /**
-     * Whether the type is deprecated or not.
-     */
-    deprecated?: boolean;
-
-    /**
-     * Example value.
-     */
-    example?: any;
-
-    /**
-     * List of example values as key-value pairs.
-     */
-    examples?: Record<string, any>;
-  }
+  export type __IAttribute = IJsonSchemaAttribute;
 
   /**
    * Configuration for ChatGPT schema composition.

--- a/src/structures/IGeminiSchema.ts
+++ b/src/structures/IGeminiSchema.ts
@@ -1,3 +1,5 @@
+import { IJsonSchemaAttribute } from "./IJsonSchemaAttribute";
+
 /**
  * Type schema info for the Gemini function calling.
  *
@@ -226,33 +228,7 @@ export namespace IGeminiSchema {
   /**
    * Common attributes that can be applied to all types.
    */
-  export interface __IAttribute {
-    /**
-     * Detailed description of the schema.
-     */
-    description?: string;
-
-    /**
-     * Whether the type is deprecated or not.
-     *
-     * @warning document of Gemini says not supported, but cannot sure
-     */
-    deprecated?: boolean;
-
-    /**
-     * Example value.
-     *
-     * @warning document of Gemini says not supported, but cannot sure
-     */
-    example?: any;
-
-    /**
-     * List of example values as key-value pairs.
-     *
-     * @warning document of Gemini says not supported, but cannot sure
-     */
-    examples?: Record<string, any>;
-  }
+  export type __IAttribute = IJsonSchemaAttribute;
 
   /**
    * Configuration for the Gemini schema composition.

--- a/src/structures/IJsonSchemaAttribute.ts
+++ b/src/structures/IJsonSchemaAttribute.ts
@@ -1,0 +1,60 @@
+/**
+ * Common attributes for JSON schema types.
+ *
+ * `IJsonSchemaAttribute` is a common interface for all JSON schema types
+ * supported in here `@samchon/openapi`. Here is the list of affected JSON
+ * schema types in `@samchon/openapi`, and you can extend the interface by
+ * declaring module augmentation.
+ *
+ * - {@link OpenApi.IJsonSchema}
+ * - {@link IChatGptSchema}
+ * - {@link IClaudeSchema}
+ * - {@link IGeminiSchema}
+ * - {@link ILlmSchemaV3}
+ * - {@link ILlmSchemaV3_1}
+ *
+ * For example, if you extend the `IJsonSchemaAttribute` interface like
+ * below, every JSON schema types in `@samchon/openapi` will have a new
+ * custom attribute `x-wrtn-placeholder`.
+ *
+ * ```typescript
+ * declare module "@samchon/openapi" {
+ *   export interface IJsonSchemaAttribute {
+ *     /// Placeholder value for frontend application
+ *     ///
+ *     /// Placeholder ia label shown in the input field as a hint.
+ *     /// For example, when an email input field exists, the label
+ *     /// value would be "Insert your email address here".
+ *     "x-wrtn-placeholder"?: string;
+ *   }
+ * }
+ * ```
+ *
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+export interface IJsonSchemaAttribute {
+  /**
+   * Title of the schema.
+   */
+  title?: string;
+
+  /**
+   * Detailed description of the schema.
+   */
+  description?: string;
+
+  /**
+   * Whether the type is deprecated or not.
+   */
+  deprecated?: boolean;
+
+  /**
+   * Example value.
+   */
+  example?: any;
+
+  /**
+   * List of example values as key-value pairs.
+   */
+  examples?: Record<string, any>;
+}

--- a/src/structures/ILlmSchemaV3.ts
+++ b/src/structures/ILlmSchemaV3.ts
@@ -1,3 +1,5 @@
+import { IJsonSchemaAttribute } from "./IJsonSchemaAttribute";
+
 /**
  * Type schema based on OpenAPI v3.0 for LLM function calling.
  *
@@ -435,32 +437,7 @@ export namespace ILlmSchemaV3 {
   /**
    * Common attributes that can be applied to all types.
    */
-  export interface __IAttribute {
-    /**
-     * Title of the schema.
-     */
-    title?: string;
-
-    /**
-     * Detailed description of the schema.
-     */
-    description?: string;
-
-    /**
-     * Whether the type is deprecated or not.
-     */
-    deprecated?: boolean;
-
-    /**
-     * Example value.
-     */
-    example?: any;
-
-    /**
-     * List of example values as key-value pairs.
-     */
-    examples?: Record<string, any>;
-  }
+  export type __IAttribute = IJsonSchemaAttribute;
 
   /**
    * Configuration for OpenAPI v3.0 based LLM schema composition.

--- a/src/structures/ILlmSchemaV3_1.ts
+++ b/src/structures/ILlmSchemaV3_1.ts
@@ -1,3 +1,5 @@
+import { IJsonSchemaAttribute } from "./IJsonSchemaAttribute";
+
 /**
  * Type schema based on OpenAPI v3.1 for LLM function calling.
  *
@@ -478,32 +480,7 @@ export namespace ILlmSchemaV3_1 {
   /**
    * Common attributes that can be applied to all types.
    */
-  export interface __IAttribute {
-    /**
-     * Title of the schema.
-     */
-    title?: string;
-
-    /**
-     * Detailed description of the schema.
-     */
-    description?: string;
-
-    /**
-     * Whether the type is deprecated or not.
-     */
-    deprecated?: boolean;
-
-    /**
-     * Example value.
-     */
-    example?: any;
-
-    /**
-     * List of example values as key-value pairs.
-     */
-    examples?: Record<string, any>;
-  }
+  export type __IAttribute = IJsonSchemaAttribute;
 
   /**
    * Configuration for OpenAPI v3.1 based LLM schema composition.


### PR DESCRIPTION
This pull request includes several changes to the `@samchon/openapi` package, focusing on updating the version, improving the schema attributes, and modifying the build process. The most important changes include updating the package version, consolidating schema attributes into a single interface, and updating the build configuration.

Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version to `3.0.0-dev.20250211`.

Schema attribute consolidation:
* [`src/structures/IJsonSchemaAttribute.ts`](diffhunk://#diff-e40ad09196e68da5724a1fd81ff44626c8d2d62a79a7e5a536f49d99a3004273R1-R60): Introduced a new `IJsonSchemaAttribute` interface to provide common attributes for JSON schema types.
* [`src/OpenApi.ts`](diffhunk://#diff-77f34fd23e2eddbd1b3ebc491255409ecceb4df2c22af81356d4788b4379efbcL1109-R1110): Replaced the `__IAttribute` interface with the `IJsonSchemaAttribute` type.
* `src/structures/IChatGptSchema.ts`, `src/structures/IGeminiSchema.ts`, `src/structures/ILlmSchemaV3.ts`, `src/structures/ILlmSchemaV3_1.ts`: Updated to use the `IJsonSchemaAttribute` type instead of individual attribute interfaces. [[1]](diffhunk://#diff-e3f5f136085423d1963db8ab983cc4962935d5b88b9687ad5ff9ee8631971d28L282-R284) [[2]](diffhunk://#diff-60308e178c2c9db8031f57981b28f49d4b3815728f5b0f91d863ba3de59b0e41L229-R231) [[3]](diffhunk://#diff-a83bad0fda93321814c4ce21df194a9e142cf63a291737fbedee22d69536bd42L438-R440) [[4]](diffhunk://#diff-72e41eeadd5016cdfe8a554caae2e2bb215b4b929ff01b52fa5f79efd14bd3abL481-R483)

Build configuration update:
* [`.github/workflows/website.yml`](diffhunk://#diff-c7731b29de71fca225e1dfac88ebe31975a4cd9759ab13e91d86eeadafbddc10R7): Added `README.md` to the paths to trigger the workflow.

These changes aim to streamline the schema attribute definitions and ensure consistency across different schema types, while also updating the package version and improving the build process.