### PR TITLE
Test program prints "Pass" for none API key cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@anthropic-ai/sdk": "^0.32.1",
     "@google/generative-ai": "^0.21.0",
     "@nestia/core": "4.2.0",
-    "@nestia/e2e": "0.7.0",
+    "@nestia/e2e": "0.8.2",
     "@nestia/fetcher": "4.2.0",
     "@nestia/sdk": "4.2.0",
     "@nestjs/common": "^10.4.1",

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_additionalProperties.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_additionalProperties.ts
@@ -4,41 +4,40 @@ import typia, { tags } from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
 
-export const test_chatgpt_function_calling_additionalProperties =
-  (): Promise<void> =>
-    ChatGptFunctionCaller.test({
-      name: "enrollPerson",
-      description: "Enroll a person to the restaurant reservation list.",
-      collection: typia.json.schemas<[{ input: IPerson }]>(),
-      validate: typia.createValidate<{ input: IPerson }>(),
-      texts: [
-        {
-          role: "assistant",
-          content: SYSTEM_MESSAGE,
-        },
-        {
-          role: "user",
-          content: USER_MESSAGE,
-        },
-      ],
-      handleParameters: async (parameters) => {
-        if (process.argv.includes("--file"))
-          await fs.promises.writeFile(
-            `${TestGlobal.ROOT}/examples/function-calling/schemas/chatgpt.additionalProperties.schema.json`,
-            JSON.stringify(parameters, null, 2),
-            "utf8",
-          );
+export const test_chatgpt_function_calling_additionalProperties = () =>
+  ChatGptFunctionCaller.test({
+    name: "enrollPerson",
+    description: "Enroll a person to the restaurant reservation list.",
+    collection: typia.json.schemas<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
       },
-      handleCompletion: async (input) => {
-        typia.assert<IPerson>(input);
-        if (process.argv.includes("--file"))
-          await fs.promises.writeFile(
-            `${TestGlobal.ROOT}/examples/function-calling/arguments/chatgpt.additionalProperties.input.json`,
-            JSON.stringify(input, null, 2),
-            "utf8",
-          );
+      {
+        role: "user",
+        content: USER_MESSAGE,
       },
-    });
+    ],
+    handleParameters: async (parameters) => {
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/schemas/chatgpt.additionalProperties.schema.json`,
+          JSON.stringify(parameters, null, 2),
+          "utf8",
+        );
+    },
+    handleCompletion: async (input) => {
+      typia.assert<IPerson>(input);
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/arguments/chatgpt.additionalProperties.input.json`,
+          JSON.stringify(input, null, 2),
+          "utf8",
+        );
+    },
+  });
 
 interface IPerson {
   /**

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_description_length.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_description_length.ts
@@ -2,8 +2,8 @@ import typia from "typia";
 
 import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
 
-export const test_chatgpt_function_calling_description_length = async () => {
-  await ChatGptFunctionCaller.test({
+export const test_chatgpt_function_calling_description_length = () =>
+  ChatGptFunctionCaller.test({
     config: {
       reference: true,
     },
@@ -25,7 +25,6 @@ export const test_chatgpt_function_calling_description_length = async () => {
       typia.assert<IPerson>(input);
     },
   });
-};
 
 interface IPerson {
   name: string;

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_empty.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_empty.ts
@@ -3,8 +3,8 @@ import OpenAI from "openai";
 
 import { TestGlobal } from "../../../TestGlobal";
 
-export const test_chatgpt_function_calling_empty = async (): Promise<void> => {
-  if (TestGlobal.env.CHATGPT_API_KEY === undefined) return;
+export const test_chatgpt_function_calling_empty = async () => {
+  if (TestGlobal.env.CHATGPT_API_KEY === undefined) return false;
 
   const client: OpenAI = new OpenAI({ apiKey: TestGlobal.env.CHATGPT_API_KEY });
   const completion: OpenAI.ChatCompletion =

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_name_length.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_name_length.ts
@@ -2,8 +2,8 @@ import typia from "typia";
 
 import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
 
-export const test_chatgpt_function_calling_name_length = async () => {
-  await ChatGptFunctionCaller.test({
+export const test_chatgpt_function_calling_name_length = () =>
+  ChatGptFunctionCaller.test({
     config: {
       reference: true,
     },
@@ -25,7 +25,6 @@ export const test_chatgpt_function_calling_name_length = async () => {
       typia.assert<IPerson>(input);
     },
   });
-};
 
 interface IPerson {
   name: string;

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_sale.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_sale.ts
@@ -6,7 +6,7 @@ import { IShoppingSale } from "../../../structures/IShoppingSale";
 import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
 import { ShoppingSalePrompt } from "../../../utils/ShoppingSalePrompt";
 
-export const test_chatgpt_function_calling_sale = async (): Promise<void> =>
+export const test_chatgpt_function_calling_sale = async () =>
   ChatGptFunctionCaller.test({
     config: {
       reference: process.argv.includes("--reference"),

--- a/test/features/llm/chatgpt/test_chatgpt_function_calling_union.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_function_calling_union.ts
@@ -4,7 +4,7 @@ import typia from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { ChatGptFunctionCaller } from "../../../utils/ChatGptFunctionCaller";
 
-export const test_chatgpt_function_calling_union = (): Promise<void> =>
+export const test_chatgpt_function_calling_union = () =>
   ChatGptFunctionCaller.test({
     config: {
       reference: false,

--- a/test/features/llm/claude/test_claude_function_calling_additionalProperties.ts
+++ b/test/features/llm/claude/test_claude_function_calling_additionalProperties.ts
@@ -4,42 +4,41 @@ import typia, { tags } from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { ClaudeFunctionCaller } from "../../../utils/ClaudeFunctionCaller";
 
-export const test_claude_function_calling_additionalProperties =
-  (): Promise<void> =>
-    ClaudeFunctionCaller.test({
-      model: "claude",
-      name: "enrollPerson",
-      description: "Enroll a person to the restaurant reservation list.",
-      collection: typia.json.schemas<[{ input: IPerson }]>(),
-      validate: typia.createValidate<{ input: IPerson }>(),
-      texts: [
-        {
-          role: "assistant",
-          content: SYSTEM_MESSAGE,
-        },
-        {
-          role: "user",
-          content: USER_MESSAGE,
-        },
-      ],
-      handleParameters: async (parameters) => {
-        if (process.argv.includes("--file"))
-          await fs.promises.writeFile(
-            `${TestGlobal.ROOT}/examples/function-calling/schemas/claude.additionalProperties.schema.json`,
-            JSON.stringify(parameters, null, 2),
-            "utf8",
-          );
+export const test_claude_function_calling_additionalProperties = () =>
+  ClaudeFunctionCaller.test({
+    model: "claude",
+    name: "enrollPerson",
+    description: "Enroll a person to the restaurant reservation list.",
+    collection: typia.json.schemas<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
       },
-      handleCompletion: async (input) => {
-        typia.assert<IPerson>(input);
-        if (process.argv.includes("--file"))
-          await fs.promises.writeFile(
-            `${TestGlobal.ROOT}/examples/function-calling/arguments/claude.additionalProperties.input.json`,
-            JSON.stringify(input, null, 2),
-            "utf8",
-          );
+      {
+        role: "user",
+        content: USER_MESSAGE,
       },
-    });
+    ],
+    handleParameters: async (parameters) => {
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/schemas/claude.additionalProperties.schema.json`,
+          JSON.stringify(parameters, null, 2),
+          "utf8",
+        );
+    },
+    handleCompletion: async (input) => {
+      typia.assert<IPerson>(input);
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/arguments/claude.additionalProperties.input.json`,
+          JSON.stringify(input, null, 2),
+          "utf8",
+        );
+    },
+  });
 
 interface IPerson {
   /**

--- a/test/features/llm/claude/test_claude_function_calling_empty.ts
+++ b/test/features/llm/claude/test_claude_function_calling_empty.ts
@@ -3,8 +3,8 @@ import { TestValidator } from "@nestia/e2e";
 
 import { TestGlobal } from "../../../TestGlobal";
 
-export const test_claude_function_calling_empty = async (): Promise<void> => {
-  if (TestGlobal.env.CLAUDE_API_KEY === undefined) return;
+export const test_claude_function_calling_empty = async () => {
+  if (TestGlobal.env.CLAUDE_API_KEY === undefined) return false;
 
   const client: Anthropic = new Anthropic({
     apiKey: TestGlobal.env.CLAUDE_API_KEY,

--- a/test/features/llm/claude/test_claude_function_calling_sale.ts
+++ b/test/features/llm/claude/test_claude_function_calling_sale.ts
@@ -6,7 +6,7 @@ import { IShoppingSale } from "../../../structures/IShoppingSale";
 import { ClaudeFunctionCaller } from "../../../utils/ClaudeFunctionCaller";
 import { ShoppingSalePrompt } from "../../../utils/ShoppingSalePrompt";
 
-export const test_claude_function_calling_sale = async (): Promise<void> =>
+export const test_claude_function_calling_sale = async () =>
   ClaudeFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "claude",
     config: {

--- a/test/features/llm/claude/test_claude_function_calling_tags.ts
+++ b/test/features/llm/claude/test_claude_function_calling_tags.ts
@@ -4,7 +4,7 @@ import typia, { tags } from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { ClaudeFunctionCaller } from "../../../utils/ClaudeFunctionCaller";
 
-export const test_claude_function_calling_tags = (): Promise<void> =>
+export const test_claude_function_calling_tags = () =>
   ClaudeFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "claude",
     config: {

--- a/test/features/llm/claude/test_claude_function_calling_union.ts
+++ b/test/features/llm/claude/test_claude_function_calling_union.ts
@@ -4,7 +4,7 @@ import typia from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { ClaudeFunctionCaller } from "../../../utils/ClaudeFunctionCaller";
 
-export const test_claude_function_calling_union = (): Promise<void> =>
+export const test_claude_function_calling_union = () =>
   ClaudeFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "claude",
     config: {

--- a/test/features/llm/deepseek/test_deepseek_function_calling_additionalProperties.ts
+++ b/test/features/llm/deepseek/test_deepseek_function_calling_additionalProperties.ts
@@ -4,42 +4,41 @@ import typia, { tags } from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { DeepSeekFunctionCaller } from "../../../utils/DeepSeekFunctionCaller";
 
-export const test_deepseek_function_calling_additionalProperties =
-  (): Promise<void> =>
-    DeepSeekFunctionCaller.test({
-      model: (TestGlobal.getArguments("model")[0] as any) ?? "chatgpt",
-      name: "enrollPerson",
-      description: "Enroll a person to the restaurant reservation list.",
-      collection: typia.json.schemas<[{ input: IPerson }]>(),
-      validate: typia.createValidate<{ input: IPerson }>(),
-      texts: [
-        {
-          role: "assistant",
-          content: SYSTEM_MESSAGE,
-        },
-        {
-          role: "user",
-          content: USER_MESSAGE,
-        },
-      ],
-      handleParameters: async (parameters) => {
-        if (process.argv.includes("--file"))
-          await fs.promises.writeFile(
-            `${TestGlobal.ROOT}/examples/function-calling/schemas/deepseek.additionalProperties.schema.json`,
-            JSON.stringify(parameters, null, 2),
-            "utf8",
-          );
+export const test_deepseek_function_calling_additionalProperties = () =>
+  DeepSeekFunctionCaller.test({
+    model: (TestGlobal.getArguments("model")[0] as any) ?? "chatgpt",
+    name: "enrollPerson",
+    description: "Enroll a person to the restaurant reservation list.",
+    collection: typia.json.schemas<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
       },
-      handleCompletion: async (input) => {
-        typia.assert<IPerson>(input);
-        if (process.argv.includes("--file"))
-          await fs.promises.writeFile(
-            `${TestGlobal.ROOT}/examples/function-calling/arguments/deepseek.additionalProperties.input.json`,
-            JSON.stringify(input, null, 2),
-            "utf8",
-          );
+      {
+        role: "user",
+        content: USER_MESSAGE,
       },
-    });
+    ],
+    handleParameters: async (parameters) => {
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/schemas/deepseek.additionalProperties.schema.json`,
+          JSON.stringify(parameters, null, 2),
+          "utf8",
+        );
+    },
+    handleCompletion: async (input) => {
+      typia.assert<IPerson>(input);
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/arguments/deepseek.additionalProperties.input.json`,
+          JSON.stringify(input, null, 2),
+          "utf8",
+        );
+    },
+  });
 
 interface IPerson {
   /**

--- a/test/features/llm/deepseek/test_deepseek_function_calling_empty.ts
+++ b/test/features/llm/deepseek/test_deepseek_function_calling_empty.ts
@@ -3,8 +3,8 @@ import OpenAI from "openai";
 
 import { TestGlobal } from "../../../TestGlobal";
 
-export const test_deepseek_function_calling_empty = async (): Promise<void> => {
-  if (TestGlobal.env.LLAMA_API_KEY === undefined) return;
+export const test_deepseek_function_calling_empty = async () => {
+  if (TestGlobal.env.LLAMA_API_KEY === undefined) return false;
 
   const client: OpenAI = new OpenAI({
     apiKey: TestGlobal.env.LLAMA_API_KEY,

--- a/test/features/llm/deepseek/test_deepseek_function_calling_nullable.ts
+++ b/test/features/llm/deepseek/test_deepseek_function_calling_nullable.ts
@@ -4,7 +4,7 @@ import typia from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { DeepSeekFunctionCaller } from "../../../utils/DeepSeekFunctionCaller";
 
-export const test_deepseek_function_calling_nullable = (): Promise<void> =>
+export const test_deepseek_function_calling_nullable = () =>
   DeepSeekFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "chatgpt",
     config: {

--- a/test/features/llm/deepseek/test_deepseek_function_calling_sale.ts
+++ b/test/features/llm/deepseek/test_deepseek_function_calling_sale.ts
@@ -6,7 +6,7 @@ import { IShoppingSale } from "../../../structures/IShoppingSale";
 import { DeepSeekFunctionCaller } from "../../../utils/DeepSeekFunctionCaller";
 import { ShoppingSalePrompt } from "../../../utils/ShoppingSalePrompt";
 
-export const test_deepseek_function_calling_sale = async (): Promise<void> =>
+export const test_deepseek_function_calling_sale = async () =>
   DeepSeekFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "chatgpt",
     ...ShoppingSalePrompt.schema(),

--- a/test/features/llm/deepseek/test_deepseek_function_calling_tags.ts
+++ b/test/features/llm/deepseek/test_deepseek_function_calling_tags.ts
@@ -4,7 +4,7 @@ import typia, { tags } from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { DeepSeekFunctionCaller } from "../../../utils/DeepSeekFunctionCaller";
 
-export const test_deepseek_function_calling_tags = (): Promise<void> =>
+export const test_deepseek_function_calling_tags = () =>
   DeepSeekFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "chatgpt",
     name: "reserve",

--- a/test/features/llm/deepseek/test_deepseek_function_calling_union.ts
+++ b/test/features/llm/deepseek/test_deepseek_function_calling_union.ts
@@ -4,7 +4,7 @@ import typia from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { DeepSeekFunctionCaller } from "../../../utils/DeepSeekFunctionCaller";
 
-export const test_deepseek_function_calling_union = (): Promise<void> =>
+export const test_deepseek_function_calling_union = () =>
   DeepSeekFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "chatgpt",
     config: {

--- a/test/features/llm/gemini/test_gemini_function_calling_empty.ts
+++ b/test/features/llm/gemini/test_gemini_function_calling_empty.ts
@@ -8,8 +8,8 @@ import { TestValidator } from "@nestia/e2e";
 
 import { TestGlobal } from "../../../TestGlobal";
 
-export const test_gemini_function_calling_empty = async (): Promise<void> => {
-  if (TestGlobal.env.GEMINI_API_KEY === undefined) return;
+export const test_gemini_function_calling_empty = async () => {
+  if (TestGlobal.env.GEMINI_API_KEY === undefined) return false;
 
   const model: GenerativeModel = new GoogleGenerativeAI(
     TestGlobal.env.GEMINI_API_KEY,

--- a/test/features/llm/gemini/test_gemini_function_calling_example.ts
+++ b/test/features/llm/gemini/test_gemini_function_calling_example.ts
@@ -4,7 +4,7 @@ import typia, { tags } from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { GeminiFunctionCaller } from "../../../utils/GeminiFunctionCaller";
 
-export const test_gemini_function_calling_example = (): Promise<void> =>
+export const test_gemini_function_calling_example = () =>
   GeminiFunctionCaller.test({
     config: {
       recursive: 3,

--- a/test/features/llm/gemini/test_gemini_function_calling_sale.ts
+++ b/test/features/llm/gemini/test_gemini_function_calling_sale.ts
@@ -6,8 +6,8 @@ import { IShoppingSale } from "../../../structures/IShoppingSale";
 import { GeminiFunctionCaller } from "../../../utils/GeminiFunctionCaller";
 import { ShoppingSalePrompt } from "../../../utils/ShoppingSalePrompt";
 
-export const test_gemini_function_calling_sale = async (): Promise<void> =>
-  await GeminiFunctionCaller.test({
+export const test_gemini_function_calling_sale = async () =>
+  GeminiFunctionCaller.test({
     config: {
       recursive: 3,
     },

--- a/test/features/llm/llama/test_llama_function_calling_additionalProperties.ts
+++ b/test/features/llm/llama/test_llama_function_calling_additionalProperties.ts
@@ -4,42 +4,41 @@ import typia, { tags } from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { LlamaFunctionCaller } from "../../../utils/LlamaFunctionCaller";
 
-export const test_llama_function_calling_additionalProperties =
-  (): Promise<void> =>
-    LlamaFunctionCaller.test({
-      model: "claude",
-      name: "enrollPerson",
-      description: "Enroll a person to the restaurant reservation list.",
-      collection: typia.json.schemas<[{ input: IPerson }]>(),
-      validate: typia.createValidate<{ input: IPerson }>(),
-      texts: [
-        {
-          role: "assistant",
-          content: SYSTEM_MESSAGE,
-        },
-        {
-          role: "user",
-          content: USER_MESSAGE,
-        },
-      ],
-      handleParameters: async (parameters) => {
-        if (process.argv.includes("--file"))
-          await fs.promises.writeFile(
-            `${TestGlobal.ROOT}/examples/function-calling/schemas/llama.additionalProperties.schema.json`,
-            JSON.stringify(parameters, null, 2),
-            "utf8",
-          );
+export const test_llama_function_calling_additionalProperties = () =>
+  LlamaFunctionCaller.test({
+    model: "claude",
+    name: "enrollPerson",
+    description: "Enroll a person to the restaurant reservation list.",
+    collection: typia.json.schemas<[{ input: IPerson }]>(),
+    validate: typia.createValidate<{ input: IPerson }>(),
+    texts: [
+      {
+        role: "assistant",
+        content: SYSTEM_MESSAGE,
       },
-      handleCompletion: async (input) => {
-        typia.assert<IPerson>(input);
-        if (process.argv.includes("--file"))
-          await fs.promises.writeFile(
-            `${TestGlobal.ROOT}/examples/function-calling/arguments/llama.additionalProperties.input.json`,
-            JSON.stringify(input, null, 2),
-            "utf8",
-          );
+      {
+        role: "user",
+        content: USER_MESSAGE,
       },
-    });
+    ],
+    handleParameters: async (parameters) => {
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/schemas/llama.additionalProperties.schema.json`,
+          JSON.stringify(parameters, null, 2),
+          "utf8",
+        );
+    },
+    handleCompletion: async (input) => {
+      typia.assert<IPerson>(input);
+      if (process.argv.includes("--file"))
+        await fs.promises.writeFile(
+          `${TestGlobal.ROOT}/examples/function-calling/arguments/llama.additionalProperties.input.json`,
+          JSON.stringify(input, null, 2),
+          "utf8",
+        );
+    },
+  });
 
 interface IPerson {
   /**

--- a/test/features/llm/llama/test_llama_function_calling_empty.ts
+++ b/test/features/llm/llama/test_llama_function_calling_empty.ts
@@ -3,8 +3,8 @@ import OpenAI from "openai";
 
 import { TestGlobal } from "../../../TestGlobal";
 
-export const test_llama_function_calling_empty = async (): Promise<void> => {
-  if (TestGlobal.env.LLAMA_API_KEY === undefined) return;
+export const test_llama_function_calling_empty = async () => {
+  if (TestGlobal.env.LLAMA_API_KEY === undefined) return false;
 
   const client: OpenAI = new OpenAI({
     apiKey: TestGlobal.env.LLAMA_API_KEY,

--- a/test/features/llm/llama/test_llama_function_calling_nullable.ts
+++ b/test/features/llm/llama/test_llama_function_calling_nullable.ts
@@ -4,7 +4,7 @@ import typia from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { LlamaFunctionCaller } from "../../../utils/LlamaFunctionCaller";
 
-export const test_llama_function_calling_nullable = (): Promise<void> =>
+export const test_llama_function_calling_nullable = () =>
   LlamaFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "llama",
     config: {

--- a/test/features/llm/llama/test_llama_function_calling_sale.ts
+++ b/test/features/llm/llama/test_llama_function_calling_sale.ts
@@ -6,7 +6,7 @@ import { IShoppingSale } from "../../../structures/IShoppingSale";
 import { LlamaFunctionCaller } from "../../../utils/LlamaFunctionCaller";
 import { ShoppingSalePrompt } from "../../../utils/ShoppingSalePrompt";
 
-export const test_llama_function_calling_sale = async (): Promise<void> =>
+export const test_llama_function_calling_sale = async () =>
   LlamaFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "llama",
     ...ShoppingSalePrompt.schema(),

--- a/test/features/llm/llama/test_llama_function_calling_tags.ts
+++ b/test/features/llm/llama/test_llama_function_calling_tags.ts
@@ -4,7 +4,7 @@ import typia, { tags } from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { LlamaFunctionCaller } from "../../../utils/LlamaFunctionCaller";
 
-export const test_llama_function_calling_tags = (): Promise<void> =>
+export const test_llama_function_calling_tags = () =>
   LlamaFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "llama",
     name: "reserve",

--- a/test/features/llm/llama/test_llama_function_calling_union.ts
+++ b/test/features/llm/llama/test_llama_function_calling_union.ts
@@ -4,7 +4,7 @@ import typia from "typia";
 import { TestGlobal } from "../../../TestGlobal";
 import { LlamaFunctionCaller } from "../../../utils/LlamaFunctionCaller";
 
-export const test_llama_function_calling_union = (): Promise<void> =>
+export const test_llama_function_calling_union = () =>
   LlamaFunctionCaller.test({
     model: (TestGlobal.getArguments("model")[0] as any) ?? "llama",
     config: {

--- a/test/index.ts
+++ b/test/index.ts
@@ -30,7 +30,8 @@ const main = async (): Promise<void> => {
     onComplete: (exec) => {
       const trace = (str: string) =>
         console.log(`  - ${chalk.green(exec.name)}: ${str}`);
-      if (exec.error === null) {
+      if (exec.value === false) trace(chalk.gray("Pass"));
+      else if (exec.error === null) {
         const elapsed: number =
           new Date(exec.completed_at).getTime() -
           new Date(exec.started_at).getTime();

--- a/test/utils/ChatGptFunctionCaller.ts
+++ b/test/utils/ChatGptFunctionCaller.ts
@@ -26,8 +26,8 @@ export namespace ChatGptFunctionCaller {
     config?: Partial<IChatGptSchema.IConfig>;
   }
 
-  export const test = async (props: IProps): Promise<void> => {
-    if (TestGlobal.env.CHATGPT_API_KEY === undefined) return;
+  export const test = async (props: IProps) => {
+    if (TestGlobal.env.CHATGPT_API_KEY === undefined) return false;
 
     let result: IValidation<any> | undefined = undefined;
     for (let i: number = 0; i < 3; ++i) {

--- a/test/utils/ClaudeFunctionCaller.ts
+++ b/test/utils/ClaudeFunctionCaller.ts
@@ -29,8 +29,8 @@ export namespace ClaudeFunctionCaller {
 
   export const test = async <Model extends "chatgpt" | "claude" | "gemini">(
     props: IProps<Model>,
-  ): Promise<void> => {
-    if (TestGlobal.env.CLAUDE_API_KEY === undefined) return;
+  ) => {
+    if (TestGlobal.env.CLAUDE_API_KEY === undefined) return false;
 
     let result: IValidation<any> | undefined = undefined;
     for (let i: number = 0; i < 3; ++i) {

--- a/test/utils/DeepSeekFunctionCaller.ts
+++ b/test/utils/DeepSeekFunctionCaller.ts
@@ -30,8 +30,8 @@ export namespace DeepSeekFunctionCaller {
 
   export const test = async <Model extends ILlmSchema.Model>(
     props: IProps<Model>,
-  ): Promise<void> => {
-    if (TestGlobal.env.LLAMA_API_KEY === undefined) return;
+  ) => {
+    if (TestGlobal.env.LLAMA_API_KEY === undefined) return false;
 
     let result: IValidation<any> | undefined = undefined;
     for (let i: number = 0; i < 3; ++i) {

--- a/test/utils/GeminiFunctionCaller.ts
+++ b/test/utils/GeminiFunctionCaller.ts
@@ -30,8 +30,8 @@ export namespace GeminiFunctionCaller {
     config?: Partial<IGeminiSchema.IConfig>;
   }
 
-  export const test = async (props: IProps): Promise<void> => {
-    if (TestGlobal.env.GEMINI_API_KEY === undefined) return;
+  export const test = async (props: IProps) => {
+    if (TestGlobal.env.GEMINI_API_KEY === undefined) return false;
 
     let result: IValidation<any> | undefined = undefined;
     for (let i: number = 0; i < 3; ++i) {

--- a/test/utils/LlamaFunctionCaller.ts
+++ b/test/utils/LlamaFunctionCaller.ts
@@ -30,8 +30,8 @@ export namespace LlamaFunctionCaller {
 
   export const test = async <Model extends ILlmSchema.Model>(
     props: IProps<Model>,
-  ): Promise<void> => {
-    if (TestGlobal.env.LLAMA_API_KEY === undefined) return;
+  ) => {
+    if (TestGlobal.env.LLAMA_API_KEY === undefined) return false;
 
     let result: IValidation<any> | undefined = undefined;
     for (let i: number = 0; i < 3; ++i) {


### PR DESCRIPTION
This pull request includes several changes to update dependencies and refactor test functions for consistency and readability. The most important changes include updating the `@nestia/e2e` dependency version and refactoring test functions to remove unnecessary `async` keywords and return types.

Dependency updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R49): Updated `@nestia/e2e` dependency from version `0.7.0` to `0.8.2`.

Test function refactoring:
* [`test_chatgpt_function_calling_additionalProperties.ts`](diffhunk://#diff-fab959ad45f4f9175f75876f880357f82e4026f738a5321a784bab7cf0b5656dL7-R7): Removed unnecessary `async` keyword and return type.
* [`test_chatgpt_function_calling_description_length.ts`](diffhunk://#diff-3468b3e3eaca64577dc1ec4fc4492e07f1eee7f10c77dea0cc36fe6d7db71673L5-R6): Removed unnecessary `async` keyword and return type. [[1]](diffhunk://#diff-3468b3e3eaca64577dc1ec4fc4492e07f1eee7f10c77dea0cc36fe6d7db71673L5-R6) [[2]](diffhunk://#diff-3468b3e3eaca64577dc1ec4fc4492e07f1eee7f10c77dea0cc36fe6d7db71673L28)
* [`test_chatgpt_function_calling_empty.ts`](diffhunk://#diff-caf8161077b178b496aa00d03392052288d3eae6a024c920fd32bdd1259a2c99L6-R7): Changed return type to `boolean` to indicate the presence of an API key.
* [`test_chatgpt_function_calling_name_length.ts`](diffhunk://#diff-bd95ca07b7ca3f34a2ad3357a191a91b05a85e3ed64cc3be75ff984416a7debfL5-R6): Removed unnecessary `async` keyword and return type. [[1]](diffhunk://#diff-bd95ca07b7ca3f34a2ad3357a191a91b05a85e3ed64cc3be75ff984416a7debfL5-R6) [[2]](diffhunk://#diff-bd95ca07b7ca3f34a2ad3357a191a91b05a85e3ed64cc3be75ff984416a7debfL28)