### PR TITLE
Fix `ILlmSchema.IParameters` missing reference descriptions problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/llm/GeminiSchemaComposer.ts
+++ b/src/composers/llm/GeminiSchemaComposer.ts
@@ -30,10 +30,10 @@ export namespace GeminiSchemaComposer {
         method: "GeminiSchemaComposer.parameters",
       });
     if (entity.success === false) return entity;
-    return schema({
-      ...props,
-      schema: entity.value,
-    }) as IResult<IGeminiSchema.IParameters, IOpenApiSchemaError>;
+    return schema(props) as IResult<
+      IGeminiSchema.IParameters,
+      IOpenApiSchemaError
+    >;
   };
 
   export const schema = (props: {

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -40,10 +40,7 @@ export namespace LlmSchemaV3Composer {
       });
     if (entity.success === false) return entity;
 
-    const result: IResult<ILlmSchemaV3, IOpenApiSchemaError> = schema({
-      ...props,
-      schema: entity.value,
-    });
+    const result: IResult<ILlmSchemaV3, IOpenApiSchemaError> = schema(props);
     if (result.success === false) return result;
     return {
       success: true,

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -54,6 +54,14 @@ export namespace LlmSchemaV3_1Composer {
         ...(result.value as ILlmSchemaV3_1.IObject),
         additionalProperties: false,
         $defs,
+        description: OpenApiTypeChecker.isReference(props.schema)
+          ? JsonDescriptionUtil.cascade({
+              prefix: "#/components/schemas/",
+              components: props.components,
+              schema: props.schema,
+              escape: true,
+            })
+          : result.value.description,
       } satisfies ILlmSchemaV3_1.IParameters,
     };
   };

--- a/test/features/llm/validate_llm_parameters_reference_escaped_description_of_name.ts
+++ b/test/features/llm/validate_llm_parameters_reference_escaped_description_of_name.ts
@@ -1,0 +1,80 @@
+import { TestValidator } from "@nestia/e2e";
+import {
+  ILlmSchema,
+  IOpenApiSchemaError,
+  IResult,
+  OpenApi,
+} from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_chatgpt_parameters_reference_escaped_description_of_name =
+  (): void =>
+    validate_llm_parameters_reference_escaped_description_of_name("chatgpt");
+
+export const test_claude_parameters_reference_escaped_description_of_name =
+  (): void =>
+    validate_llm_parameters_reference_escaped_description_of_name("claude");
+
+export const test_gemini_parameters_reference_escaped_description_of_name =
+  (): void =>
+    validate_llm_parameters_reference_escaped_description_of_name("gemini");
+
+export const test_llama_parameters_reference_escaped_description_of_name =
+  (): void =>
+    validate_llm_parameters_reference_escaped_description_of_name("llama");
+
+export const test_llm_v30_parameters_reference_escaped_description_of_name =
+  (): void =>
+    validate_llm_parameters_reference_escaped_description_of_name("3.0");
+
+export const test_llm_v31_parameters_reference_escaped_description_of_name =
+  (): void =>
+    validate_llm_parameters_reference_escaped_description_of_name("3.1");
+
+const validate_llm_parameters_reference_escaped_description_of_name = <
+  Model extends ILlmSchema.Model,
+>(
+  model: Model,
+): void => {
+  const collection: IJsonSchemaCollection =
+    typia.json.schemas<[Something.INested.IDeep]>();
+  const deep: ILlmSchema.IParameters<Model> = composeSchema(model)(collection);
+  TestValidator.predicate("description")(
+    () => !!deep.description?.includes("Something.INested.IDeep"),
+  );
+};
+
+interface Something {
+  x: number;
+}
+namespace Something {
+  export interface INested {
+    y: number;
+  }
+  export namespace INested {
+    export interface IDeep {
+      z: number;
+    }
+  }
+}
+
+const composeSchema =
+  <Model extends ILlmSchema.Model>(model: Model) =>
+  (collection: IJsonSchemaCollection): ILlmSchema.IParameters<Model> => {
+    const result: IResult<
+      ILlmSchema.IParameters<Model>,
+      IOpenApiSchemaError
+    > = LlmSchemaComposer.parameters(model)({
+      components: collection.components,
+      schema: typia.assert<
+        OpenApi.IJsonSchema.IObject | OpenApi.IJsonSchema.IReference
+      >(collection.schemas[0]),
+      config: {
+        ...LlmSchemaComposer.defaultConfig(model),
+        reference: false,
+      } satisfies ILlmSchema.IConfig<Model> as any,
+    }) as IResult<ILlmSchema.IParameters<Model>, IOpenApiSchemaError>;
+    if (result.success === false) throw new Error("Invalid schema");
+    return result.value;
+  };


### PR DESCRIPTION
This pull request includes several updates to the `@samchon/openapi` package, focusing on schema composition and validation improvements. The changes include version updates, simplification of schema composition logic, and the addition of new test cases for validating escaped descriptions.

### Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `3.2.0` to `3.2.1`.

### Schema composition improvements:
* [`src/composers/llm/GeminiSchemaComposer.ts`](diffhunk://#diff-4e9da1f0bdac90742383f58756d5fe60a9d5de3293d24f67f6015f9e88d54759L33-R36): Simplified the schema composition by removing the spread operator and directly passing `props` to the `schema` function.
* [`src/composers/llm/LlmSchemaV3Composer.ts`](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L43-R43): Simplified the schema composition by removing the spread operator and directly passing `props` to the `schema` function.
* [`src/composers/llm/LlmSchemaV3_1Composer.ts`](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R57-R64): Enhanced the schema composition to include a description when the schema is a reference, using `JsonDescriptionUtil.cascade`.

### Testing improvements:
* [`test/features/llm/validate_llm_parameters_reference_escaped_description_of_name.ts`](diffhunk://#diff-0d3f085e98d908d6e8401bd1aa794cb1a011f1eb5b73dfd5dc593bf5bc21f3d6R1-R80): Added new test cases to validate the escaped descriptions for various LLM models, ensuring the correct handling of schema references.