### PR TITLE
New function `LlmSchemaComposer.invert()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/LlmSchemaComposer.ts
+++ b/src/composers/LlmSchemaComposer.ts
@@ -35,6 +35,9 @@ export namespace LlmSchemaComposer {
     model: Model,
   ) => SEPARATE_PARAMETERS[model];
 
+  export const invert = <Model extends ILlmSchema.Model>(model: Model) =>
+    INVERTS[model];
+
   /**
    * @internal
    */
@@ -68,6 +71,15 @@ const SEPARATE_PARAMETERS = {
   llama: LlamaSchemaComposer.separateParameters,
   "3.0": LlmSchemaV3Composer.separateParameters,
   "3.1": LlmSchemaV3_1Composer.separateParameters,
+};
+
+const INVERTS = {
+  chatgpt: ChatGptSchemaComposer.invert,
+  claude: ClaudeSchemaComposer.invert,
+  gemini: GeminiSchemaComposer.invert,
+  llama: LlamaSchemaComposer.invert,
+  "3.0": LlmSchemaV3Composer.invert,
+  "3.1": LlmSchemaV3_1Composer.invert,
 };
 
 const DEFAULT_CONFIGS = {

--- a/src/composers/llm/ClaudeSchemaComposer.ts
+++ b/src/composers/llm/ClaudeSchemaComposer.ts
@@ -50,4 +50,10 @@ export namespace ClaudeSchemaComposer {
       LlmSchemaV3_1Composer.separateParameters(props);
     return separated as any as ILlmFunction.ISeparated<"claude">;
   };
+
+  export const invert = (props: {
+    components: OpenApi.IComponents;
+    schema: IClaudeSchema;
+    $defs: Record<string, IClaudeSchema>;
+  }): OpenApi.IJsonSchema => LlmSchemaV3_1Composer.invert(props);
 }

--- a/src/composers/llm/GeminiSchemaComposer.ts
+++ b/src/composers/llm/GeminiSchemaComposer.ts
@@ -119,6 +119,10 @@ export namespace GeminiSchemaComposer {
       );
     return separated as any as ILlmFunction.ISeparated<"gemini">;
   };
+
+  export const invert = (props: {
+    schema: IGeminiSchema;
+  }): OpenApi.IJsonSchema => LlmSchemaV3Composer.invert(props);
 }
 
 const isOneOf =

--- a/src/composers/llm/LlamaSchemaComposer.ts
+++ b/src/composers/llm/LlamaSchemaComposer.ts
@@ -45,4 +45,10 @@ export namespace LlamaSchemaComposer {
     LlmSchemaV3_1Composer.separateParameters(
       props,
     ) as any as ILlmFunction.ISeparated<"llama">;
+
+  export const invert = (props: {
+    components: OpenApi.IComponents;
+    schema: ILlamaSchema;
+    $defs: Record<string, ILlamaSchema>;
+  }): OpenApi.IJsonSchema => LlmSchemaV3_1Composer.invert(props);
 }

--- a/src/composers/llm/LlmDescriptionInverter.ts
+++ b/src/composers/llm/LlmDescriptionInverter.ts
@@ -1,0 +1,134 @@
+import { OpenApi } from "../../OpenApi";
+
+export namespace LlmDescriptionInverter {
+  export const numeric = (
+    description: string,
+  ): Pick<
+    OpenApi.IJsonSchema.INumber,
+    | "minimum"
+    | "maximum"
+    | "exclusiveMinimum"
+    | "exclusiveMaximum"
+    | "multipleOf"
+  > => {
+    const lines: string[] = description.split("\n");
+    const exclusiveMinimum: number | undefined = find({
+      type: "number",
+      name: "exclusiveMinimum",
+      lines,
+    });
+    const exclusiveMaximum: number | undefined = find({
+      type: "number",
+      name: "exclusiveMaximum",
+      lines,
+    });
+    return {
+      minimum:
+        exclusiveMinimum ??
+        find({
+          type: "number",
+          name: "minimum",
+          lines,
+        }),
+      maximum:
+        exclusiveMaximum ??
+        find({
+          type: "number",
+          name: "maximum",
+          lines,
+        }),
+      exclusiveMinimum: exclusiveMinimum !== undefined ? true : undefined,
+      exclusiveMaximum: exclusiveMaximum !== undefined ? true : undefined,
+      multipleOf: find({
+        type: "number",
+        name: "multipleOf",
+        lines,
+      }),
+    };
+  };
+
+  export const string = (
+    description: string,
+  ): Pick<
+    OpenApi.IJsonSchema.IString,
+    "format" | "pattern" | "contentMediaType" | "minLength" | "maxLength"
+  > => {
+    const lines: string[] = description.split("\n");
+    return {
+      format: find({
+        type: "string",
+        name: "format",
+        lines,
+      }),
+      pattern: find({
+        type: "string",
+        name: "pattern",
+        lines: description.split("\n"),
+      }),
+      contentMediaType: find({
+        type: "string",
+        name: "contentMediaType",
+        lines,
+      }),
+      minLength: find({
+        type: "number",
+        name: "minLength",
+        lines,
+      }),
+      maxLength: find({
+        type: "number",
+        name: "maxLength",
+        lines: description.split("\n"),
+      }),
+    };
+  };
+
+  export const array = (
+    description: string,
+  ): Pick<
+    OpenApi.IJsonSchema.IArray,
+    "minItems" | "maxItems" | "uniqueItems"
+  > => {
+    const lines: string[] = description.split("\n");
+    return {
+      minItems: find({
+        type: "number",
+        name: "minItems",
+        lines,
+      }),
+      maxItems: find({
+        type: "number",
+        name: "maxItems",
+        lines,
+      }),
+      uniqueItems: find({
+        type: "boolean",
+        name: "uniqueItems",
+        lines,
+      }),
+    };
+  };
+
+  const find = <Type extends "boolean" | "number" | "string">(props: {
+    type: Type;
+    name: string;
+    lines: string[];
+  }):
+    | (Type extends "boolean" ? true : Type extends "number" ? number : string)
+    | undefined => {
+    if (props.type === "boolean")
+      return props.lines.some((line) => line.startsWith(`@${props.name}`))
+        ? true
+        : (undefined as any);
+    for (const line of props.lines) {
+      if (line.startsWith(`@${props.name} `) === false) continue;
+      const value: string = line.replace(`@${props.name} `, "").trim();
+      if (props.type === "number")
+        return (isNaN(Number(value)) ? undefined : Number(value)) satisfies
+          | number
+          | undefined as any;
+      return value as any;
+    }
+    return undefined as any;
+  };
+}

--- a/src/utils/OpenApiConstraintShifter.ts
+++ b/src/utils/OpenApiConstraintShifter.ts
@@ -38,7 +38,6 @@ export namespace OpenApiConstraintShifter {
       | "exclusiveMinimum"
       | "exclusiveMaximum"
       | "multipleOf"
-      | "default"
     >,
   >(
     v: Schema,
@@ -49,32 +48,29 @@ export namespace OpenApiConstraintShifter {
     | "exclusiveMinimum"
     | "exclusiveMaximum"
     | "multipleOf"
-    | "default"
   > => {
     const tags: string[] = [];
-    if (v.minimum !== undefined) {
+    if (v.exclusiveMinimum === undefined && v.minimum !== undefined) {
       tags.push(`@minimum ${v.minimum}`);
       delete v.minimum;
     }
-    if (v.maximum !== undefined) {
+    if (v.exclusiveMaximum === undefined && v.maximum !== undefined) {
       tags.push(`@maximum ${v.maximum}`);
       delete v.maximum;
     }
-    if (v.exclusiveMinimum !== undefined) {
-      tags.push(`@exclusiveMinimum ${v.exclusiveMinimum}`);
+    if (v.minimum !== undefined && v.exclusiveMinimum === true) {
+      tags.push(`@exclusiveMinimum ${v.minimum}`);
+      delete v.minimum;
       delete v.exclusiveMinimum;
     }
-    if (v.exclusiveMaximum !== undefined) {
-      tags.push(`@exclusiveMaximum ${v.exclusiveMaximum}`);
+    if (v.maximum !== undefined && v.exclusiveMaximum === true) {
+      tags.push(`@exclusiveMaximum ${v.maximum}`);
+      delete v.maximum;
       delete v.exclusiveMaximum;
     }
     if (v.multipleOf !== undefined) {
       tags.push(`@multipleOf ${v.multipleOf}`);
       delete v.multipleOf;
-    }
-    if (v.default !== undefined) {
-      tags.push(`@default ${v.default}`);
-      delete v.default;
     }
     v.description = writeTagWithDescription({
       description: v.description,
@@ -92,18 +88,12 @@ export namespace OpenApiConstraintShifter {
       | "format"
       | "pattern"
       | "contentMediaType"
-      | "default"
     >,
   >(
     v: Schema,
   ): Omit<
     Schema,
-    | "minLength"
-    | "maxLength"
-    | "format"
-    | "pattern"
-    | "contentMediaType"
-    | "default"
+    "minLength" | "maxLength" | "format" | "pattern" | "contentMediaType"
   > => {
     const tags: string[] = [];
     if (v.minLength !== undefined) {
@@ -125,10 +115,6 @@ export namespace OpenApiConstraintShifter {
     if (v.contentMediaType !== undefined) {
       tags.push(`@contentMediaType ${v.contentMediaType}`);
       delete v.contentMediaType;
-    }
-    if (v.default !== undefined) {
-      tags.push(`@default ${v.default}`);
-      delete v.default;
     }
     v.description = writeTagWithDescription({
       description: v.description,

--- a/test/features/llm/validate_llm_invert_array.ts
+++ b/test/features/llm/validate_llm_invert_array.ts
@@ -1,0 +1,48 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection, tags } from "typia";
+
+export const test_chatgpt_invert_array = (): void =>
+  validate_llm_invert_array("chatgpt");
+
+export const test_claude_invert_array = (): void =>
+  validate_llm_invert_array("claude");
+
+export const test_llama_invert_array = (): void =>
+  validate_llm_invert_array("llama");
+
+export const test_gemini_invert_array = (): void =>
+  validate_llm_invert_array("gemini");
+
+export const test_llm_v30_invert_array = (): void =>
+  validate_llm_invert_array("3.0");
+
+export const test_llm_v31_invert_array = (): void =>
+  validate_llm_invert_array("3.1");
+
+const validate_llm_invert_array = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const collection: IJsonSchemaCollection =
+    typia.json.schemas<
+      [Array<string> & tags.MinItems<1> & tags.MaxItems<10> & tags.UniqueItems]
+    >();
+  const $defs: Record<string, ILlmSchema<Model>> = {};
+  const converted = LlmSchemaComposer.schema(model)({
+    components: collection.components,
+    schema: collection.schemas[0],
+    config: LlmSchemaComposer.defaultConfig(model) as any,
+    $defs: $defs as any,
+  });
+  if (converted.success === false) throw new Error(converted.error.message);
+  const inverted = LlmSchemaComposer.invert(model)({
+    $defs,
+    components: collection.components,
+    schema: converted.value,
+  } as any);
+  TestValidator.equals(
+    "inverted",
+    (key) => key !== "description",
+  )(collection.schemas[0])(inverted);
+};

--- a/test/features/llm/validate_llm_invert_enum.ts
+++ b/test/features/llm/validate_llm_invert_enum.ts
@@ -1,0 +1,49 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_chatgpt_invert_enum = (): void =>
+  validate_llm_invert_enum("chatgpt");
+
+export const test_claude_invert_enum = (): void =>
+  validate_llm_invert_enum("claude");
+
+export const test_llama_invert_enum = (): void =>
+  validate_llm_invert_enum("llama");
+
+export const test_gemini_invert_enum = (): void =>
+  validate_llm_invert_enum("gemini");
+
+export const test_llm_v30_invert_enum = (): void =>
+  validate_llm_invert_enum("3.0");
+
+export const test_llm_v31_invert_enum = (): void =>
+  validate_llm_invert_enum("3.1");
+
+const validate_llm_invert_enum = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const validate = (collection: IJsonSchemaCollection) => {
+    const $defs: Record<string, ILlmSchema<Model>> = {};
+    const converted = LlmSchemaComposer.schema(model)({
+      components: collection.components,
+      schema: collection.schemas[0],
+      config: LlmSchemaComposer.defaultConfig(model) as any,
+      $defs: $defs as any,
+    });
+    if (converted.success === false) throw new Error(converted.error.message);
+    const inverted = LlmSchemaComposer.invert(model)({
+      $defs,
+      components: collection.components,
+      schema: collection.schemas[0],
+    } as any);
+    TestValidator.equals(
+      "inverted",
+      (key) => key !== "description",
+    )(collection.schemas[0])(inverted);
+  };
+  validate(typia.json.schemas<[false]>());
+  validate(typia.json.schemas<[1 | 2 | 3]>());
+  validate(typia.json.schemas<["a" | "b" | "c"]>());
+};

--- a/test/features/llm/validate_llm_invert_integer.ts
+++ b/test/features/llm/validate_llm_invert_integer.ts
@@ -1,0 +1,68 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection, tags } from "typia";
+
+export const test_chatgpt_invert_integer = (): void =>
+  validate_llm_invert_integer("chatgpt");
+
+export const test_claude_invert_integer = (): void =>
+  validate_llm_invert_integer("claude");
+
+export const test_llama_invert_integer = (): void =>
+  validate_llm_invert_integer("llama");
+
+export const test_gemini_invert_integer = (): void =>
+  validate_llm_invert_integer("gemini");
+
+export const test_llm_v30_invert_integer = (): void =>
+  validate_llm_invert_integer("3.0");
+
+export const test_llm_v31_invert_integer = (): void =>
+  validate_llm_invert_integer("3.1");
+
+const validate_llm_invert_integer = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const validate = (collection: IJsonSchemaCollection) => {
+    const $defs: Record<string, ILlmSchema<Model>> = {};
+    const converted = LlmSchemaComposer.schema(model)({
+      components: collection.components,
+      schema: collection.schemas[0],
+      config: LlmSchemaComposer.defaultConfig(model) as any,
+      $defs: $defs as any,
+    });
+    if (converted.success === false) throw new Error(converted.error.message);
+    const inverted = LlmSchemaComposer.invert(model)({
+      $defs,
+      components: collection.components,
+      schema: converted.value,
+    } as any);
+    TestValidator.equals(
+      "inverted",
+      (key) => key !== "description",
+    )(collection.schemas[0])(inverted);
+  };
+  validate(typia.json.schemas<[number & tags.Type<"int32">]>());
+  validate(
+    typia.json.schemas<
+      [
+        number &
+          tags.Type<"int32"> &
+          tags.Minimum<0> &
+          tags.Maximum<100> &
+          tags.MultipleOf<5>,
+      ]
+    >(),
+  );
+  validate(
+    typia.json.schemas<
+      [
+        number &
+          tags.Type<"int32"> &
+          tags.ExclusiveMinimum<0> &
+          tags.ExclusiveMaximum<100>,
+      ]
+    >(),
+  );
+};

--- a/test/features/llm/validate_llm_invert_nullable.ts
+++ b/test/features/llm/validate_llm_invert_nullable.ts
@@ -1,0 +1,97 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection, tags } from "typia";
+
+export const test_chatgpt_invert_nullable = (): void =>
+  validate_llm_invert_nullable("chatgpt");
+
+export const test_claude_invert_nullable = (): void =>
+  validate_llm_invert_nullable("claude");
+
+export const test_gemini_invert_nullable = (): void =>
+  validate_llm_invert_nullable("gemini");
+
+export const test_llama_invert_nullable = (): void =>
+  validate_llm_invert_nullable("llama");
+
+export const test_llm_v30_invert_nullable = (): void =>
+  validate_llm_invert_nullable("3.0");
+
+export const test_llm_v31_invert_nullable = (): void =>
+  validate_llm_invert_nullable("3.1");
+
+const validate_llm_invert_nullable = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const validate = (collection: IJsonSchemaCollection) => {
+    const $defs: Record<string, ILlmSchema<Model>> = {};
+    const converted = LlmSchemaComposer.schema(model)({
+      components: collection.components,
+      schema: collection.schemas[0],
+      config: LlmSchemaComposer.defaultConfig(model) as any,
+      $defs: $defs as any,
+    });
+    if (converted.success === false) throw new Error(converted.error.message);
+    const inverted = LlmSchemaComposer.invert(model)({
+      $defs,
+      components: collection.components,
+      schema: converted.value,
+    } as any);
+    TestValidator.equals(
+      "inverted",
+      (key) => key !== "description",
+    )(collection.schemas[0])(inverted);
+  };
+  validate(typia.json.schemas<[boolean | null]>());
+  validate(
+    typia.json.schemas<
+      [
+        | (number &
+            tags.ExclusiveMinimum<0> &
+            tags.Maximum<100> &
+            tags.MultipleOf<5>)
+        | null,
+      ]
+    >(),
+  );
+  validate(
+    typia.json.schemas<
+      [
+        | (string &
+            tags.Format<"uri"> &
+            tags.ContentMediaType<"image/png"> &
+            tags.MinLength<5>)
+        | null,
+      ]
+    >(),
+  );
+  validate(
+    typia.json.schemas<
+      [(Array<number> & tags.MinItems<1> & tags.MaxItems<10>) | null]
+    >(),
+  );
+  validate(
+    typia.json.schemas<
+      [
+        {
+          /**
+           * Primary Key.
+           */
+          id: string & tags.Format<"uuid">;
+
+          /**
+           * Email Address.
+           */
+          email: string & tags.Format<"email">;
+          name: string;
+          age: null | (number & tags.Minimum<0> & tags.Maximum<100>);
+          hobbies: Array<{
+            title: string;
+            description: string;
+          }>;
+        } | null,
+      ]
+    >(),
+  );
+};

--- a/test/features/llm/validate_llm_invert_number.ts
+++ b/test/features/llm/validate_llm_invert_number.ts
@@ -1,0 +1,57 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection, tags } from "typia";
+
+export const test_chatgpt_invert_number = (): void =>
+  validate_llm_invert_number("chatgpt");
+
+export const test_claude_invert_number = (): void =>
+  validate_llm_invert_number("claude");
+
+export const test_llama_invert_number = (): void =>
+  validate_llm_invert_number("llama");
+
+export const test_gemini_invert_number = (): void =>
+  validate_llm_invert_number("gemini");
+
+export const test_llm_v30_invert_number = (): void =>
+  validate_llm_invert_number("3.0");
+
+export const test_llm_v31_invert_number = (): void =>
+  validate_llm_invert_number("3.1");
+
+const validate_llm_invert_number = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const validate = (collection: IJsonSchemaCollection) => {
+    const $defs: Record<string, ILlmSchema<Model>> = {};
+    const converted = LlmSchemaComposer.schema(model)({
+      components: collection.components,
+      schema: collection.schemas[0],
+      config: LlmSchemaComposer.defaultConfig(model) as any,
+      $defs: $defs as any,
+    });
+    if (converted.success === false) throw new Error(converted.error.message);
+    const inverted = LlmSchemaComposer.invert(model)({
+      $defs,
+      components: collection.components,
+      schema: converted.value,
+    } as any);
+    TestValidator.equals(
+      "inverted",
+      (key) => key !== "description",
+    )(collection.schemas[0])(inverted);
+  };
+  validate(typia.json.schemas<[number]>());
+  validate(
+    typia.json.schemas<
+      [number & tags.Minimum<0> & tags.Maximum<100> & tags.MultipleOf<5>]
+    >(),
+  );
+  validate(
+    typia.json.schemas<
+      [number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<100>]
+    >(),
+  );
+};

--- a/test/features/llm/validate_llm_invert_object.ts
+++ b/test/features/llm/validate_llm_invert_object.ts
@@ -1,0 +1,61 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema, OpenApi } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection, tags } from "typia";
+
+export const test_chatgpt_invert_object = (): void =>
+  validate_llm_invert_object("chatgpt");
+
+export const test_claude_invert_object = (): void =>
+  validate_llm_invert_object("claude");
+
+export const test_llama_invert_object = (): void =>
+  validate_llm_invert_object("llama");
+
+export const test_gemini_invert_object = (): void =>
+  validate_llm_invert_object("gemini");
+
+export const test_llm_v30_invert_object = (): void =>
+  validate_llm_invert_object("3.0");
+
+export const test_llm_v31_invert_object = (): void =>
+  validate_llm_invert_object("3.1");
+
+const validate_llm_invert_object = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const collection: IJsonSchemaCollection = typia.json.schemas<
+    [
+      {
+        id: string & tags.Format<"uuid">;
+        email: string & tags.Format<"email">;
+        name: string;
+        hobbies: Array<{
+          title: string;
+          description: string;
+        }> &
+          tags.MaxItems<10>;
+        thumbnail: string &
+          tags.Format<"uri"> &
+          tags.ContentMediaType<"image/png">;
+      },
+    ]
+  >();
+  const converted = LlmSchemaComposer.parameters(model)({
+    config: {
+      reference: true,
+    } as any,
+    components: collection.components,
+    schema: collection.schemas[0] as OpenApi.IJsonSchema.IReference,
+  });
+  if (converted.success === false) throw new Error(converted.error.message);
+  const inverted = LlmSchemaComposer.invert(model)({
+    $defs: (converted.value as any).$defs,
+    components: collection.components,
+    schema: converted.value,
+  } as any);
+  TestValidator.equals(
+    "inverted",
+    (key) => key !== "description",
+  )(collection.schemas[0])(inverted);
+};

--- a/test/features/llm/validate_llm_invert_oneof.ts
+++ b/test/features/llm/validate_llm_invert_oneof.ts
@@ -1,0 +1,57 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_chatgpt_invert_oneof = (): void =>
+  validate_llm_invert_oneof("chatgpt");
+
+export const test_claude_invert_oneof = (): void =>
+  validate_llm_invert_oneof("claude");
+
+export const test_llama_invert_oneof = (): void =>
+  validate_llm_invert_oneof("llama");
+
+export const test_llm_v30_invert_oneof = (): void =>
+  validate_llm_invert_oneof("3.0");
+
+export const test_llm_v31_invert_oneof = (): void =>
+  validate_llm_invert_oneof("3.1");
+
+const validate_llm_invert_oneof = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const validate = (collection: IJsonSchemaCollection) => {
+    const $defs: Record<string, ILlmSchema<Model>> = {};
+    const converted = LlmSchemaComposer.schema(model)({
+      components: collection.components,
+      schema: collection.schemas[0],
+      config: LlmSchemaComposer.defaultConfig(model) as any,
+      $defs: $defs as any,
+    });
+    if (converted.success === false) throw new Error(converted.error.message);
+    const inverted = LlmSchemaComposer.invert(model)({
+      $defs,
+      components: collection.components,
+      schema: converted.value,
+    } as any);
+    TestValidator.equals(
+      "inverted",
+      (key) => key !== "description",
+    )(collection.schemas[0])(inverted);
+  };
+  validate(typia.json.schemas<[string | number | boolean]>());
+  validate(typia.json.schemas<[string | 1 | 2 | 3 | null]>());
+  validate(
+    typia.json.schemas<
+      [
+        | { x: number }
+        | { y: number }
+        | { z: number }
+        | Array<boolean>
+        | string
+        | number,
+      ]
+    >(),
+  );
+};

--- a/test/features/llm/validate_llm_invert_ref.ts
+++ b/test/features/llm/validate_llm_invert_ref.ts
@@ -1,0 +1,54 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema, OpenApi, OpenApiTypeChecker } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection, tags } from "typia";
+
+export const test_chatgpt_invert_ref = (): void =>
+  validate_llm_invert_ref("chatgpt");
+
+export const test_claude_invert_ref = (): void =>
+  validate_llm_invert_ref("claude");
+
+export const test_llama_invert_ref = (): void =>
+  validate_llm_invert_ref("llama");
+
+export const test_llm_v31_invert_ref = (): void =>
+  validate_llm_invert_ref("3.1");
+
+const validate_llm_invert_ref = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const collection: IJsonSchemaCollection = typia.json.schemas<[IMember]>();
+  const converted = LlmSchemaComposer.parameters(model)({
+    config: {
+      reference: true,
+    } as any,
+    components: collection.components,
+    schema: collection.schemas[0] as OpenApi.IJsonSchema.IReference,
+  });
+  if (converted.success === false) throw new Error(converted.error.message);
+  const inverted = LlmSchemaComposer.invert(model)({
+    $defs: (converted.value as any).$defs,
+    components: collection.components,
+    schema: converted.value,
+  } as any);
+  TestValidator.predicate("inverted")(
+    OpenApiTypeChecker.isObject(inverted) &&
+      inverted.properties !== undefined &&
+      OpenApiTypeChecker.isArray(inverted.properties.hobbies) &&
+      OpenApiTypeChecker.isReference(inverted.properties.hobbies.items) &&
+      inverted.properties.hobbies.items.$ref === "#/components/schemas/IHobby",
+  );
+};
+
+interface IMember {
+  id: string & tags.Format<"uuid">;
+  email: string & tags.Format<"email">;
+  name: string;
+  hobbies: IHobby[] & tags.MaxItems<10>;
+  thumbnail: string & tags.Format<"uri"> & tags.ContentMediaType<"image/png">;
+}
+interface IHobby {
+  title: string;
+  description: string;
+}

--- a/test/features/llm/validate_llm_invert_string.ts
+++ b/test/features/llm/validate_llm_invert_string.ts
@@ -1,0 +1,52 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection, tags } from "typia";
+
+export const test_chatgpt_invert_string = (): void =>
+  validate_llm_invert_string("chatgpt");
+
+export const test_claude_invert_string = (): void =>
+  validate_llm_invert_string("claude");
+
+export const test_llama_invert_string = (): void =>
+  validate_llm_invert_string("llama");
+
+export const test_llm_v30_invert_string = (): void =>
+  validate_llm_invert_string("3.0");
+
+export const test_llm_v31_invert_string = (): void =>
+  validate_llm_invert_string("3.1");
+
+const validate_llm_invert_string = <Model extends ILlmSchema.Model>(
+  model: Model,
+): void => {
+  const validate = (collection: IJsonSchemaCollection) => {
+    const $defs: Record<string, ILlmSchema<Model>> = {};
+    const converted = LlmSchemaComposer.schema(model)({
+      components: collection.components,
+      schema: collection.schemas[0],
+      config: LlmSchemaComposer.defaultConfig(model) as any,
+      $defs: $defs as any,
+    });
+    if (converted.success === false) throw new Error(converted.error.message);
+    const inverted = LlmSchemaComposer.invert(model)({
+      $defs,
+      components: collection.components,
+      schema: converted.value,
+    } as any);
+    TestValidator.equals(
+      "inverted",
+      (key) => key !== "description",
+    )(collection.schemas[0])(inverted);
+  };
+  validate(
+    typia.json.schemas<[string & tags.MinLength<3> & tags.MaxLength<10>]>(),
+  );
+  validate(typia.json.schemas<[string & tags.Pattern<"^[a-z]+$">]>());
+  validate(
+    typia.json.schemas<
+      [string & tags.Format<"uri"> & tags.ContentMediaType<"image/png">]
+    >(),
+  );
+};


### PR DESCRIPTION
This pull request includes significant updates to the `LlmSchemaComposer` module, including the introduction of inversion functions for various schema composers and the addition of the `LlmDescriptionInverter` utility. These changes enhance the functionality and flexibility of the schema composers by allowing the inversion of schema descriptions.

Key changes include:

### Version Update
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.4.3` to `2.5.0`.

### Inversion Functions
* [`src/composers/LlmSchemaComposer.ts`](diffhunk://#diff-058da3c4ceb4aa02b198488eef3b8dd547d7c0f0ee2b2355e1d104527b1d597dR38-R40): Added an `invert` function and an `INVERTS` constant to support schema inversion. [[1]](diffhunk://#diff-058da3c4ceb4aa02b198488eef3b8dd547d7c0f0ee2b2355e1d104527b1d597dR38-R40) [[2]](diffhunk://#diff-058da3c4ceb4aa02b198488eef3b8dd547d7c0f0ee2b2355e1d104527b1d597dR76-R84)
* [`src/composers/llm/ChatGptSchemaComposer.ts`](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR19-R21): Introduced an `invert` function and added sections for converters and separators. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR19-R21) [[2]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR196-R198) [[3]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR422-R536)
* `src/composers/llm/ClaudeSchemaComposer.ts`, `src/composers/llm/GeminiSchemaComposer.ts`, `src/composers/llm/LlamaSchemaComposer.ts`: Added `invert` functions to support schema inversion. [[1]](diffhunk://#diff-09e976921cbf7ded8e1667800e245195ac7a939f7640fdd806acedcb69f91d65R53-R58) [[2]](diffhunk://#diff-4e9da1f0bdac90742383f58756d5fe60a9d5de3293d24f67f6015f9e88d54759R122-R125) [[3]](diffhunk://#diff-5b7ae0e3be666c887786a4fdb4dfc30b7f0505900ff35bca89338d2f9d3ec0b6R48-R53)

### Utility Additions
* [`src/composers/llm/LlmDescriptionInverter.ts`](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837R1-R134): Added the `LlmDescriptionInverter` utility to handle inversion of numeric, string, and array descriptions.
* `src/composers/llm/LlmSchemaV3Composer.ts`, `src/composers/llm/LlmSchemaV3_1Composer.ts`: Integrated the `LlmDescriptionInverter` and added sections for converters, separators, and inverters. [[1]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R3-R11) [[2]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R20-R22) [[3]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R294-R329) [[4]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R10) [[5]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R19-R21) [[6]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R335-R337) [[7]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R564-R627)

### Miscellaneous
* [`src/utils/OpenApiConstraintShifter.ts`](diffhunk://#diff-e78dd3edb6aaa624cdd35fe91bd78d2a521c4b4e9709b0f89bec76d0776a6f39L41): Adjusted the handling of `exclusiveMinimum` and `exclusiveMaximum` properties to avoid conflicts. [[1]](diffhunk://#diff-e78dd3edb6aaa624cdd35fe91bd78d2a521c4b4e9709b0f89bec76d0776a6f39L41) [[2]](diffhunk://#diff-e78dd3edb6aaa624cdd35fe91bd78d2a521c4b4e9709b0f89bec76d0776a6f39L52-L78)