### PR TITLE
Fix JSON schema: SwaggerV2 and OpenApiV3 -> exclusiveMinimum/Maximum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/OpenApiV3.ts
+++ b/src/OpenApiV3.ts
@@ -193,8 +193,8 @@ export namespace OpenApiV3 {
       /** @type int64 */ enum?: Array<number | null>;
       /** @type int64 */ minimum?: number;
       /** @type int64 */ maximum?: number;
-      exclusiveMinimum?: boolean;
-      exclusiveMaximum?: boolean;
+      exclusiveMinimum?: number | boolean;
+      exclusiveMaximum?: number | boolean;
       /**
        * @type uint64
        * @exclusiveMinimum 0
@@ -207,8 +207,8 @@ export namespace OpenApiV3 {
       enum?: Array<number | null>;
       minimum?: number;
       maximum?: number;
-      exclusiveMinimum?: boolean;
-      exclusiveMaximum?: boolean;
+      exclusiveMinimum?: number | boolean;
+      exclusiveMaximum?: number | boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
     export interface IString extends __ISignificant<"string"> {

--- a/src/SwaggerV2.ts
+++ b/src/SwaggerV2.ts
@@ -145,8 +145,8 @@ export namespace SwaggerV2 {
       /** @type int64 */ enum?: Array<number | null>;
       /** @type int64 */ minimum?: number;
       /** @type int64 */ maximum?: number;
-      exclusiveMinimum?: boolean;
-      exclusiveMaximum?: boolean;
+      exclusiveMinimum?: number | boolean;
+      exclusiveMaximum?: number | boolean;
       /**
        * @type uint64
        * @exclusiveMinimum 0
@@ -160,8 +160,8 @@ export namespace SwaggerV2 {
       enum?: Array<number | null>;
       minimum?: number;
       maximum?: number;
-      exclusiveMinimum?: boolean;
-      exclusiveMaximum?: boolean;
+      exclusiveMinimum?: number | boolean;
+      exclusiveMaximum?: number | boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
     export interface IString

--- a/src/converters/OpenApiV3Upgrader.ts
+++ b/src/converters/OpenApiV3Upgrader.ts
@@ -299,6 +299,35 @@ export namespace OpenApiV3Upgrader {
                 .filter((v) => v !== null)
                 .map((value) => ({ const: value })),
             );
+          else if (
+            TypeChecker.isInteger(schema) ||
+            TypeChecker.isNumber(schema)
+          )
+            union.push({
+              ...schema,
+              default: (schema.default ?? undefined) satisfies
+                | boolean
+                | number
+                | string
+                | undefined as any,
+              ...{ enum: undefined },
+              ...(typeof schema.exclusiveMinimum === "number"
+                ? {
+                    minimum: schema.exclusiveMinimum,
+                    exclusiveMinimum: true,
+                  }
+                : {
+                    exclusiveMinimum: schema.exclusiveMinimum,
+                  }),
+              ...(typeof schema.exclusiveMaximum === "number"
+                ? {
+                    maximum: schema.exclusiveMaximum,
+                    exclusiveMaximum: true,
+                  }
+                : {
+                    exclusiveMaximum: schema.exclusiveMaximum,
+                  }),
+            });
           else
             union.push({
               ...schema,

--- a/src/converters/SwaggerV2Upgrader.ts
+++ b/src/converters/SwaggerV2Upgrader.ts
@@ -321,6 +321,40 @@ export namespace SwaggerV2Upgrader {
                 .filter((v) => v !== null)
                 .map((value) => ({ const: value })),
             );
+          else if (
+            TypeChecker.isInteger(schema) ||
+            TypeChecker.isNumber(schema)
+          )
+            union.push({
+              ...schema,
+              default: (schema.default ?? undefined) satisfies
+                | boolean
+                | number
+                | string
+                | undefined as any,
+              examples: schema.examples
+                ? Object.fromEntries(
+                    schema.examples.map((v, i) => [i.toString(), v]),
+                  )
+                : undefined,
+              ...{ enum: undefined },
+              ...(typeof schema.exclusiveMinimum === "number"
+                ? {
+                    minimum: schema.exclusiveMinimum,
+                    exclusiveMinimum: true,
+                  }
+                : {
+                    exclusiveMinimum: schema.exclusiveMinimum,
+                  }),
+              ...(typeof schema.exclusiveMaximum === "number"
+                ? {
+                    maximum: schema.exclusiveMaximum,
+                    exclusiveMaximum: true,
+                  }
+                : {
+                    exclusiveMaximum: schema.exclusiveMaximum,
+                  }),
+            });
           else
             union.push({
               ...schema,


### PR DESCRIPTION
This pull request includes updates to the `package.json` file and several changes to the `OpenApiV3` and `SwaggerV2` namespaces to enhance the handling of `exclusiveMinimum` and `exclusiveMaximum` properties. Additionally, improvements have been made to the `OpenApiV3Upgrader` and `SwaggerV2Upgrader` converters.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `3.2.4` to `3.3.0`.

### Property Type Enhancements:
* [`src/OpenApiV3.ts`](diffhunk://#diff-6aa34a8c7b2707907658c6d0c4e829ff022e937feafb2787fd6f675a51c2953dL196-R197): Changed the types of `exclusiveMinimum` and `exclusiveMaximum` properties to accept both `number` and `boolean`. [[1]](diffhunk://#diff-6aa34a8c7b2707907658c6d0c4e829ff022e937feafb2787fd6f675a51c2953dL196-R197) [[2]](diffhunk://#diff-6aa34a8c7b2707907658c6d0c4e829ff022e937feafb2787fd6f675a51c2953dL210-R211)
* [`src/SwaggerV2.ts`](diffhunk://#diff-c150dea885c1758f34af4be174ddaabd63dff142325e92a138312b8ee4c7475dL148-R149): Changed the types of `exclusiveMinimum` and `exclusiveMaximum` properties to accept both `number` and `boolean`. [[1]](diffhunk://#diff-c150dea885c1758f34af4be174ddaabd63dff142325e92a138312b8ee4c7475dL148-R149) [[2]](diffhunk://#diff-c150dea885c1758f34af4be174ddaabd63dff142325e92a138312b8ee4c7475dL163-R164)

### Converter Improvements:
* [`src/converters/OpenApiV3Upgrader.ts`](diffhunk://#diff-7182fe579f935912dde424620ec820d6e2532ddef6dbdfae1c87c3ed155d11b0R302-R330): Enhanced the converter to handle `exclusiveMinimum` and `exclusiveMaximum` properties correctly when they are numbers.
* [`src/converters/SwaggerV2Upgrader.ts`](diffhunk://#diff-f66fb33123a6cc2e421b10df5e17851683ad5ba4977cafa9e1716e73abb38519R324-R357): Enhanced the converter to handle `exclusiveMinimum` and `exclusiveMaximum` properties correctly when they are numbers and added support for `examples` property.