### PR TITLE
Fix zero string length instead of undefined problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/utils/internal/JsonDescriptionUtil.ts
+++ b/src/utils/internal/JsonDescriptionUtil.ts
@@ -24,6 +24,8 @@ export namespace JsonDescriptionUtil {
         (schema, i): schema is IParentReference =>
           i === 0 || !!schema?.description,
       );
+    if (!props.schema.description?.length && pReferences.length === 0)
+      return undefined;
     return [
       ...(!!props.schema.description?.length ? [props.schema.description] : []),
       ...pReferences.map((pRef, i) =>


### PR DESCRIPTION
This pull request includes a version update for the `@samchon/openapi` package and a change to the `JsonDescriptionUtil` utility to handle cases where there is no description or parent references.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version of `@samchon/openapi` from `3.2.1` to `3.2.2`.

Enhancements to `JsonDescriptionUtil`:

* [`src/utils/internal/JsonDescriptionUtil.ts`](diffhunk://#diff-1d99bef15c7e17d904357ea02b82dc443b7142f4ad7d87bad6cf928d3cc1b434R27-R28): Added a check to return `undefined` if there is no description and no parent references.