### PR TITLE
Fix dangerous URL composition rule.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/http/HttpMigrateRouteFetcher.ts
+++ b/src/http/HttpMigrateRouteFetcher.ts
@@ -81,12 +81,12 @@ const _Propagate = async (
     ) as any;
 
   // DO REQUEST
-  const path: string =
-    props.connection.host[props.connection.host.length - 1] !== "/" &&
-    props.route.path[0] !== "/"
+  const resolvedPath: string =
+    props.connection.host.endsWith("/") === false &&
+    props.route.emendedPath.startsWith("/") === false
       ? `/${getPath(props)}`
       : getPath(props);
-  const url: URL = new URL(`${props.connection.host}/${path}`);
+  const url: URL = new URL(`${props.connection.host}${resolvedPath}`);
 
   const response: Response = await (props.connection.fetch ?? fetch)(url, init);
   const status: number = response.status;


### PR DESCRIPTION
This pull request includes a version update and a code improvement in the `HttpMigrateRouteFetcher` module. The most important changes are:

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `2.4.2` to `2.4.3`.

### Code Improvement:
* [`src/http/HttpMigrateRouteFetcher.ts`](diffhunk://#diff-e147f1a12a63eec2e3d5a1577f3820cefc0b8c86817f0f573e588df00ab63f48L84-R89): Refactored the path resolution logic in the `_Propagate` function for better readability and maintainability. The variables `path` and `url` were replaced with `resolvedPath` and a more concise URL construction.