### PR TITLE
Polyfill `IJsonSchema.examples`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "4.0.0-dev.20250405-3",
+  "version": "4.0.0-dev.20250405-4",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/OpenApiV3.ts
+++ b/src/OpenApiV3.ts
@@ -182,12 +182,16 @@ export namespace OpenApiV3 {
     | IJsonSchema.INullOnly
     | IJsonSchema.IUnknown;
   export namespace IJsonSchema {
-    export interface IBoolean extends __ISignificant<"boolean"> {
+    export interface IBoolean
+      extends Omit<IJsonSchemaAttribute.IBoolean, "examples">,
+        __IAttribute {
       nullable?: boolean;
       default?: boolean | null;
       enum?: Array<boolean | null>;
     }
-    export interface IInteger extends __ISignificant<"integer"> {
+    export interface IInteger
+      extends Omit<IJsonSchemaAttribute.IInteger, "examples">,
+        __IAttribute {
       nullable?: boolean;
       /** @type int64 */ default?: number | null;
       /** @type int64 */ enum?: Array<number | null>;
@@ -201,7 +205,9 @@ export namespace OpenApiV3 {
        */
       multipleOf?: number;
     }
-    export interface INumber extends __ISignificant<"number"> {
+    export interface INumber
+      extends Omit<IJsonSchemaAttribute.INumber, "examples">,
+        __IAttribute {
       nullable?: boolean;
       default?: number | null;
       enum?: Array<number | null>;
@@ -211,7 +217,9 @@ export namespace OpenApiV3 {
       exclusiveMaximum?: number | boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
-    export interface IString extends __ISignificant<"string"> {
+    export interface IString
+      extends Omit<IJsonSchemaAttribute.IString, "examples">,
+        __IAttribute {
       nullable?: boolean;
       default?: string | null;
       enum?: Array<string | null>;
@@ -245,14 +253,18 @@ export namespace OpenApiV3 {
       /** @type uint64 */ maxLength?: number;
     }
 
-    export interface IArray extends IJsonSchemaAttribute.IArray {
+    export interface IArray
+      extends Omit<IJsonSchemaAttribute.IArray, "examples">,
+        __IAttribute {
       nullable?: boolean;
       items: IJsonSchema;
       uniqueItems?: boolean;
       /** @type uint64 */ minItems?: number;
       /** @type uint64 */ maxItems?: number;
     }
-    export interface IObject extends IJsonSchemaAttribute.IObject {
+    export interface IObject
+      extends Omit<IJsonSchemaAttribute.IObject, "examples">,
+        __IAttribute {
       nullable?: boolean;
       properties?: Record<string, IJsonSchema>;
       required?: string[];
@@ -260,17 +272,17 @@ export namespace OpenApiV3 {
       maxProperties?: number;
       minProperties?: number;
     }
-    export interface IReference<Key = string> extends IJsonSchemaAttribute {
+    export interface IReference<Key = string> extends __IAttribute {
       $ref: Key;
     }
 
-    export interface IAllOf extends IJsonSchemaAttribute {
+    export interface IAllOf extends __IAttribute {
       allOf: IJsonSchema[];
     }
-    export interface IAnyOf extends IJsonSchemaAttribute {
+    export interface IAnyOf extends __IAttribute {
       anyOf: IJsonSchema[];
     }
-    export interface IOneOf extends IJsonSchemaAttribute {
+    export interface IOneOf extends __IAttribute {
       oneOf: IJsonSchema[];
       discriminator?: IOneOf.IDiscriminator;
     }
@@ -281,28 +293,21 @@ export namespace OpenApiV3 {
       }
     }
 
-    export interface INullOnly extends IJsonSchemaAttribute.INull {
+    export interface INullOnly
+      extends Omit<IJsonSchemaAttribute.INull, "examples">,
+        __IAttribute {
       default?: null;
     }
-    export interface IUnknown extends IJsonSchemaAttribute.IUnknown {
+    export interface IUnknown
+      extends Omit<IJsonSchemaAttribute.IUnknown, "examples">,
+        __IAttribute {
       default?: any;
     }
 
-    /**
-     * @deprecated
-     * @hidden
-     */
-    export interface __ISignificant<Type extends string>
-      extends IJsonSchemaAttribute {
-      type: Type;
-      nullable?: boolean;
+    export interface __IAttribute
+      extends Omit<IJsonSchemaAttribute, "examples"> {
+      examples?: any[] | Record<string, any>;
     }
-
-    /**
-     * @deprecated
-     * @hidden
-     */
-    export type __IAttribute = IJsonSchemaAttribute;
   }
 
   export type ISecurityScheme =

--- a/src/OpenApiV3_1.ts
+++ b/src/OpenApiV3_1.ts
@@ -215,16 +215,20 @@ export namespace OpenApiV3_1 {
       enum?: any[];
     }
 
-    export interface IConstant extends IJsonSchemaAttribute {
+    export interface IConstant extends __IAttribute {
       const: boolean | number | string;
       nullable?: boolean;
     }
-    export interface IBoolean extends IJsonSchemaAttribute.IBoolean {
+    export interface IBoolean
+      extends Omit<IJsonSchemaAttribute.IBoolean, "examples">,
+        __IAttribute {
       nullable?: boolean;
       default?: boolean | null;
       enum?: Array<boolean | null>;
     }
-    export interface IInteger extends IJsonSchemaAttribute.IInteger {
+    export interface IInteger
+      extends Omit<IJsonSchemaAttribute.IInteger, "examples">,
+        __IAttribute {
       nullable?: boolean;
       /** @type int64 */ default?: number | null;
       /** @type int64 */ enum?: Array<number | null>;
@@ -238,7 +242,9 @@ export namespace OpenApiV3_1 {
        */
       multipleOf?: number;
     }
-    export interface INumber extends IJsonSchemaAttribute.INumber {
+    export interface INumber
+      extends Omit<IJsonSchemaAttribute.INumber, "examples">,
+        __IAttribute {
       nullable?: boolean;
       default?: number | null;
       enum?: Array<number | null>;
@@ -248,7 +254,9 @@ export namespace OpenApiV3_1 {
       exclusiveMaximum?: number | boolean;
       /** @exclusiveMinimum 0 */ multipleOf?: number;
     }
-    export interface IString extends IJsonSchemaAttribute.IString {
+    export interface IString
+      extends Omit<IJsonSchemaAttribute.IString, "examples">,
+        __IAttribute {
       nullable?: boolean;
       default?: string | null;
       enum?: Array<string | null>;
@@ -283,7 +291,9 @@ export namespace OpenApiV3_1 {
       /** @type uint64 */ maxLength?: number;
     }
 
-    export interface IObject extends IJsonSchemaAttribute.IObject {
+    export interface IObject
+      extends Omit<IJsonSchemaAttribute.IObject, "examples">,
+        __IAttribute {
       nullable?: boolean;
       properties?: Record<string, IJsonSchema>;
       required?: string[];
@@ -291,7 +301,9 @@ export namespace OpenApiV3_1 {
       maxProperties?: number;
       minProperties?: number;
     }
-    export interface IArray extends IJsonSchemaAttribute.IArray {
+    export interface IArray
+      extends Omit<IJsonSchemaAttribute.IArray, "examples">,
+        __IAttribute {
       nullable?: boolean;
       items?: IJsonSchema | IJsonSchema[];
       prefixItems?: IJsonSchema[];
@@ -300,20 +312,20 @@ export namespace OpenApiV3_1 {
       /** @type uint64 */ minItems?: number;
       /** @type uint64 */ maxItems?: number;
     }
-    export interface IReference<Key = string> extends IJsonSchemaAttribute {
+    export interface IReference<Key = string> extends __IAttribute {
       $ref: Key;
     }
-    export interface IRecursiveReference extends IJsonSchemaAttribute {
+    export interface IRecursiveReference extends __IAttribute {
       $recursiveRef: string;
     }
 
-    export interface IAllOf extends IJsonSchemaAttribute {
+    export interface IAllOf extends __IAttribute {
       allOf: IJsonSchema[];
     }
-    export interface IAnyOf extends IJsonSchemaAttribute {
+    export interface IAnyOf extends __IAttribute {
       anyOf: IJsonSchema[];
     }
-    export interface IOneOf extends IJsonSchemaAttribute {
+    export interface IOneOf extends __IAttribute {
       oneOf: IJsonSchema[];
       discriminator?: IOneOf.IDiscriminator;
     }
@@ -324,28 +336,22 @@ export namespace OpenApiV3_1 {
       }
     }
 
-    export interface INull extends IJsonSchemaAttribute.INull {
+    export interface INull
+      extends Omit<IJsonSchemaAttribute.INull, "examples">,
+        __IAttribute {
       default?: null;
     }
-    export interface IUnknown extends IJsonSchemaAttribute.IUnknown {
+    export interface IUnknown
+      extends Omit<IJsonSchemaAttribute.IUnknown, "examples">,
+        __IAttribute {
       type?: undefined;
       default?: any;
     }
 
-    /**
-     * @deprecated
-     * @hidden
-     */
-    export interface __ISignificant<Type extends string> extends __IAttribute {
-      type: Type;
-      nullable?: boolean;
+    export interface __IAttribute
+      extends Omit<IJsonSchemaAttribute, "examples"> {
+      examples?: any[] | Record<string, any>;
     }
-
-    /**
-     * @deprecated
-     * @hidden
-     */
-    export type __IAttribute = IJsonSchemaAttribute;
   }
 
   export type ISecurityScheme =

--- a/src/composers/llm/GeminiSchemaComposer.ts
+++ b/src/composers/llm/GeminiSchemaComposer.ts
@@ -159,9 +159,7 @@ const isOneOf =
     const visitConstant = (schema: OpenApi.IJsonSchema): void => {
       const insert = (value: any): void => {
         const matched: OpenApiV3_1.IJsonSchema.INumber | undefined = union.find(
-          (u) =>
-            (u as OpenApiV3.IJsonSchema.__ISignificant<any>).type ===
-            typeof value,
+          (u) => (u as OpenApiV3.IJsonSchema.INumber).type === typeof value,
         ) as OpenApiV3.IJsonSchema.INumber | undefined;
         if (matched !== undefined) {
           matched.enum ??= [];

--- a/src/converters/OpenApiV3Downgrader.ts
+++ b/src/converters/OpenApiV3Downgrader.ts
@@ -258,9 +258,7 @@ export namespace OpenApiV3Downgrader {
       const visitConstant = (schema: OpenApi.IJsonSchema): void => {
         const insert = (value: any): void => {
           const matched: OpenApiV3.IJsonSchema.INumber | undefined = union.find(
-            (u) =>
-              (u as OpenApiV3.IJsonSchema.__ISignificant<any>).type ===
-              typeof value,
+            (u) => (u as OpenApiV3.IJsonSchema.INumber).type === typeof value,
           ) as OpenApiV3.IJsonSchema.INumber | undefined;
           if (matched !== undefined) {
             matched.enum ??= [];

--- a/src/converters/OpenApiV3Upgrader.ts
+++ b/src/converters/OpenApiV3Upgrader.ts
@@ -258,16 +258,15 @@ export namespace OpenApiV3Upgrader {
           ),
         ),
         example: input.example,
-        examples: input.examples,
+        examples: Array.isArray(input.examples)
+          ? Object.fromEntries(input.examples.map((v, i) => [`v${i}`, v]))
+          : input.examples,
       };
       const visit = (schema: OpenApiV3.IJsonSchema): void => {
         // NULLABLE PROPERTY
-        if (
-          (schema as OpenApiV3.IJsonSchema.__ISignificant<any>).nullable ===
-          true
-        ) {
+        if ((schema as OpenApiV3.IJsonSchema.IBoolean).nullable === true) {
           nullable.value ||= true;
-          if ((schema as OpenApiV3.IJsonSchema.INumber).default === null)
+          if ((schema as OpenApiV3.IJsonSchema.IBoolean).default === null)
             nullable.default = null;
         }
         if (

--- a/src/converters/OpenApiV3_1Emender.ts
+++ b/src/converters/OpenApiV3_1Emender.ts
@@ -281,7 +281,7 @@ export namespace OpenApiV3_1Emender {
           ),
         ),
         examples: Array.isArray(input.examples)
-          ? Object.fromEntries(input.examples.map((v, i) => [`e${i}`, v]))
+          ? Object.fromEntries(input.examples.map((v, i) => [`v${i}`, v]))
           : input.examples,
       };
       const nullable: { value: boolean; default?: null } = {

--- a/src/converters/OpenApiV3_1Emender.ts
+++ b/src/converters/OpenApiV3_1Emender.ts
@@ -280,6 +280,9 @@ export namespace OpenApiV3_1Emender {
             ([key, value]) => key.startsWith("x-") && value !== undefined,
           ),
         ),
+        examples: Array.isArray(input.examples)
+          ? Object.fromEntries(input.examples.map((v, i) => [`e${i}`, v]))
+          : input.examples,
       };
       const nullable: { value: boolean; default?: null } = {
         value: false,
@@ -288,10 +291,7 @@ export namespace OpenApiV3_1Emender {
 
       const visit = (schema: OpenApiV3_1.IJsonSchema): void => {
         // NULLABLE PROPERTY
-        if (
-          (schema as OpenApiV3_1.IJsonSchema.__ISignificant<any>).nullable ===
-          true
-        ) {
+        if ((schema as OpenApiV3_1.IJsonSchema.INumber).nullable === true) {
           nullable.value ||= true;
           if ((schema as OpenApiV3_1.IJsonSchema.INumber).default === null)
             nullable.default = null;

--- a/src/converters/SwaggerV2Upgrader.ts
+++ b/src/converters/SwaggerV2Upgrader.ts
@@ -278,7 +278,7 @@ export namespace SwaggerV2Upgrader {
         ),
         example: input.example,
         examples: input.examples
-          ? Object.fromEntries(input.examples.map((v, i) => [i.toString(), v]))
+          ? Object.fromEntries(input.examples.map((v, i) => [`v${i}`, v]))
           : undefined,
       };
       const visit = (schema: SwaggerV2.IJsonSchema): void => {
@@ -336,7 +336,7 @@ export namespace SwaggerV2Upgrader {
                   | undefined as any,
                 examples: schema.examples
                   ? Object.fromEntries(
-                      schema.examples.map((v, i) => [i.toString(), v]),
+                      schema.examples.map((v, i) => [`v${i}`, v]),
                     )
                   : undefined,
                 exclusiveMinimum:
@@ -368,7 +368,7 @@ export namespace SwaggerV2Upgrader {
                 | undefined as any,
               examples: schema.examples
                 ? Object.fromEntries(
-                    schema.examples.map((v, i) => [i.toString(), v]),
+                    schema.examples.map((v, i) => [`v${i}`, v]),
                   )
                 : undefined,
               ...{ enum: undefined },
@@ -379,9 +379,7 @@ export namespace SwaggerV2Upgrader {
             ...schema,
             items: convertSchema(definitions)(schema.items),
             examples: schema.examples
-              ? Object.fromEntries(
-                  schema.examples.map((v, i) => [i.toString(), v]),
-                )
+              ? Object.fromEntries(schema.examples.map((v, i) => [`v${i}`, v]))
               : undefined,
           });
         else if (TypeChecker.isObject(schema))
@@ -406,9 +404,7 @@ export namespace SwaggerV2Upgrader {
                 : undefined,
             },
             examples: schema.examples
-              ? Object.fromEntries(
-                  schema.examples.map((v, i) => [i.toString(), v]),
-                )
+              ? Object.fromEntries(schema.examples.map((v, i) => [`v${i}`, v]))
               : undefined,
             required: schema.required ?? [],
           });
@@ -420,18 +416,14 @@ export namespace SwaggerV2Upgrader {
               "#/components/schemas/",
             ),
             examples: schema.examples
-              ? Object.fromEntries(
-                  schema.examples.map((v, i) => [i.toString(), v]),
-                )
+              ? Object.fromEntries(schema.examples.map((v, i) => [`v${i}`, v]))
               : undefined,
           });
         else
           union.push({
             ...schema,
             examples: schema.examples
-              ? Object.fromEntries(
-                  schema.examples.map((v, i) => [i.toString(), v]),
-                )
+              ? Object.fromEntries(schema.examples.map((v, i) => [`v${i}`, v]))
               : undefined,
           });
       };


### PR DESCRIPTION
Even though JSON schema's `examples` property must be `Record<string, any>` type, too much people and frameworks are filling the property with array value.

Considering the specification, this PR is not proper, but as industry players are following the specification, I've determined to allow for the compatibility.