### PR TITLE
Add `@ts-ignore` to `@modelcontextprotocol/sdk` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,23 +668,48 @@ console.log(result);
 
 https://github.com/wrtnlabs/agentica
 
-`agentica` is the simplest **Agentic AI** library, specialized in **LLM Function Calling** with `@samchon/openapi`.
+Agentic AI framework specialized in AI Function Calling using `@samchon/openapi`.
 
-With it, you don't need to compose a complex agent graph or workflow. Instead, just deliver **Swagger/OpenAPI/MCP** documents or **TypeScript class** types linearly to the `agentica`. Then `agentica` will do everything with the function calling.
-Look at the below demonstration, and feel how `agentica` is easy and powerful combining with `@samchon/openapi`.
+Don't be afraid of AI agent development. Just list functions from three protocols below. This is everything you should do for AI agent development.
+
+- TypeScript Class
+- Swagger/OpenAPI Document
+- MCP (Model Context Protocol) Server
+
+Wanna make an e-commerce agent? Bring in e-commerce functions. Need a newspaper agent? Get API functions from the newspaper company. Just prepare any functions that you need, then it becomes an AI agent.
+
+Are you a TypeScript developer? Then you're already an AI developer. Familiar with backend development? You're already well-versed in AI development. Anyone who can make functions can make AI agents.
 
 ```typescript
-import { Agentica } from "@agentica/core";
+import { Agentica, assertHttpController } from "@agentica/core";
+import OpenAI from "openai";
 import typia from "typia";
 
+import { MobileFileSystem } from "./services/MobileFileSystem";
+
 const agent = new Agentica({
+  vendor: {
+    api: new OpenAI({ apiKey: "********" }),
+    model: "gpt-4o-mini",
+  },
   controllers: [
-    await fetch(
-      "https://shopping-be.wrtn.ai/editor/swagger.json",
-    ).then(r => r.json()),
-    typia.llm.application<ShoppingCounselor>(),
-    typia.llm.application<ShoppingPolicy>(),
-    typia.llm.application<ShoppingSearchRag>(),
+    // functions from TypeScript class
+    typia.llm.controller<MobileFileSystem, "chatgpt">(
+      "filesystem",
+      new MobileFileSystem(),
+    ),
+    // functions from Swagger/OpenAPI
+    assertHttpController({
+      name: "shopping",
+      model: "chatgpt",
+      document: await fetch(
+        "https://shopping-be.wrtn.ai/editor/swagger.json",
+      ).then(r => r.json()),
+      connection: {
+        host: "https://shopping-be.wrtn.ai",
+        headers: { Authorization: "Bearer ********" },
+      },
+    }),
   ],
 });
 await agent.conversate("I wanna buy MacBook Pro");

--- a/src/structures/IMcpLlmController.ts
+++ b/src/structures/IMcpLlmController.ts
@@ -78,6 +78,11 @@ export interface IMcpLlmController<Model extends ILlmSchema.Model> {
 
   /**
    * MCP client for connection.
+   *
+   * @warning You have to install `@modelcontextprotocol/sdk` package
+   *          to use this type properly. If not, this type would work
+   *          as an `any` type, so that you can't validate it.
    */
+  // @ts-ignore
   client: import("@modelcontextprotocol/sdk/client/index.d.ts").Client;
 }


### PR DESCRIPTION
This pull request introduces significant updates to the `agentica` library documentation and code examples, as well as a type-related enhancement in the `IMcpLlmController` interface. The key changes include a revamped README for improved clarity and accessibility, and a new dependency warning in the TypeScript interface definition.

### Documentation and Code Example Updates:
* **Enhanced README content**: Simplified and clarified the purpose of `agentica`, emphasizing its ease of use for AI agent development with clear examples of supported protocols (TypeScript Class, Swagger/OpenAPI, MCP). Added a motivational section targeting TypeScript and backend developers to highlight their readiness for AI development.
* **Updated code examples**: Introduced `MobileFileSystem` as a TypeScript class example and added a new `vendor` configuration for specifying the AI model (`gpt-4o-mini`) and API key. Also replaced outdated `typia.llm.application` calls with updated `typia.llm.controller` and `assertHttpController` methods.

### TypeScript Interface Enhancement:
* **Dependency warning for `IMcpLlmController`**: Added a warning in the `IMcpLlmController` interface documentation to inform users about the need to install the `@modelcontextprotocol/sdk` package for proper type validation. This ensures better developer awareness and reduces potential issues with the `client` type defaulting to `any`.