### PR TITLE
`exclusiveMinimum`/`exclusiveMaximum` as `number` type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm run build
-      - name: Test
-        run: pnpm run test
       - name: Publish to npm
         run: npm publish --provenance
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "4.0.0-dev.20250405-2",
+  "version": "4.0.0-dev.20250405-3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@samchon/openapi",
-  "version": "3.3.0",
+  "version": "4.0.0-dev.20250405-2",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",
   "typings": "./lib/index.d.ts",
   "scripts": {
     "prepare": "ts-patch install",
-    "build": "npm run build:main && npm run build:test",
+    "build": "pnpm run build:main && pnpm run build:test",
     "build:main": "rimraf lib && tsc && rollup -c",
     "build:test": "rimraf bin && tsc -p test/tsconfig.json",
-    "dev": "npm run build:test -- --watch",
+    "dev": "pnpm run build:test --watch",
     "test": "node bin/test",
     "typedoc": "typedoc --plugin typedoc-github-theme --theme typedoc-github-theme"
   },
@@ -82,7 +82,7 @@
     "typedoc-github-theme": "^0.2.1",
     "typescript": "~5.7.2",
     "typescript-transform-paths": "^3.5.2",
-    "typia": "^8.0.0",
+    "typia": "^9.0.0-dev.20250405",
     "uuid": "^10.0.0"
   },
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 0.21.0
       '@nestia/core':
         specifier: 4.2.0
-        version: 4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3))
+        version: 4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3))
       '@nestia/e2e':
         specifier: 0.8.3
         version: 0.8.3
@@ -25,7 +25,7 @@ importers:
         version: 4.2.0(typescript@5.7.3)
       '@nestia/sdk':
         specifier: 4.2.0
-        version: 4.2.0(@nestia/core@4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3)))(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.22)(typescript@5.7.3))(typescript@5.7.3)(typia@8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3))
+        version: 4.2.0(@nestia/core@4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3)))(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.22)(typescript@5.7.3))(typescript@5.7.3)(typia@9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3))
       '@nestjs/common':
         specifier: ^10.4.1
         version: 10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -126,8 +126,8 @@ importers:
         specifier: ^3.5.2
         version: 3.5.3(typescript@5.7.3)
       typia:
-        specifier: ^8.0.0
-        version: 8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3)
+        specifier: ^9.0.0-dev.20250405
+        version: 9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3)
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -1818,11 +1818,11 @@ packages:
       '@samchon/openapi': '>=2.4.2 <3.0.0'
       typescript: '>=4.8.0 <5.8.0'
 
-  typia@8.0.4:
-    resolution: {integrity: sha512-JPCqinM0PJzQ4DrCqewlQ5YuPAGlAMhEUrMH2iCx67XDRByNxCYgljOau5gWOfkx3ecIi6PfMlmCYPv4RuHRPQ==}
+  typia@9.0.0-dev.20250405:
+    resolution: {integrity: sha512-gi+pdWkzhasv1znP4OhdO5N9o+Oi7b7q0J4iPpYASFCp52SzhiS7L6nd5Y5K2rPYO/hLLj9w9yjeUie9DnWY+w==}
     hasBin: true
     peerDependencies:
-      '@samchon/openapi': '>=3.0.0 <4.0.0'
+      '@samchon/openapi': '>=4.0.0 <5.0.0'
       typescript: '>=4.8.0 <5.9.0'
 
   uc.micro@2.1.0:
@@ -2070,7 +2070,7 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
-  '@nestia/core@4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3))':
+  '@nestia/core@4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3))':
     dependencies:
       '@nestia/fetcher': 4.2.0(typescript@5.7.3)
       '@nestjs/common': 10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -2084,7 +2084,7 @@ snapshots:
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tgrid: 1.1.0
-      typia: 8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3)
+      typia: 9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3)
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -2098,9 +2098,9 @@ snapshots:
       typescript: 5.7.3
       typia: 7.6.4(@samchon/openapi@2.5.3)(typescript@5.7.3)
 
-  '@nestia/sdk@4.2.0(@nestia/core@4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3)))(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.22)(typescript@5.7.3))(typescript@5.7.3)(typia@8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3))':
+  '@nestia/sdk@4.2.0(@nestia/core@4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3)))(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.22)(typescript@5.7.3))(typescript@5.7.3)(typia@9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3))':
     dependencies:
-      '@nestia/core': 4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3))
+      '@nestia/core': 4.2.0(@nestia/fetcher@4.2.0(typescript@5.7.3))(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3))
       '@nestia/fetcher': 4.2.0(typescript@5.7.3)
       '@nestjs/common': 10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.15(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -2115,7 +2115,7 @@ snapshots:
       tsconfck: 2.1.2(typescript@5.7.3)
       tsconfig-paths: 4.2.0
       tstl: 3.0.0
-      typia: 8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3)
+      typia: 9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
 
@@ -3657,7 +3657,7 @@ snapshots:
       randexp: 0.5.3
       typescript: 5.7.3
 
-  typia@8.0.4(@samchon/openapi@2.5.3)(typescript@5.7.3):
+  typia@9.0.0-dev.20250405(@samchon/openapi@2.5.3)(typescript@5.7.3):
     dependencies:
       '@samchon/openapi': 2.5.3
       commander: 10.0.1

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -192,9 +192,9 @@ export namespace OpenApi {
     tags?: IDocument.ITag[];
 
     /**
-     * Flag for indicating this document is emended by `@samchon/openapi`.
+     * Flag for indicating this document is emended by `@samchon/openapi` v4.
      */
-    "x-samchon-emended": true;
+    "x-samchon-emended-v4": true;
   }
   export namespace IDocument {
     /**
@@ -713,23 +713,13 @@ export namespace OpenApi {
 
       /**
        * Exclusive minimum value restriction.
-       *
-       * For reference, even though your Swagger (or OpenAPI) document has
-       * defined the `exclusiveMinimum` value as `number`, {@link OpenApi}
-       * forcibly converts it to `boolean` type, and assign the numeric value to
-       * the {@link minimum} property.
        */
-      exclusiveMinimum?: boolean;
+      exclusiveMinimum?: number;
 
       /**
        * Exclusive maximum value restriction.
-       *
-       * For reference, even though your Swagger (or OpenAPI) document has
-       * defined the `exclusiveMaximum` value as `number`, {@link OpenApi}
-       * forcibly converts it to `boolean` type, and assign the numeric value to
-       * the {@link maximum} property.
        */
-      exclusiveMaximum?: boolean;
+      exclusiveMaximum?: number;
 
       /**
        * Multiple of value restriction.
@@ -761,23 +751,13 @@ export namespace OpenApi {
 
       /**
        * Exclusive minimum value restriction.
-       *
-       * For reference, even though your Swagger (or OpenAPI) document has
-       * defined the `exclusiveMinimum` value as `number`, {@link OpenAiComposer}
-       * forcibly converts it to `boolean` type, and assign the numeric value to
-       * the {@link minimum} property.
        */
-      exclusiveMinimum?: boolean;
+      exclusiveMinimum?: number;
 
       /**
        * Exclusive maximum value restriction.
-       *
-       * For reference, even though your Swagger (or OpenAPI) document has
-       * defined the `exclusiveMaximum` value as `number`, {@link OpenAiComposer}
-       * forcibly converts it to `boolean` type, and assign the numeric value to
-       * the {@link maximum} property.
        */
-      exclusiveMaximum?: boolean;
+      exclusiveMaximum?: number;
 
       /**
        * Multiple of value restriction.

--- a/src/composers/llm/LlmDescriptionInverter.ts
+++ b/src/composers/llm/LlmDescriptionInverter.ts
@@ -1,4 +1,5 @@
 import { OpenApi } from "../../OpenApi";
+import { OpenApiExclusiveEmender } from "../../utils/OpenApiExclusiveEmender";
 
 export namespace LlmDescriptionInverter {
   export const numeric = (
@@ -15,33 +16,27 @@ export namespace LlmDescriptionInverter {
     if (description === undefined) return {};
 
     const lines: string[] = description.split("\n");
-    const exclusiveMinimum: number | undefined = find({
-      type: "number",
-      name: "exclusiveMinimum",
-      lines,
-    });
-    const exclusiveMaximum: number | undefined = find({
-      type: "number",
-      name: "exclusiveMaximum",
-      lines,
-    });
-    return {
-      minimum:
-        exclusiveMinimum ??
-        find({
-          type: "number",
-          name: "minimum",
-          lines,
-        }),
-      maximum:
-        exclusiveMaximum ??
-        find({
-          type: "number",
-          name: "maximum",
-          lines,
-        }),
-      exclusiveMinimum: exclusiveMinimum !== undefined ? true : undefined,
-      exclusiveMaximum: exclusiveMaximum !== undefined ? true : undefined,
+    return OpenApiExclusiveEmender.emend({
+      minimum: find({
+        type: "number",
+        name: "minimum",
+        lines,
+      }),
+      maximum: find({
+        type: "number",
+        name: "maximum",
+        lines,
+      }),
+      exclusiveMinimum: find({
+        type: "number",
+        name: "exclusiveMinimum",
+        lines,
+      }),
+      exclusiveMaximum: find({
+        type: "number",
+        name: "exclusiveMaximum",
+        lines,
+      }),
       multipleOf: find({
         type: "number",
         name: "multipleOf",
@@ -54,7 +49,7 @@ export namespace LlmDescriptionInverter {
         "exclusiveMaximum",
         "multipleOf",
       ]),
-    };
+    });
   };
 
   export const string = (
@@ -145,7 +140,7 @@ export namespace LlmDescriptionInverter {
     | undefined => {
     if (props.type === "boolean")
       return props.lines.some((line) => line.startsWith(`@${props.name}`))
-        ? true
+        ? (true as any)
         : (undefined as any);
     for (const line of props.lines) {
       if (line.startsWith(`@${props.name} `) === false) continue;

--- a/src/structures/ILlmSchemaV3.ts
+++ b/src/structures/ILlmSchemaV3.ts
@@ -183,23 +183,13 @@ export namespace ILlmSchemaV3 {
 
     /**
      * Exclusive minimum value restriction.
-     *
-     * For reference, even though your Swagger document has defined the
-     * `exclusiveMinimum` value as `number`, it has been forcibly converted
-     * to `boolean` type, and assigns the numeric value to the
-     * {@link minimum} property in the {@link OpenApi} conversion.
      */
-    exclusiveMinimum?: boolean;
+    exclusiveMinimum?: number;
 
     /**
      * Exclusive maximum value restriction.
-     *
-     * For reference, even though your Swagger document has defined the
-     * `exclusiveMaximum` value as `number`, it has been forcibly converted
-     * to `boolean` type, and assigns the numeric value to the
-     * {@link maximum} property in the {@link OpenApi} conversion.
      */
-    exclusiveMaximum?: boolean;
+    exclusiveMaximum?: number;
 
     /**
      * Multiple of value restriction.
@@ -241,23 +231,13 @@ export namespace ILlmSchemaV3 {
 
     /**
      * Exclusive minimum value restriction.
-     *
-     * For reference, even though your Swagger (or OpenAPI) document has
-     * defined the `exclusiveMinimum` value as `number`, {@link OpenAiComposer}
-     * forcibly converts it to `boolean` type, and assign the numeric value to
-     * the {@link minimum} property.
      */
-    exclusiveMinimum?: boolean;
+    exclusiveMinimum?: number;
 
     /**
      * Exclusive maximum value restriction.
-     *
-     * For reference, even though your Swagger (or OpenAPI) document has
-     * defined the `exclusiveMaximum` value as `number`, {@link OpenAiComposer}
-     * forcibly converts it to `boolean` type, and assign the numeric value to
-     * the {@link maximum} property.
      */
-    exclusiveMaximum?: boolean;
+    exclusiveMaximum?: number;
 
     /**
      * Multiple of value restriction.

--- a/src/structures/ILlmSchemaV3_1.ts
+++ b/src/structures/ILlmSchemaV3_1.ts
@@ -202,23 +202,13 @@ export namespace ILlmSchemaV3_1 {
 
     /**
      * Exclusive minimum value restriction.
-     *
-     * For reference, even though your Swagger (or OpenAPI) document has
-     * defined the `exclusiveMinimum` value as `number`, {@link OpenApi}
-     * forcibly converts it to `boolean` type, and assign the numeric value to
-     * the {@link minimum} property.
      */
-    exclusiveMinimum?: boolean;
+    exclusiveMinimum?: number;
 
     /**
      * Exclusive maximum value restriction.
-     *
-     * For reference, even though your Swagger (or OpenAPI) document has
-     * defined the `exclusiveMaximum` value as `number`, {@link OpenApi}
-     * forcibly converts it to `boolean` type, and assign the numeric value to
-     * the {@link maximum} property.
      */
-    exclusiveMaximum?: boolean;
+    exclusiveMaximum?: number;
 
     /**
      * Multiple of value restriction.
@@ -250,23 +240,13 @@ export namespace ILlmSchemaV3_1 {
 
     /**
      * Exclusive minimum value restriction.
-     *
-     * For reference, even though your Swagger (or OpenAPI) document has
-     * defined the `exclusiveMinimum` value as `number`, {@link OpenAiComposer}
-     * forcibly converts it to `boolean` type, and assign the numeric value to
-     * the {@link minimum} property.
      */
-    exclusiveMinimum?: boolean;
+    exclusiveMinimum?: number;
 
     /**
      * Exclusive maximum value restriction.
-     *
-     * For reference, even though your Swagger (or OpenAPI) document has
-     * defined the `exclusiveMaximum` value as `number`, {@link OpenAiComposer}
-     * forcibly converts it to `boolean` type, and assign the numeric value to
-     * the {@link maximum} property.
      */
-    exclusiveMaximum?: boolean;
+    exclusiveMaximum?: number;
 
     /**
      * Multiple of value restriction.

--- a/src/utils/LlmTypeCheckerV3.ts
+++ b/src/utils/LlmTypeCheckerV3.ts
@@ -1,4 +1,5 @@
 import { ILlmSchemaV3 } from "../structures/ILlmSchemaV3";
+import { OpenApiTypeCheckerBase } from "./internal/OpenApiTypeCheckerBase";
 
 /**
  * Type checker for LLM type schema.
@@ -110,25 +111,7 @@ export namespace LlmTypeCheckerV3 {
   ): boolean => {
     if (x.enum !== undefined)
       return y.enum !== undefined && x.enum.every((v) => y.enum!.includes(v));
-    return [
-      x.type === y.type,
-      x.minimum === undefined ||
-        (y.minimum !== undefined && x.minimum <= y.minimum),
-      x.maximum === undefined ||
-        (y.maximum !== undefined && x.maximum >= y.maximum),
-      x.exclusiveMinimum !== true ||
-        x.minimum === undefined ||
-        (y.minimum !== undefined &&
-          (y.exclusiveMinimum === true || x.minimum < y.minimum)),
-      x.exclusiveMaximum !== true ||
-        x.maximum === undefined ||
-        (y.maximum !== undefined &&
-          (y.exclusiveMaximum === true || x.maximum > y.maximum)),
-      x.multipleOf === undefined ||
-        (y.multipleOf !== undefined &&
-          y.multipleOf / x.multipleOf ===
-            Math.floor(y.multipleOf / x.multipleOf)),
-    ].every((v) => v);
+    return x.type === y.type && OpenApiTypeCheckerBase.coverNumericRange(x, y);
   };
 
   /**
@@ -140,25 +123,10 @@ export namespace LlmTypeCheckerV3 {
   ): boolean => {
     if (x.enum !== undefined)
       return y.enum !== undefined && x.enum.every((v) => y.enum!.includes(v));
-    return [
-      x.type === y.type || (x.type === "number" && y.type === "integer"),
-      x.minimum === undefined ||
-        (y.minimum !== undefined && x.minimum <= y.minimum),
-      x.maximum === undefined ||
-        (y.maximum !== undefined && x.maximum >= y.maximum),
-      x.exclusiveMinimum !== true ||
-        x.minimum === undefined ||
-        (y.minimum !== undefined &&
-          (y.exclusiveMinimum === true || x.minimum < y.minimum)),
-      x.exclusiveMaximum !== true ||
-        x.maximum === undefined ||
-        (y.maximum !== undefined &&
-          (y.exclusiveMaximum === true || x.maximum > y.maximum)),
-      x.multipleOf === undefined ||
-        (y.multipleOf !== undefined &&
-          y.multipleOf / x.multipleOf ===
-            Math.floor(y.multipleOf / x.multipleOf)),
-    ].every((v) => v);
+    return (
+      (x.type === y.type || (x.type === "number" && y.type === "integer")) &&
+      OpenApiTypeCheckerBase.coverNumericRange(x, y)
+    );
   };
 
   /**

--- a/src/utils/OpenApiConstraintShifter.ts
+++ b/src/utils/OpenApiConstraintShifter.ts
@@ -1,4 +1,5 @@
 import { OpenApi } from "../OpenApi";
+import { OpenApiExclusiveEmender } from "./OpenApiExclusiveEmender";
 
 export namespace OpenApiConstraintShifter {
   export const shiftArray = <
@@ -7,26 +8,26 @@ export namespace OpenApiConstraintShifter {
       "description" | "minItems" | "maxItems" | "uniqueItems"
     >,
   >(
-    v: Schema,
+    schema: Schema,
   ): Omit<Schema, "minItems" | "maxItems" | "uniqueItems"> => {
     const tags: string[] = [];
-    if (v.minItems !== undefined) {
-      tags.push(`@minItems ${v.minItems}`);
-      delete v.minItems;
+    if (schema.minItems !== undefined) {
+      tags.push(`@minItems ${schema.minItems}`);
+      delete schema.minItems;
     }
-    if (v.maxItems !== undefined) {
-      tags.push(`@maxItems ${v.maxItems}`);
-      delete v.maxItems;
+    if (schema.maxItems !== undefined) {
+      tags.push(`@maxItems ${schema.maxItems}`);
+      delete schema.maxItems;
     }
-    if (v.uniqueItems !== undefined) {
-      if (v.uniqueItems === true) tags.push(`@uniqueItems`);
-      delete v.uniqueItems;
+    if (schema.uniqueItems !== undefined) {
+      if (schema.uniqueItems === true) tags.push(`@uniqueItems`);
+      delete schema.uniqueItems;
     }
-    v.description = writeTagWithDescription({
-      description: v.description,
+    schema.description = writeTagWithDescription({
+      description: schema.description,
       tags,
     });
-    return v;
+    return schema;
   };
 
   export const shiftNumeric = <
@@ -41,7 +42,7 @@ export namespace OpenApiConstraintShifter {
       | "default"
     >,
   >(
-    v: Schema,
+    schema: Schema,
   ): Omit<
     Schema,
     | "minimum"
@@ -51,38 +52,38 @@ export namespace OpenApiConstraintShifter {
     | "multipleOf"
     | "default"
   > => {
+    Object.assign(OpenApiExclusiveEmender.emend(schema));
+
     const tags: string[] = [];
-    if (v.exclusiveMinimum === undefined && v.minimum !== undefined) {
-      tags.push(`@minimum ${v.minimum}`);
-      delete v.minimum;
+    if (schema.minimum !== undefined) {
+      tags.push(`@minimum ${schema.minimum}`);
+      delete schema.minimum;
     }
-    if (v.exclusiveMaximum === undefined && v.maximum !== undefined) {
-      tags.push(`@maximum ${v.maximum}`);
-      delete v.maximum;
+    if (schema.maximum !== undefined) {
+      tags.push(`@maximum ${schema.maximum}`);
+      delete schema.maximum;
     }
-    if (v.minimum !== undefined && v.exclusiveMinimum === true) {
-      tags.push(`@exclusiveMinimum ${v.minimum}`);
-      delete v.minimum;
-      delete v.exclusiveMinimum;
+    if (schema.exclusiveMinimum !== undefined) {
+      tags.push(`@exclusiveMinimum ${schema.exclusiveMinimum}`);
+      delete schema.exclusiveMinimum;
     }
-    if (v.maximum !== undefined && v.exclusiveMaximum === true) {
-      tags.push(`@exclusiveMaximum ${v.maximum}`);
-      delete v.maximum;
-      delete v.exclusiveMaximum;
+    if (schema.exclusiveMaximum !== undefined) {
+      tags.push(`@exclusiveMaximum ${schema.exclusiveMaximum}`);
+      delete schema.exclusiveMaximum;
     }
-    if (v.multipleOf !== undefined) {
-      tags.push(`@multipleOf ${v.multipleOf}`);
-      delete v.multipleOf;
+    if (schema.multipleOf !== undefined) {
+      tags.push(`@multipleOf ${schema.multipleOf}`);
+      delete schema.multipleOf;
     }
-    v.description = writeTagWithDescription({
-      description: v.description,
+    schema.description = writeTagWithDescription({
+      description: schema.description,
       tags,
     });
-    if (v.default !== undefined) {
-      tags.push(`@default ${v.default}`);
-      delete v.default;
+    if (schema.default !== undefined) {
+      tags.push(`@default ${schema.default}`);
+      delete schema.default;
     }
-    return v;
+    return schema;
   };
 
   export const shiftString = <
@@ -97,7 +98,7 @@ export namespace OpenApiConstraintShifter {
       | "default"
     >,
   >(
-    v: Schema,
+    schema: Schema,
   ): Omit<
     Schema,
     | "minLength"
@@ -108,35 +109,35 @@ export namespace OpenApiConstraintShifter {
     | "default"
   > => {
     const tags: string[] = [];
-    if (v.minLength !== undefined) {
-      tags.push(`@minLength ${v.minLength}`);
-      delete v.minLength;
+    if (schema.minLength !== undefined) {
+      tags.push(`@minLength ${schema.minLength}`);
+      delete schema.minLength;
     }
-    if (v.maxLength !== undefined) {
-      tags.push(`@maxLength ${v.maxLength}`);
-      delete v.maxLength;
+    if (schema.maxLength !== undefined) {
+      tags.push(`@maxLength ${schema.maxLength}`);
+      delete schema.maxLength;
     }
-    if (v.format !== undefined) {
-      tags.push(`@format ${v.format}`);
-      delete v.format;
+    if (schema.format !== undefined) {
+      tags.push(`@format ${schema.format}`);
+      delete schema.format;
     }
-    if (v.pattern !== undefined) {
-      tags.push(`@pattern ${v.pattern}`);
-      delete v.pattern;
+    if (schema.pattern !== undefined) {
+      tags.push(`@pattern ${schema.pattern}`);
+      delete schema.pattern;
     }
-    if (v.contentMediaType !== undefined) {
-      tags.push(`@contentMediaType ${v.contentMediaType}`);
-      delete v.contentMediaType;
+    if (schema.contentMediaType !== undefined) {
+      tags.push(`@contentMediaType ${schema.contentMediaType}`);
+      delete schema.contentMediaType;
     }
-    if (v.default !== undefined) {
-      tags.push(`@default ${v.default}`);
-      delete v.default;
+    if (schema.default !== undefined) {
+      tags.push(`@default ${schema.default}`);
+      delete schema.default;
     }
-    v.description = writeTagWithDescription({
-      description: v.description,
+    schema.description = writeTagWithDescription({
+      description: schema.description,
       tags,
     });
-    return v;
+    return schema;
   };
 }
 

--- a/src/utils/OpenApiExclusiveEmender.ts
+++ b/src/utils/OpenApiExclusiveEmender.ts
@@ -1,0 +1,46 @@
+import { OpenApi } from "../OpenApi";
+
+export namespace OpenApiExclusiveEmender {
+  export const emend = <
+    Schema extends Pick<
+      OpenApi.IJsonSchema.INumber,
+      "exclusiveMinimum" | "exclusiveMaximum" | "minimum" | "maximum"
+    >,
+  >(
+    schema: Schema,
+  ): Schema => {
+    const minimum =
+      typeof schema.minimum === "number" &&
+      typeof schema.exclusiveMinimum === "number"
+        ? {
+            minimum:
+              schema.minimum > schema.exclusiveMinimum
+                ? schema.minimum
+                : undefined,
+            exclusiveMinimum:
+              schema.minimum > schema.exclusiveMinimum
+                ? undefined
+                : schema.exclusiveMinimum,
+          }
+        : {};
+    const maximum =
+      typeof schema.maximum === "number" &&
+      typeof schema.exclusiveMaximum === "number"
+        ? {
+            maximum:
+              schema.maximum < schema.exclusiveMaximum
+                ? schema.maximum
+                : undefined,
+            exclusiveMaximum:
+              schema.maximum < schema.exclusiveMaximum
+                ? undefined
+                : schema.exclusiveMaximum,
+          }
+        : {};
+    return {
+      ...schema,
+      ...minimum,
+      ...maximum,
+    };
+  };
+}

--- a/src/utils/internal/OpenApiTypeCheckerBase.ts
+++ b/src/utils/internal/OpenApiTypeCheckerBase.ts
@@ -685,25 +685,7 @@ export namespace OpenApiTypeCheckerBase {
   ): boolean => {
     if (isConstant(y))
       return typeof y.const === "number" && Number.isInteger(y.const);
-    return [
-      x.type === y.type,
-      x.minimum === undefined ||
-        (y.minimum !== undefined && x.minimum <= y.minimum),
-      x.maximum === undefined ||
-        (y.maximum !== undefined && x.maximum >= y.maximum),
-      x.exclusiveMinimum !== true ||
-        x.minimum === undefined ||
-        (y.minimum !== undefined &&
-          (y.exclusiveMinimum === true || x.minimum < y.minimum)),
-      x.exclusiveMaximum !== true ||
-        x.maximum === undefined ||
-        (y.maximum !== undefined &&
-          (y.exclusiveMaximum === true || x.maximum > y.maximum)),
-      x.multipleOf === undefined ||
-        (y.multipleOf !== undefined &&
-          y.multipleOf / x.multipleOf ===
-            Math.floor(y.multipleOf / x.multipleOf)),
-    ].every((v) => v);
+    return x.type === y.type && coverNumericRange(x, y);
   };
 
   const coverNumber = (
@@ -714,25 +696,10 @@ export namespace OpenApiTypeCheckerBase {
       | OpenApi.IJsonSchema.INumber,
   ): boolean => {
     if (isConstant(y)) return typeof y.const === "number";
-    return [
-      x.type === y.type || (x.type === "number" && y.type === "integer"),
-      x.minimum === undefined ||
-        (y.minimum !== undefined && x.minimum <= y.minimum),
-      x.maximum === undefined ||
-        (y.maximum !== undefined && x.maximum >= y.maximum),
-      x.exclusiveMinimum !== true ||
-        x.minimum === undefined ||
-        (y.minimum !== undefined &&
-          (y.exclusiveMinimum === true || x.minimum < y.minimum)),
-      x.exclusiveMaximum !== true ||
-        x.maximum === undefined ||
-        (y.maximum !== undefined &&
-          (y.exclusiveMaximum === true || x.maximum > y.maximum)),
-      x.multipleOf === undefined ||
-        (y.multipleOf !== undefined &&
-          y.multipleOf / x.multipleOf ===
-            Math.floor(y.multipleOf / x.multipleOf)),
-    ].every((v) => v);
+    return (
+      (x.type === y.type || (x.type === "number" && y.type === "integer")) &&
+      coverNumericRange(x, y)
+    );
   };
 
   const coverString = (
@@ -803,4 +770,39 @@ export namespace OpenApiTypeCheckerBase {
       schema: found,
     });
   };
+
+  export const coverNumericRange = (
+    x: Pick<
+      OpenApi.IJsonSchema.INumber,
+      | "minimum"
+      | "maximum"
+      | "exclusiveMinimum"
+      | "exclusiveMaximum"
+      | "multipleOf"
+    >,
+    y: Pick<
+      OpenApi.IJsonSchema.INumber,
+      | "minimum"
+      | "maximum"
+      | "exclusiveMinimum"
+      | "exclusiveMaximum"
+      | "multipleOf"
+    >,
+  ): boolean =>
+    [
+      x.minimum === undefined ||
+        (y.minimum !== undefined && x.minimum <= y.minimum) ||
+        (y.exclusiveMinimum !== undefined && x.minimum < y.exclusiveMinimum),
+      x.maximum === undefined ||
+        (y.maximum !== undefined && x.maximum >= y.maximum) ||
+        (y.exclusiveMaximum !== undefined && x.maximum > y.exclusiveMaximum),
+      x.exclusiveMinimum === undefined ||
+        (y.minimum !== undefined && x.exclusiveMinimum <= y.minimum) ||
+        (y.exclusiveMinimum !== undefined &&
+          x.exclusiveMinimum <= y.exclusiveMinimum),
+      x.exclusiveMaximum === undefined ||
+        (y.maximum !== undefined && x.exclusiveMaximum >= y.maximum) ||
+        (y.exclusiveMaximum !== undefined &&
+          x.exclusiveMaximum >= y.exclusiveMaximum),
+    ].every((v) => v);
 }

--- a/src/utils/internal/OpenApiTypeCheckerBase.ts
+++ b/src/utils/internal/OpenApiTypeCheckerBase.ts
@@ -804,5 +804,9 @@ export namespace OpenApiTypeCheckerBase {
         (y.maximum !== undefined && x.exclusiveMaximum >= y.maximum) ||
         (y.exclusiveMaximum !== undefined &&
           x.exclusiveMaximum >= y.exclusiveMaximum),
+      x.multipleOf === undefined ||
+        (y.multipleOf !== undefined &&
+          y.multipleOf / x.multipleOf ===
+            Math.floor(y.multipleOf / x.multipleOf)),
     ].every((v) => v);
 }

--- a/test/features/issues/test_issue_121_reference_accessor.ts
+++ b/test/features/issues/test_issue_121_reference_accessor.ts
@@ -3,7 +3,7 @@ import { OpenApiTypeChecker } from "@samchon/openapi";
 import typia from "typia";
 
 export const test_issue_121_reference_accessor = (): void => {
-  const collection = typia.json.application<[IMember]>();
+  const collection = typia.json.schemas<[IMember]>();
   const accessors: string[] = [];
   OpenApiTypeChecker.visit({
     closure: (_schema, acc) => {

--- a/test/features/llm/gemini/test_gemini_schema_constraint.ts
+++ b/test/features/llm/gemini/test_gemini_schema_constraint.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import { GeminiTypeChecker } from "@samchon/openapi";
+import { GeminiSchemaComposer } from "@samchon/openapi/lib/composers/llm/GeminiSchemaComposer";
+
+export const test_gemini_schema_constraint = (): void => {
+  const result = GeminiSchemaComposer.schema({
+    config: {
+      recursive: false,
+    },
+    schema: {
+      type: "number",
+      minimum: 0,
+      exclusiveMaximum: 3,
+    },
+    components: {},
+  });
+  TestValidator.predicate("schema")(
+    () =>
+      result.success &&
+      GeminiTypeChecker.isNumber(result.value) &&
+      !!result.value.description?.includes("@minimum 0") &&
+      !!result.value.description?.includes("@exclusiveMaximum 3"),
+  );
+};

--- a/test/features/llm/validate_llm_application_mismatch.ts
+++ b/test/features/llm/validate_llm_application_mismatch.ts
@@ -72,7 +72,7 @@ const validate_llm_application_mismatch = <Model extends ILlmSchema.Model>(
         },
       },
     },
-    "x-samchon-emended": true,
+    "x-samchon-emended-v4": true,
   };
 
   const app: IHttpLlmApplication<Model> = HttpLlm.application({

--- a/test/features/llm/validate_llm_application_tuple.ts
+++ b/test/features/llm/validate_llm_application_tuple.ts
@@ -98,7 +98,7 @@ const validate_llm_application_tuple = <Model extends ILlmSchema.Model>(
         },
       },
     },
-    "x-samchon-emended": true,
+    "x-samchon-emended-v4": true,
   };
   const app: IHttpLlmApplication<Model> = HttpLlm.application({
     model,

--- a/test/features/llm/validate_llm_application_type.ts
+++ b/test/features/llm/validate_llm_application_type.ts
@@ -48,7 +48,9 @@ const application = <Model extends ILlmSchema.Model>(model: Model) =>
   });
 
 const document = new Singleton(() =>
-  typia.json.assertParse<OpenApi.IDocument>(
-    fs.readFileSync(`${TestGlobal.ROOT}/examples/v3.1/shopping.json`, "utf8"),
+  OpenApi.convert(
+    JSON.parse(
+      fs.readFileSync(`${TestGlobal.ROOT}/examples/v3.1/shopping.json`, "utf8"),
+    ),
   ),
 );

--- a/test/features/llm/validate_llm_schema_invert.ts
+++ b/test/features/llm/validate_llm_schema_invert.ts
@@ -58,11 +58,9 @@ const validate_llm_schema_invert = <Model extends ILlmSchema.Model>(
     } as any),
   )({
     type: "integer",
-    minimum: 0,
-    maximum: 100,
     multipleOf: 5,
-    exclusiveMinimum: true,
-    exclusiveMaximum: true,
+    exclusiveMinimum: 0,
+    exclusiveMaximum: 100,
   });
 
   TestValidator.equals("number")(
@@ -79,11 +77,9 @@ const validate_llm_schema_invert = <Model extends ILlmSchema.Model>(
     } as any),
   )({
     type: "number",
-    minimum: 0,
-    maximum: 100,
     multipleOf: 5,
-    exclusiveMinimum: true,
-    exclusiveMaximum: true,
+    exclusiveMinimum: 0,
+    exclusiveMaximum: 100,
   });
 
   TestValidator.equals("array")(
@@ -119,11 +115,9 @@ const validate_llm_schema_invert = <Model extends ILlmSchema.Model>(
     } as any),
   )({
     type: "number",
-    minimum: 0,
-    maximum: 100,
     multipleOf: 5,
-    exclusiveMinimum: true,
-    exclusiveMaximum: true,
+    exclusiveMinimum: 0,
+    exclusiveMaximum: 100,
   });
 
   TestValidator.equals("object")(

--- a/test/features/openapi/test_json_schema_type_checker_cover_number.ts
+++ b/test/features/openapi/test_json_schema_type_checker_cover_number.ts
@@ -50,7 +50,7 @@ export const test_json_schema_type_checker_cover_number = (): void => {
   TestValidator.equals("exclusiveMinimum covers minimum only when less")(true)(
     OpenApiTypeChecker.covers({
       components: {},
-      x: { type: "number", minimum: 1, exclusiveMinimum: true },
+      x: { type: "number", exclusiveMinimum: 1 },
       y: { type: "number", minimum: 2 },
     }),
   );
@@ -75,7 +75,7 @@ export const test_json_schema_type_checker_cover_number = (): void => {
   )(
     OpenApiTypeChecker.covers({
       components: {},
-      x: { type: "number", maximum: 2, exclusiveMaximum: true },
+      x: { type: "number", exclusiveMaximum: 2 },
       y: { type: "number", maximum: 1 },
     }),
   );
@@ -121,7 +121,7 @@ export const test_json_schema_type_checker_cover_number = (): void => {
   TestValidator.equals("exclusiveMinimum can't cover equal")(false)(
     OpenApiTypeChecker.covers({
       components: {},
-      x: { type: "number", minimum: 1, exclusiveMinimum: true },
+      x: { type: "number", exclusiveMinimum: 1 },
       y: { type: "number", minimum: 1 },
     }),
   );
@@ -137,7 +137,7 @@ export const test_json_schema_type_checker_cover_number = (): void => {
   TestValidator.equals("exclusiveMaximum can't cover equal")(false)(
     OpenApiTypeChecker.covers({
       components: {},
-      x: { type: "number", maximum: 2, exclusiveMaximum: true },
+      x: { type: "number", exclusiveMaximum: 2 },
       y: { type: "number", maximum: 2 },
     }),
   );

--- a/test/features/openapi/test_json_schema_type_checker_cover_number.ts
+++ b/test/features/openapi/test_json_schema_type_checker_cover_number.ts
@@ -118,7 +118,7 @@ export const test_json_schema_type_checker_cover_number = (): void => {
       y: { type: "number", minimum: 1 },
     }),
   );
-  TestValidator.equals("exclusiveMinimum can't cover equal")(false)(
+  TestValidator.equals("exclusiveMinimum can cover equal")(true)(
     OpenApiTypeChecker.covers({
       components: {},
       x: { type: "number", exclusiveMinimum: 1 },
@@ -134,7 +134,7 @@ export const test_json_schema_type_checker_cover_number = (): void => {
       y: { type: "number", maximum: 2 },
     }),
   );
-  TestValidator.equals("exclusiveMaximum can't cover equal")(false)(
+  TestValidator.equals("exclusiveMaximum can cover equal")(true)(
     OpenApiTypeChecker.covers({
       components: {},
       x: { type: "number", exclusiveMaximum: 2 },


### PR DESCRIPTION
Anthropic Claude has banned `boolean` typed `exclusiveMinimum` and `exclusiveMaximum` properties.

So this PR changes them to `number` type to support claude perflectly, and this is a typical major update.

cc @ryoppippi 

-----------------

This pull request includes several changes that update dependencies, modify type definitions, and refactor code for better maintainability. The most important changes include updates to `package.json` dependencies, modifications to the `OpenApi` namespace, and the introduction of the `OpenApiExclusiveEmender` utility.

### Dependency Updates:
* Updated `typia` dependency from `^8.0.0` to `^9.0.0-dev.20250405` in `package.json`.
* Changed `build` and `dev` scripts in `package.json` to use `pnpm` instead of `npm`.

### Type Definition Modifications:
* Changed `exclusiveMinimum` and `exclusiveMaximum` properties from `boolean` to `number` in `OpenApi` namespace and related structures [[1]](diffhunk://#diff-77f34fd23e2eddbd1b3ebc491255409ecceb4df2c22af81356d4788b4379efbcL716-R722) [[2]](diffhunk://#diff-77f34fd23e2eddbd1b3ebc491255409ecceb4df2c22af81356d4788b4379efbcL764-R760) [[3]](diffhunk://#diff-a83bad0fda93321814c4ce21df194a9e142cf63a291737fbedee22d69536bd42L186-R192) [[4]](diffhunk://#diff-72e41eeadd5016cdfe8a554caae2e2bb215b4b929ff01b52fa5f79efd14bd3abL205-R211).

### Code Refactoring:
* Introduced `OpenApiExclusiveEmender` utility to handle the transformation of `exclusiveMinimum` and `exclusiveMaximum` properties [[1]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837R2) [[2]](diffhunk://#diff-7182fe579f935912dde424620ec820d6e2532ddef6dbdfae1c87c3ed155d11b0R3) [[3]](diffhunk://#diff-0d6baac3e1dd36c89a3e4e967c85bc6c10f6b24917feff764e460250b78d9e72R3-R7) [[4]](diffhunk://#diff-f66fb33123a6cc2e421b10df5e17851683ad5ba4977cafa9e1716e73abb38519R3) [[5]](diffhunk://#diff-3f6a5d654d060e3608b7d273e65698226015a40651229712b9dd9fd187bd16a4R2).
* Refactored `LlmDescriptionInverter` to use `OpenApiExclusiveEmender` for property transformations [[1]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837L18-L44) [[2]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837L57-R52) [[3]](diffhunk://#diff-2250914d491874aab2e76c81574afef16dbc703848dc39b4c7a1fb37eab82837L148-R143).
* Updated `x-samchon-emended` flag to `x-samchon-emended-v4` in various files [[1]](diffhunk://#diff-7182fe579f935912dde424620ec820d6e2532ddef6dbdfae1c87c3ed155d11b0L19-R20) [[2]](diffhunk://#diff-0d6baac3e1dd36c89a3e4e967c85bc6c10f6b24917feff764e460250b78d9e72L31-R32) [[3]](diffhunk://#diff-f66fb33123a6cc2e421b10df5e17851683ad5ba4977cafa9e1716e73abb38519L28-R29). 