### PR TITLE
`ChatGptSchemaComposer.separateParameters` added new property `convention`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/llm/ClaudeSchemaComposer.ts
+++ b/src/composers/llm/ClaudeSchemaComposer.ts
@@ -43,8 +43,9 @@ export namespace ClaudeSchemaComposer {
     });
 
   export const separateParameters = (props: {
-    predicate: (schema: IClaudeSchema) => boolean;
     parameters: IClaudeSchema.IParameters;
+    predicate: (schema: IClaudeSchema) => boolean;
+    convention?: (key: string, type: "llm" | "human") => string;
   }): ILlmFunction.ISeparated<"claude"> => {
     const separated: ILlmFunction.ISeparated<"3.1"> =
       LlmSchemaV3_1Composer.separateParameters(props);

--- a/src/composers/llm/LlamaSchemaComposer.ts
+++ b/src/composers/llm/LlamaSchemaComposer.ts
@@ -39,8 +39,9 @@ export namespace LlamaSchemaComposer {
     });
 
   export const separateParameters = (props: {
-    predicate: (schema: ILlamaSchema) => boolean;
     parameters: ILlamaSchema.IParameters;
+    predicate: (schema: ILlamaSchema) => boolean;
+    convention?: (key: string, type: "llm" | "human") => string;
   }): ILlmFunction.ISeparated<"llama"> =>
     LlmSchemaV3_1Composer.separateParameters(
       props,

--- a/src/utils/NamingConvention.ts
+++ b/src/utils/NamingConvention.ts
@@ -83,7 +83,7 @@ export namespace NamingConvention {
       if (last.length) ret += capitalize(piece);
       return prefix + escaper(ret);
     };
-}
 
-const capitalize = (str: string): string =>
-  str.length !== 0 ? str[0].toUpperCase() + str.slice(1).toLowerCase() : str;
+  export const capitalize = (str: string): string =>
+    str.length !== 0 ? str[0].toUpperCase() + str.slice(1).toLowerCase() : str;
+}


### PR DESCRIPTION
This pull request includes several changes to the `ChatGptSchemaComposer`, `ClaudeSchemaComposer`, `LlamaSchemaComposer`, and `LlmSchemaV3_1Composer` files, as well as updates to the `NamingConvention` utility. The main focus of these changes is the addition of a `convention` parameter to various functions to handle naming conventions more effectively.

Key changes include:

### General Enhancements:
* Added `NamingConvention` import to `ChatGptSchemaComposer`, `LlamaSchemaComposer`, and `LlmSchemaV3_1Composer` files to handle naming conventions. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR9) [[2]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R7)

### Function Parameter Updates:
* Added an optional `convention` parameter to the `separateParameters` function in `ChatGptSchemaComposer`, `ClaudeSchemaComposer`, `LlamaSchemaComposer`, and `LlmSchemaV3_1Composer` to customize naming conventions. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL226-R237) [[2]](diffhunk://#diff-09e976921cbf7ded8e1667800e245195ac7a939f7640fdd806acedcb69f91d65L46-R48) [[3]](diffhunk://#diff-5b7ae0e3be666c887786a4fdb4dfc30b7f0505900ff35bca89338d2f9d3ec0b6L42-R44) [[4]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L339-R351)

### Internal Function Updates:
* Updated internal functions like `separateStation`, `separateObject`, `separateArray`, and `separateReference` in `ChatGptSchemaComposer` and `LlmSchemaV3_1Composer` to use the new `convention` parameter. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL272-R280) [[2]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL284-R322) [[3]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR344) [[4]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL353-R368) [[5]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL365-R381) [[6]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL383-R440) [[7]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L385-R393) [[8]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L397-R435) [[9]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L443-R457) [[10]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L466-R481) [[11]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L478-R494) [[12]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L496-R568)

### Utility Function:
* Exported the `capitalize` function in `NamingConvention` to make it available for use in other modules.

### Version Update:
* Updated the version in `package.json` from `2.5.2` to `2.5.3`.