### PR TITLE
Experiment of `ISboppingSale.ICreate` validation feedback count

### DIFF
--- a/test/benchmark/validate.ts
+++ b/test/benchmark/validate.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+
+import { TestGlobal } from "../TestGlobal";
+import { ChatGptFunctionCaller } from "../utils/ChatGptFunctionCaller";
+import { ShoppingSalePrompt } from "../utils/ShoppingSalePrompt";
+
+const main = async (): Promise<void> => {
+  const trials: number[] = await Promise.all(
+    new Array(100).fill(0).map(async () => {
+      const counter = { value: 0 };
+      await ChatGptFunctionCaller.test({
+        config: {
+          reference: process.argv.includes("--reference"),
+        },
+        ...ShoppingSalePrompt.schema(),
+        texts: await ShoppingSalePrompt.texts(),
+        handleParameters: async (parameters) => {
+          if (process.argv.includes("--file"))
+            fs.promises.writeFile(
+              `${TestGlobal.ROOT}/examples/function-calling/schemas/chatgpt.sale.schema.json`,
+              JSON.stringify(parameters, null, 2),
+              "utf8",
+            );
+        },
+        handleCompletion: async () => {},
+        counter,
+        model: "gpt-4o",
+      });
+      return counter.value;
+    }),
+  );
+  console.log(trials);
+};
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/test/examples/chatgpt-function-call-to-sale-create.ts
+++ b/test/examples/chatgpt-function-call-to-sale-create.ts
@@ -33,7 +33,7 @@ const main = async (): Promise<void> => {
   // Let's imagine that LLM has selected a function to call
   const func: IHttpLlmFunction<"chatgpt"> | undefined =
     application.functions.find(
-      // (f) => f.name === "llm_selected_fuction_name"
+      // (f) => f.name === "llm_selected_function_name"
       (f) => f.path === "/shoppings/sellers/sale" && f.method === "post",
     );
   if (func === undefined) throw new Error("No matched function exists.");

--- a/test/utils/ChatGptFunctionCaller.ts
+++ b/test/utils/ChatGptFunctionCaller.ts
@@ -24,6 +24,8 @@ export namespace ChatGptFunctionCaller {
       parameters: IChatGptSchema.IParameters,
     ) => Promise<void>;
     config?: Partial<IChatGptSchema.IConfig>;
+    counter?: { value: number };
+    model?: OpenAI.ChatModel | (string & {});
   }
 
   export const test = async (props: IProps) => {
@@ -31,6 +33,7 @@ export namespace ChatGptFunctionCaller {
 
     let result: IValidation<any> | undefined = undefined;
     for (let i: number = 0; i < 3; ++i) {
+      if (props.counter) props.counter.value = i + 1;
       if (result && result.success === true) break;
       result = await step(props, TestGlobal.env.CHATGPT_API_KEY, result);
     }
@@ -65,7 +68,7 @@ export namespace ChatGptFunctionCaller {
     });
     const completion: OpenAI.ChatCompletion =
       await client.chat.completions.create({
-        model: "gpt-4o",
+        model: props.model ?? "gpt-4o",
         messages: previous
           ? [
               ...props.texts.slice(0, -1),


### PR DESCRIPTION
This pull request introduces several changes to enhance the testing and validation process for ChatGPT function calls and shopping sale prompts. The key changes include the addition of a new benchmark validation script, updates to the `ChatGptFunctionCaller` utility, and minor corrections in existing test scripts.

### Enhancements to testing and validation:

* **New benchmark validation script:**
  - Added a new script `test/benchmark/validate.ts` to perform multiple trials of ChatGPT function calls and log the results. This script includes asynchronous handling of parameters and completions, as well as optional file writing for schema outputs.

* **Updates to `ChatGptFunctionCaller` utility:**
  - Introduced optional `counter` and `model` properties in the `IProps` interface to track the number of attempts and specify the model used for completions.
  - Modified the `test` function to increment the counter value on each attempt and use the specified model if provided.

### Minor corrections:

* **Typo correction:**
  - Fixed a typo in a comment within the `test/examples/chatgpt-function-call-to-sale-create.ts` file, changing "llm_selected_fuction_name" to "llm_selected_function_name".