### PR TITLE
Fix ChatGptSchemaComposer's strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/test/features/llm/chatgpt/test_chatgpt_schema_strict.ts
+++ b/test/features/llm/chatgpt/test_chatgpt_schema_strict.ts
@@ -1,0 +1,42 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema, IOpenApiSchemaError, IResult } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_chatgpt_schema_strict = (): void => {
+  const collection: IJsonSchemaCollection = typia.json.schemas<
+    [
+      {
+        id: string;
+        name: string;
+        hobbies: {
+          id: string;
+          name: string;
+        }[];
+      },
+    ]
+  >();
+  const res: IResult<ILlmSchema, IOpenApiSchemaError> =
+    LlmSchemaComposer.schema("chatgpt")({
+      config: {
+        ...LlmSchemaComposer.defaultConfig("chatgpt"),
+        strict: true,
+      },
+      components: collection.components,
+      schema: collection.schemas[0],
+      $defs: {},
+    } as any);
+  TestValidator.equals("strict")({
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      hobbies: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+        },
+      },
+    },
+  })((res.success ? res.value : null) as any);
+};


### PR DESCRIPTION
This pull request includes several changes to the `ChatGptSchemaComposer` and introduces a new test for the strict schema validation. The most important changes are the refactoring of the `transform` function to take a configuration object and the addition of a new test file.

Refactoring and improvements to `ChatGptSchemaComposer`:

* [`src/composers/llm/ChatGptSchemaComposer.ts`](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL46-R55): Refactored the `transform` function to accept a configuration object, allowing for more flexible schema transformations. This change affects multiple parts of the file, including how `$defs` and other schema properties are processed. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL46-R55) [[2]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL80-R95) [[3]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL112-R133) [[4]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL130-R170) [[5]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL170-R197)

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `2.5.1` to `2.5.2`.

New test for strict schema validation:

* [`test/features/llm/chatgpt/test_chatgpt_schema_strict.ts`](diffhunk://#diff-583bc7048d2bb5793b0a57e5c7f62e5a66cc56e5f628b543f9af54faf2997e8bR1-R42): Added a new test file to validate the strict schema configuration using `TestValidator` and `LlmSchemaComposer`.