### PR TITLE
Fix `HttpLlm.application()`'s options problem.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/HttpLlm.ts
+++ b/src/HttpLlm.ts
@@ -99,11 +99,18 @@ export namespace HttpLlm {
     const migrate: IHttpMigrateApplication = HttpMigration.application(
       props.document,
     );
+    const defaultConfig: ILlmSchema.IConfig<Model> =
+      LlmSchemaComposer.defaultConfig(props.model);
     return HttpLlmComposer.application<Model>({
       migrate,
       model: props.model,
       options: {
-        ...LlmSchemaComposer.defaultConfig(props.model),
+        ...Object.fromEntries(
+          Object.entries(defaultConfig).map(
+            ([key, value]) =>
+              [key, (props.options as any)?.[key] ?? value] as const,
+          ),
+        ),
         separate: props.options?.separate ?? null,
         maxLength: props.options?.maxLength ?? null,
       } as any as IHttpLlmApplication.IOptions<Model>,


### PR DESCRIPTION
This pull request includes a version update and an improvement to the configuration handling in the `HttpLlm` namespace. The most important changes are:

Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `3.2.2` to `3.2.3`.

Configuration handling improvement:
* [`src/HttpLlm.ts`](diffhunk://#diff-0c890635e48b22e4dea1926131f2726dff205a7f9f78cb2e29cdc0ddedecb8c8R102-R113): Introduced `defaultConfig` for `ILlmSchema.IConfig<Model>` and modified the options merging logic to use `Object.fromEntries` for cleaner and more readable code.