### PR TITLE
feat(test): add strict mode option for function calling

### DIFF
--- a/test/benchmark/validate.ts
+++ b/test/benchmark/validate.ts
@@ -11,6 +11,7 @@ const main = async (): Promise<void> => {
       await ChatGptFunctionCaller.test({
         config: {
           reference: process.argv.includes("--reference"),
+          strict: process.argv.includes("--strict"),
         },
         ...ShoppingSalePrompt.schema(),
         texts: await ShoppingSalePrompt.texts(),

--- a/test/utils/ChatGptFunctionCaller.ts
+++ b/test/utils/ChatGptFunctionCaller.ts
@@ -108,6 +108,7 @@ export namespace ChatGptFunctionCaller {
               name: props.name,
               description: props.description,
               parameters: parameters.value as Record<string, any>,
+              strict: props.config?.strict ?? false,
             },
           },
         ],


### PR DESCRIPTION
Adds a --strict command line flag for validation tests and passes the strict parameter to the OpenAI function definition when enabled. This allows testing function calls with strict schema validation.