### PR TITLE
Exact `LlmSchemaComposer.invert()` function.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/llm/ChatGptSchemaComposer.ts
+++ b/src/composers/llm/ChatGptSchemaComposer.ts
@@ -510,8 +510,8 @@ export namespace ChatGptSchemaComposer {
     const visit = (schema: IChatGptSchema): void => {
       if (ChatGptTypeChecker.isArray(schema))
         union.push({
-          ...LlmDescriptionInverter.array(schema.description ?? ""),
           ...schema,
+          ...LlmDescriptionInverter.array(schema.description),
           items: next(schema.items),
         });
       else if (ChatGptTypeChecker.isObject(schema))
@@ -561,8 +561,8 @@ export namespace ChatGptSchemaComposer {
           );
         else
           union.push({
-            ...LlmDescriptionInverter.numeric(schema.description ?? ""),
             ...schema,
+            ...LlmDescriptionInverter.numeric(schema.description),
             ...{ enum: undefined },
           });
       else if (ChatGptTypeChecker.isString(schema))
@@ -574,8 +574,8 @@ export namespace ChatGptSchemaComposer {
           );
         else
           union.push({
-            ...LlmDescriptionInverter.string(schema.description ?? ""),
             ...schema,
+            ...LlmDescriptionInverter.string(schema.description),
             ...{ enum: undefined },
           });
       else
@@ -586,12 +586,12 @@ export namespace ChatGptSchemaComposer {
     visit(props.schema);
 
     return {
+      ...attribute,
       ...(union.length === 0
         ? { type: undefined }
         : union.length === 1
           ? { ...union[0] }
           : { oneOf: union.map((u) => ({ ...u, nullable: undefined })) }),
-      ...attribute,
     };
   };
 }

--- a/src/composers/llm/LlmDescriptionInverter.ts
+++ b/src/composers/llm/LlmDescriptionInverter.ts
@@ -80,7 +80,7 @@ export namespace LlmDescriptionInverter {
       pattern: find({
         type: "string",
         name: "pattern",
-        lines: description.split("\n"),
+        lines,
       }),
       contentMediaType: find({
         type: "string",
@@ -95,7 +95,7 @@ export namespace LlmDescriptionInverter {
       maxLength: find({
         type: "number",
         name: "maxLength",
-        lines: description.split("\n"),
+        lines,
       }),
       description: describe(lines, [
         "format",
@@ -160,13 +160,12 @@ export namespace LlmDescriptionInverter {
   };
 
   const describe = (lines: string[], tags: string[]): string | undefined => {
-    const ret = trimArray(
+    const ret: string = trimArray(
       lines
         .map((str) => str.trim())
-        .filter((str) => {
-          str = str.trim();
-          return tags.every((tag) => str.startsWith(`@${tag}`) === false);
-        }),
+        .filter((str) =>
+          tags.every((tag) => str.startsWith(`@${tag}`) === false),
+        ),
     ).join("\n");
     return ret.length === 0 ? undefined : ret;
   };

--- a/src/composers/llm/LlmDescriptionInverter.ts
+++ b/src/composers/llm/LlmDescriptionInverter.ts
@@ -2,7 +2,7 @@ import { OpenApi } from "../../OpenApi";
 
 export namespace LlmDescriptionInverter {
   export const numeric = (
-    description: string,
+    description: string | undefined,
   ): Pick<
     OpenApi.IJsonSchema.INumber,
     | "minimum"
@@ -10,7 +10,10 @@ export namespace LlmDescriptionInverter {
     | "exclusiveMinimum"
     | "exclusiveMaximum"
     | "multipleOf"
+    | "description"
   > => {
+    if (description === undefined) return {};
+
     const lines: string[] = description.split("\n");
     const exclusiveMinimum: number | undefined = find({
       type: "number",
@@ -44,15 +47,29 @@ export namespace LlmDescriptionInverter {
         name: "multipleOf",
         lines,
       }),
+      description: describe(lines, [
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+      ]),
     };
   };
 
   export const string = (
-    description: string,
+    description: string | undefined,
   ): Pick<
     OpenApi.IJsonSchema.IString,
-    "format" | "pattern" | "contentMediaType" | "minLength" | "maxLength"
+    | "format"
+    | "pattern"
+    | "contentMediaType"
+    | "minLength"
+    | "maxLength"
+    | "description"
   > => {
+    if (description === undefined) return {};
+
     const lines: string[] = description.split("\n");
     return {
       format: find({
@@ -80,15 +97,24 @@ export namespace LlmDescriptionInverter {
         name: "maxLength",
         lines: description.split("\n"),
       }),
+      description: describe(lines, [
+        "format",
+        "pattern",
+        "contentMediaType",
+        "minLength",
+        "maxLength",
+      ]),
     };
   };
 
   export const array = (
-    description: string,
+    description: string | undefined,
   ): Pick<
     OpenApi.IJsonSchema.IArray,
-    "minItems" | "maxItems" | "uniqueItems"
+    "minItems" | "maxItems" | "uniqueItems" | "description"
   > => {
+    if (description === undefined) return {};
+
     const lines: string[] = description.split("\n");
     return {
       minItems: find({
@@ -106,6 +132,7 @@ export namespace LlmDescriptionInverter {
         name: "uniqueItems",
         lines,
       }),
+      description: describe(lines, ["minItems", "maxItems", "uniqueItems"]),
     };
   };
 
@@ -130,5 +157,27 @@ export namespace LlmDescriptionInverter {
       return value as any;
     }
     return undefined as any;
+  };
+
+  const describe = (lines: string[], tags: string[]): string | undefined => {
+    const ret = trimArray(
+      lines
+        .map((str) => str.trim())
+        .filter((str) => {
+          str = str.trim();
+          return tags.every((tag) => str.startsWith(`@${tag}`) === false);
+        }),
+    ).join("\n");
+    return ret.length === 0 ? undefined : ret;
+  };
+
+  const trimArray = (array: string[]): string[] => {
+    let first: number = 0;
+    let last: number = array.length - 1;
+
+    for (; first < array.length; ++first)
+      if (array[first]!.trim().length !== 0) break;
+    for (; last >= 0; --last) if (array[last]!.trim().length !== 0) break;
+    return array.slice(first, last + 1);
   };
 }

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -310,21 +310,21 @@ export namespace LlmSchemaV3Composer {
       closure: (schema) => {
         if (OpenApiTypeChecker.isArray(schema))
           Object.assign(schema, {
-            ...LlmDescriptionInverter.array(schema.description ?? ""),
             ...schema,
+            ...LlmDescriptionInverter.array(schema.description),
           });
         else if (
           OpenApiTypeChecker.isInteger(schema) ||
           OpenApiTypeChecker.isNumber(schema)
         )
           Object.assign(schema, {
-            ...LlmDescriptionInverter.numeric(schema.description ?? ""),
             ...schema,
+            ...LlmDescriptionInverter.numeric(schema.description),
           });
         else if (OpenApiTypeChecker.isString(schema))
           Object.assign(schema, {
-            ...LlmDescriptionInverter.string(schema.description ?? ""),
             ...schema,
+            ...LlmDescriptionInverter.string(schema.description),
           });
       },
       components: {},

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -608,8 +608,8 @@ export namespace LlmSchemaV3_1Composer {
       });
     if (LlmTypeCheckerV3_1.isArray(props.schema))
       return {
-        ...LlmDescriptionInverter.array(props.schema.description ?? ""),
         ...props.schema,
+        ...LlmDescriptionInverter.array(props.schema.description),
         items: next(props.schema.items),
       };
     else if (LlmTypeCheckerV3_1.isObject(props.schema))
@@ -645,13 +645,13 @@ export namespace LlmSchemaV3_1Composer {
       LlmTypeCheckerV3_1.isNumber(props.schema)
     )
       return {
-        ...LlmDescriptionInverter.numeric(props.schema.description ?? ""),
         ...props.schema,
+        ...LlmDescriptionInverter.numeric(props.schema.description),
       };
     else if (LlmTypeCheckerV3_1.isString(props.schema))
       return {
-        ...LlmDescriptionInverter.string(props.schema.description ?? ""),
         ...props.schema,
+        ...LlmDescriptionInverter.string(props.schema.description),
       };
     return props.schema;
   };

--- a/test/executable/chatgpt-invert.ts
+++ b/test/executable/chatgpt-invert.ts
@@ -1,0 +1,11 @@
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { tags } from "typia";
+
+for (const model of ["chatgpt", "gemini", "llama", "3.0", "3.1"] as const) {
+  const invert = LlmSchemaComposer.invert(model)({
+    components: {},
+    $defs: {},
+    schema: typia.llm.schema<string & tags.Format<"uuid">, "chatgpt">({}),
+  } as any);
+  console.log(invert);
+}

--- a/test/features/llm/validate_llm_schema_invert.ts
+++ b/test/features/llm/validate_llm_schema_invert.ts
@@ -104,4 +104,61 @@ const validate_llm_schema_invert = <Model extends ILlmSchema.Model>(
     maxItems: 5,
     uniqueItems: true,
   });
+
+  TestValidator.equals("number")(
+    LlmSchemaComposer.invert(model)({
+      components: {},
+      $defs: {},
+      schema: typia.llm.schema<
+        number &
+          tags.ExclusiveMinimum<0> &
+          tags.ExclusiveMaximum<100> &
+          tags.MultipleOf<5>,
+        "chatgpt"
+      >({}),
+    } as any),
+  )({
+    type: "number",
+    minimum: 0,
+    maximum: 100,
+    multipleOf: 5,
+    exclusiveMinimum: true,
+    exclusiveMaximum: true,
+  });
+
+  TestValidator.equals("object")(
+    LlmSchemaComposer.invert(model)({
+      components: {},
+      $defs: {},
+      schema: typia.llm.schema<
+        {
+          /**
+           * List of items.
+           *
+           * List of items containing any string values.
+           */
+          array: Array<string & tags.Pattern<"*">>;
+        },
+        "chatgpt"
+      >({}),
+    } as any),
+  )({
+    type: "object",
+    properties: {
+      array: {
+        type: "array",
+        items: {
+          type: "string",
+          pattern: "*",
+        },
+        minItems: 1,
+        maxItems: 5,
+        uniqueItems: true,
+        title: "List of items",
+        description:
+          "List of items.\n\nList of items containing any string values.",
+      },
+    },
+    required: ["array"],
+  });
 };

--- a/test/features/llm/validate_llm_schema_invert.ts
+++ b/test/features/llm/validate_llm_schema_invert.ts
@@ -1,0 +1,107 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
+import typia, { tags } from "typia";
+
+export const test_chatgpt_schema_invert = () =>
+  validate_llm_schema_invert("chatgpt");
+
+export const test_gemini_schema_invert = () =>
+  validate_llm_schema_invert("gemini");
+
+export const test_llama_schema_invert = () =>
+  validate_llm_schema_invert("llama");
+
+export const test_llm_v30_schema_invert = () =>
+  validate_llm_schema_invert("3.0");
+
+export const test_llm_v31_schema_invert = () =>
+  validate_llm_schema_invert("3.1");
+
+const validate_llm_schema_invert = <Model extends ILlmSchema.Model>(
+  model: Model,
+) => {
+  TestValidator.equals("string")(
+    LlmSchemaComposer.invert(model)({
+      components: {},
+      $defs: {},
+      schema: typia.llm.schema<
+        string &
+          tags.Format<"uri"> &
+          tags.ContentMediaType<"image/*"> &
+          tags.MinLength<0> &
+          tags.MaxLength<128>,
+        "chatgpt"
+      >({}),
+    } as any),
+  )({
+    type: "string",
+    format: "uri",
+    contentMediaType: "image/*",
+    minLength: 0,
+    maxLength: 128,
+  });
+
+  TestValidator.equals("integer")(
+    LlmSchemaComposer.invert(model)({
+      components: {},
+      $defs: {},
+      schema: typia.llm.schema<
+        number &
+          tags.Type<"int32"> &
+          tags.ExclusiveMinimum<0> &
+          tags.ExclusiveMaximum<100> &
+          tags.MultipleOf<5> &
+          tags.Default<5>,
+        "chatgpt"
+      >({}),
+    } as any),
+  )({
+    type: "integer",
+    minimum: 0,
+    maximum: 100,
+    multipleOf: 5,
+    exclusiveMinimum: true,
+    exclusiveMaximum: true,
+  });
+
+  TestValidator.equals("number")(
+    LlmSchemaComposer.invert(model)({
+      components: {},
+      $defs: {},
+      schema: typia.llm.schema<
+        number &
+          tags.ExclusiveMinimum<0> &
+          tags.ExclusiveMaximum<100> &
+          tags.MultipleOf<5>,
+        "chatgpt"
+      >({}),
+    } as any),
+  )({
+    type: "number",
+    minimum: 0,
+    maximum: 100,
+    multipleOf: 5,
+    exclusiveMinimum: true,
+    exclusiveMaximum: true,
+  });
+
+  TestValidator.equals("array")(
+    LlmSchemaComposer.invert(model)({
+      components: {},
+      $defs: {},
+      schema: typia.llm.schema<Array<string & tags.Pattern<"*">>, "chatgpt">(
+        {},
+      ),
+    } as any),
+  )({
+    type: "array",
+    items: {
+      type: "string",
+      pattern: "*",
+    },
+    minItems: 1,
+    maxItems: 5,
+    uniqueItems: true,
+  });
+};


### PR DESCRIPTION
This pull request includes several changes primarily aimed at improving the handling of descriptions in the `LlmDescriptionInverter` and adding new test cases for schema inversion. The most important changes include modifying the `LlmDescriptionInverter` methods to handle undefined descriptions, updating the `ChatGptSchemaComposer` and `LlmSchemaV3Composer` to remove unnecessary nullish coalescing operators, and adding test cases for schema inversion.

Improvements to description handling:

* [`src/composers/llm/LlmDescriptionInverter.ts`](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837L5-R16): Modified the `numeric`, `string`, and `array` methods to handle `undefined` descriptions and added a new `describe` function to filter out tags and trim the description lines. [[1]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837L5-R16) [[2]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837R50-R72) [[3]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837R100-R117) [[4]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837R135) [[5]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837R161-R182)

Codebase simplification:

* [`src/composers/llm/ChatGptSchemaComposer.ts`](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL513-R514): Removed unnecessary nullish coalescing operators when passing descriptions to `LlmDescriptionInverter` methods. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL513-R514) [[2]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL564-R565) [[3]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfL577-R578) [[4]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR589-L594)
* [`src/composers/llm/LlmSchemaV3Composer.ts`](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4L313-R327): Removed unnecessary nullish coalescing operators when passing descriptions to `LlmDescriptionInverter` methods.
* [`src/composers/llm/LlmSchemaV3_1Composer.ts`](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L611-R612): Removed unnecessary nullish coalescing operators when passing descriptions to `LlmDescriptionInverter` methods. [[1]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L611-R612) [[2]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L648-R654)

New test cases:

* [`test/executable/chatgpt-invert.ts`](diffhunk://#diff-4a3392dc204796969ea708751bb3e84ce5178925551158b800090177b02daae4R1-R11): Added a new test script to validate schema inversion for different models.
* [`test/features/llm/validate_llm_schema_invert.ts`](diffhunk://#diff-276684786c4ca4b5dbed589a1449f3677e5534852c04d9b5a1284eee5009f021R1-R107): Added comprehensive test cases to validate the schema inversion for various types including string, integer, number, and array.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `3.2.3` to `3.2.4`.Remove duplicated JSDocTag and constraint property.