### PR TITLE
Make `HttpLlm.application()` function convenient.

### DIFF
--- a/src/HttpLlm.ts
+++ b/src/HttpLlm.ts
@@ -1,5 +1,8 @@
 import { HttpMigration } from "./HttpMigration";
 import { OpenApi } from "./OpenApi";
+import { OpenApiV3 } from "./OpenApiV3";
+import { OpenApiV3_1 } from "./OpenApiV3_1";
+import { SwaggerV2 } from "./SwaggerV2";
 import { HttpLlmComposer } from "./composers/HttpLlmApplicationComposer";
 import { LlmSchemaComposer } from "./composers/LlmSchemaComposer";
 import { HttpLlmFunctionFetcher } from "./http/HttpLlmFunctionFetcher";
@@ -52,7 +55,11 @@ export namespace HttpLlm {
     /**
      * OpenAPI document to convert.
      */
-    document: OpenApi.IDocument;
+    document:
+      | OpenApi.IDocument
+      | SwaggerV2.IDocument
+      | OpenApiV3.IDocument
+      | OpenApiV3_1.IDocument;
 
     /**
      * Options for the LLM function calling schema conversion.
@@ -90,7 +97,7 @@ export namespace HttpLlm {
   ): IHttpLlmApplication<Model> => {
     // MIGRATE
     const migrate: IHttpMigrateApplication = HttpMigration.application(
-      props.document as OpenApi.IDocument,
+      props.document,
     );
     return HttpLlmComposer.application<Model>({
       migrate,

--- a/src/HttpMigration.ts
+++ b/src/HttpMigration.ts
@@ -1,4 +1,7 @@
 import { OpenApi } from "./OpenApi";
+import { OpenApiV3 } from "./OpenApiV3";
+import { OpenApiV3_1 } from "./OpenApiV3_1";
+import { SwaggerV2 } from "./SwaggerV2";
 import { HttpMigrateApplicationComposer } from "./composers/migrate/HttpMigrateApplicationComposer";
 import { HttpMigrateRouteFetcher } from "./http/HttpMigrateRouteFetcher";
 import { IHttpConnection } from "./structures/IHttpConnection";
@@ -73,9 +76,13 @@ export namespace HttpMigration {
    * @returns Migrated application.
    */
   export const application = (
-    document: OpenApi.IDocument,
+    document:
+      | OpenApi.IDocument
+      | SwaggerV2.IDocument
+      | OpenApiV3.IDocument
+      | OpenApiV3_1.IDocument,
   ): IHttpMigrateApplication =>
-    HttpMigrateApplicationComposer.compose(document);
+    HttpMigrateApplicationComposer.compose(OpenApi.convert(document));
 
   /**
    * Properties for the request to the HTTP server.


### PR DESCRIPTION
This pull request includes changes to support additional OpenAPI and Swagger document versions in the `HttpLlm` and `HttpMigration` modules. The most important changes include updating the document type definitions and modifying the migration application composition process.

Support for additional document versions:

* [`src/HttpLlm.ts`](diffhunk://#diff-0c890635e48b22e4dea1926131f2726dff205a7f9f78cb2e29cdc0ddedecb8c8R3-R5): Added imports for `OpenApiV3`, `OpenApiV3_1`, and `SwaggerV2` to support additional document versions. Updated the `document` type in the `HttpLlm` namespace to include these new types. [[1]](diffhunk://#diff-0c890635e48b22e4dea1926131f2726dff205a7f9f78cb2e29cdc0ddedecb8c8R3-R5) [[2]](diffhunk://#diff-0c890635e48b22e4dea1926131f2726dff205a7f9f78cb2e29cdc0ddedecb8c8L55-R62)
* [`src/HttpMigration.ts`](diffhunk://#diff-5ff67abc93efa2ae733c4a2334753c7bb4b3fc30ea69ae4024f3110d376721c0R2-R4): Added imports for `OpenApiV3`, `OpenApiV3_1`, and `SwaggerV2` to support additional document versions. Updated the `document` type in the `HttpMigration` namespace to include these new types. [[1]](diffhunk://#diff-5ff67abc93efa2ae733c4a2334753c7bb4b3fc30ea69ae4024f3110d376721c0R2-R4) [[2]](diffhunk://#diff-5ff67abc93efa2ae733c4a2334753c7bb4b3fc30ea69ae4024f3110d376721c0L76-R85)

Migration application composition:

* [`src/HttpLlm.ts`](diffhunk://#diff-0c890635e48b22e4dea1926131f2726dff205a7f9f78cb2e29cdc0ddedecb8c8L93-R100): Modified the `application` method in the `HttpLlm` namespace to handle the updated `document` type without casting.
* [`src/HttpMigration.ts`](diffhunk://#diff-5ff67abc93efa2ae733c4a2334753c7bb4b3fc30ea69ae4024f3110d376721c0L76-R85): Modified the `application` method in the `HttpMigration` namespace to use `OpenApi.convert` for document conversion before composing the migration application.