### PR TITLE
Fix #163: avoid `export import` statements for specific bundler reason.

### DIFF
--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -1027,7 +1027,7 @@ export namespace OpenApi {
     /**
      * Union type.
      *
-     * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+     * `IOneOf` represents an union type of the TypeScript (`A | B | C`).
      *
      * For reference, even though your Swagger (or OpenAPI) document has
      * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly

--- a/src/structures/IChatGptSchema.ts
+++ b/src/structures/IChatGptSchema.ts
@@ -258,7 +258,7 @@ export namespace IChatGptSchema {
   /**
    * Union type.
    *
-   * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+   * `IOneOf` represents an union type of the TypeScript (`A | B | C`).
    *
    * For reference, even though your Swagger (or OpenAPI) document has
    * defined `anyOf` instead of the `oneOf`, {@link IChatGptSchema} forcibly

--- a/src/structures/IClaudeSchema.ts
+++ b/src/structures/IClaudeSchema.ts
@@ -78,18 +78,82 @@ export namespace IClaudeSchema {
     reference: boolean;
   }
 
-  export import IParameters = ILlmSchemaV3_1.IParameters;
+  /**
+   * Type of the function parameters.
+   *
+   * `IClaudeSchema.IParameters` is a type defining a function's parameters
+   * as a keyworded object type.
+   *
+   * It also can be utilized for the structured output metadata.
+   *
+   * @reference https://platform.openai.com/docs/guides/structured-outputs
+   */
+  export type IParameters = ILlmSchemaV3_1.IParameters;
 
-  export import IConstant = ILlmSchemaV3_1.IConstant;
-  export import IBoolean = ILlmSchemaV3_1.IBoolean;
-  export import IInteger = ILlmSchemaV3_1.IInteger;
-  export import INumber = ILlmSchemaV3_1.INumber;
-  export import IString = ILlmSchemaV3_1.IString;
+  /**
+   * Constant value type.
+   */
+  export type IConstant = ILlmSchemaV3_1.IConstant;
 
-  export import IObject = ILlmSchemaV3_1.IObject;
-  export import IArray = ILlmSchemaV3_1.IArray;
-  export import IReference = ILlmSchemaV3_1.IReference;
-  export import IOneOf = ILlmSchemaV3_1.IOneOf;
-  export import INull = ILlmSchemaV3_1.INull;
-  export import IUnknown = ILlmSchemaV3_1.IUnknown;
+  /**
+   * Boolean type info.
+   */
+  export type IBoolean = ILlmSchemaV3_1.IBoolean;
+
+  /**
+   * Integer type info.
+   */
+  export type IInteger = ILlmSchemaV3_1.IInteger;
+
+  /**
+   * Number (double) type info.
+   */
+  export type INumber = ILlmSchemaV3_1.INumber;
+
+  /**
+   * String type info.
+   */
+  export type IString = ILlmSchemaV3_1.IString;
+
+  /**
+   * Array type info.
+   */
+  export type IArray = ILlmSchemaV3_1.IArray;
+
+  /**
+   * Object type info.
+   */
+  export type IObject = ILlmSchemaV3_1.IObject;
+
+  /**
+   * Reference type directing named schema.
+   */
+  export type IReference = ILlmSchemaV3_1.IReference;
+
+  /**
+   * Union type.
+   *
+   * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+   *
+   * For reference, even though your Swagger (or OpenAPI) document has
+   * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly
+   * converts it to `oneOf` type.
+   */
+  export type IOneOf = ILlmSchemaV3_1.IOneOf;
+  export namespace IOneOf {
+    /**
+     * Discriminator info of the union type.
+     */
+    export type IDiscriminator = ILlmSchemaV3_1.IOneOf.IDiscriminator;
+  }
+
+  /**
+   * Null type.
+   */
+  export type INull = ILlmSchemaV3_1.INull;
+
+  /**
+   * Unknown, the `any` type.
+   */
+  export type IUnknown = ILlmSchemaV3_1.IUnknown;
 }

--- a/src/structures/IClaudeSchema.ts
+++ b/src/structures/IClaudeSchema.ts
@@ -133,7 +133,7 @@ export namespace IClaudeSchema {
   /**
    * Union type.
    *
-   * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+   * `IOneOf` represents an union type of the TypeScript (`A | B | C`).
    *
    * For reference, even though your Swagger (or OpenAPI) document has
    * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly

--- a/src/structures/IDeepSeekSchema.ts
+++ b/src/structures/IDeepSeekSchema.ts
@@ -131,7 +131,7 @@ export namespace IDeepSeekSchema {
   /**
    * Union type.
    *
-   * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+   * `IOneOf` represents an union type of the TypeScript (`A | B | C`).
    *
    * For reference, even though your Swagger (or OpenAPI) document has
    * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly

--- a/src/structures/IDeepSeekSchema.ts
+++ b/src/structures/IDeepSeekSchema.ts
@@ -76,18 +76,82 @@ export namespace IDeepSeekSchema {
     reference: boolean;
   }
 
-  export import IParameters = ILlmSchemaV3_1.IParameters;
+  /**
+   * Type of the function parameters.
+   *
+   * `IDeepSeekSchema.IParameters` is a type defining a function's parameters
+   * as a keyworded object type.
+   *
+   * It also can be utilized for the structured output metadata.
+   *
+   * @reference https://platform.openai.com/docs/guides/structured-outputs
+   */
+  export type IParameters = ILlmSchemaV3_1.IParameters;
 
-  export import IConstant = ILlmSchemaV3_1.IConstant;
-  export import IBoolean = ILlmSchemaV3_1.IBoolean;
-  export import IInteger = ILlmSchemaV3_1.IInteger;
-  export import INumber = ILlmSchemaV3_1.INumber;
-  export import IString = ILlmSchemaV3_1.IString;
+  /**
+   * Constant value type.
+   */
+  export type IConstant = ILlmSchemaV3_1.IConstant;
 
-  export import IObject = ILlmSchemaV3_1.IObject;
-  export import IArray = ILlmSchemaV3_1.IArray;
-  export import IReference = ILlmSchemaV3_1.IReference;
-  export import IOneOf = ILlmSchemaV3_1.IOneOf;
-  export import INull = ILlmSchemaV3_1.INull;
-  export import IUnknown = ILlmSchemaV3_1.IUnknown;
+  /**
+   * Boolean type info.
+   */
+  export type IBoolean = ILlmSchemaV3_1.IBoolean;
+
+  /**
+   * Integer type info.
+   */
+  export type IInteger = ILlmSchemaV3_1.IInteger;
+
+  /**
+   * Number (double) type info.
+   */
+  export type INumber = ILlmSchemaV3_1.INumber;
+
+  /**
+   * String type info.
+   */
+  export type IString = ILlmSchemaV3_1.IString;
+
+  /**
+   * Array type info.
+   */
+  export type IArray = ILlmSchemaV3_1.IArray;
+
+  /**
+   * Object type info.
+   */
+  export type IObject = ILlmSchemaV3_1.IObject;
+
+  /**
+   * Reference type directing named schema.
+   */
+  export type IReference = ILlmSchemaV3_1.IReference;
+
+  /**
+   * Union type.
+   *
+   * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+   *
+   * For reference, even though your Swagger (or OpenAPI) document has
+   * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly
+   * converts it to `oneOf` type.
+   */
+  export type IOneOf = ILlmSchemaV3_1.IOneOf;
+  export namespace IOneOf {
+    /**
+     * Discriminator info of the union type.
+     */
+    export type IDiscriminator = ILlmSchemaV3_1.IOneOf.IDiscriminator;
+  }
+
+  /**
+   * Null type.
+   */
+  export type INull = ILlmSchemaV3_1.INull;
+
+  /**
+   * Unknown, the `any` type.
+   */
+  export type IUnknown = ILlmSchemaV3_1.IUnknown;
 }

--- a/src/structures/ILlamaSchema.ts
+++ b/src/structures/ILlamaSchema.ts
@@ -57,21 +57,6 @@ export type ILlamaSchema =
   | ILlamaSchema.INull
   | ILlamaSchema.IUnknown;
 export namespace ILlamaSchema {
-  export import IParameters = ILlmSchemaV3_1.IParameters;
-
-  export import IConstant = ILlmSchemaV3_1.IConstant;
-  export import IBoolean = ILlmSchemaV3_1.IBoolean;
-  export import IInteger = ILlmSchemaV3_1.IInteger;
-  export import INumber = ILlmSchemaV3_1.INumber;
-  export import IString = ILlmSchemaV3_1.IString;
-
-  export import IObject = ILlmSchemaV3_1.IObject;
-  export import IArray = ILlmSchemaV3_1.IArray;
-  export import IReference = ILlmSchemaV3_1.IReference;
-  export import IOneOf = ILlmSchemaV3_1.IOneOf;
-  export import INull = ILlmSchemaV3_1.INull;
-  export import IUnknown = ILlmSchemaV3_1.IUnknown;
-
   /**
    * Configuration for Llama schema composition.
    */
@@ -96,4 +81,83 @@ export namespace ILlamaSchema {
      */
     reference: boolean;
   }
+
+  /**
+   * Type of the function parameters.
+   *
+   * `ILlamaSchema.IParameters` is a type defining a function's parameters
+   * as a keyworded object type.
+   *
+   * It also can be utilized for the structured output metadata.
+   *
+   * @reference https://platform.openai.com/docs/guides/structured-outputs
+   */
+  export type IParameters = ILlmSchemaV3_1.IParameters;
+
+  /**
+   * Constant value type.
+   */
+  export type IConstant = ILlmSchemaV3_1.IConstant;
+
+  /**
+   * Boolean type info.
+   */
+  export type IBoolean = ILlmSchemaV3_1.IBoolean;
+
+  /**
+   * Integer type info.
+   */
+  export type IInteger = ILlmSchemaV3_1.IInteger;
+
+  /**
+   * Number (double) type info.
+   */
+  export type INumber = ILlmSchemaV3_1.INumber;
+
+  /**
+   * String type info.
+   */
+  export type IString = ILlmSchemaV3_1.IString;
+
+  /**
+   * Array type info.
+   */
+  export type IArray = ILlmSchemaV3_1.IArray;
+
+  /**
+   * Object type info.
+   */
+  export type IObject = ILlmSchemaV3_1.IObject;
+
+  /**
+   * Reference type directing named schema.
+   */
+  export type IReference = ILlmSchemaV3_1.IReference;
+
+  /**
+   * Union type.
+   *
+   * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+   *
+   * For reference, even though your Swagger (or OpenAPI) document has
+   * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly
+   * converts it to `oneOf` type.
+   */
+  export type IOneOf = ILlmSchemaV3_1.IOneOf;
+  export namespace IOneOf {
+    /**
+     * Discriminator info of the union type.
+     */
+    export type IDiscriminator = ILlmSchemaV3_1.IOneOf.IDiscriminator;
+  }
+
+  /**
+   * Null type.
+   */
+  export type INull = ILlmSchemaV3_1.INull;
+
+  /**
+   * Unknown, the `any` type.
+   */
+  export type IUnknown = ILlmSchemaV3_1.IUnknown;
 }

--- a/src/structures/ILlamaSchema.ts
+++ b/src/structures/ILlamaSchema.ts
@@ -137,7 +137,7 @@ export namespace ILlamaSchema {
   /**
    * Union type.
    *
-   * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+   * `IOneOf` represents an union type of the TypeScript (`A | B | C`).
    *
    * For reference, even though your Swagger (or OpenAPI) document has
    * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly

--- a/src/structures/ILlmSchemaV3_1.ts
+++ b/src/structures/ILlmSchemaV3_1.ts
@@ -446,7 +446,7 @@ export namespace ILlmSchemaV3_1 {
   /**
    * Union type.
    *
-   * IOneOf` represents an union type of the TypeScript (`A | B | C`).
+   * `IOneOf` represents an union type of the TypeScript (`A | B | C`).
    *
    * For reference, even though your Swagger (or OpenAPI) document has
    * defined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly

--- a/src/utils/ClaudeTypeChecker.ts
+++ b/src/utils/ClaudeTypeChecker.ts
@@ -1,3 +1,3 @@
 import { LlmTypeCheckerV3_1 } from "./LlmTypeCheckerV3_1";
 
-export import ClaudeTypeChecker = LlmTypeCheckerV3_1;
+export const ClaudeTypeChecker = LlmTypeCheckerV3_1;

--- a/src/utils/DeepSeekTypeChecker.ts
+++ b/src/utils/DeepSeekTypeChecker.ts
@@ -1,3 +1,3 @@
 import { LlmTypeCheckerV3_1 } from "./LlmTypeCheckerV3_1";
 
-export import DeepSeekTypeChecker = LlmTypeCheckerV3_1;
+export const DeepSeekTypeChecker = LlmTypeCheckerV3_1;

--- a/src/utils/LlamaTypeChecker.ts
+++ b/src/utils/LlamaTypeChecker.ts
@@ -1,3 +1,3 @@
 import { LlmTypeCheckerV3_1 } from "./LlmTypeCheckerV3_1";
 
-export import LlamaTypeChecker = LlmTypeCheckerV3_1;
+export const LlamaTypeChecker = LlmTypeCheckerV3_1;


### PR DESCRIPTION
This pull request refactors type definitions and type checker exports across multiple schema-related files to improve clarity and consistency. The most significant changes include replacing `export import` with `export type` for type definitions, adding detailed documentation for each type, and switching from `export import` to `export const` for type checkers.

### Type Definition Refactoring and Documentation:

* Replaced `export import` with `export type` for type definitions in `IClaudeSchema`, `IDeepSeekSchema`, and `ILlamaSchema` to better align with TypeScript conventions. Each type now includes detailed comments explaining its purpose and usage. (`src/structures/IClaudeSchema.ts`: [[1]](diffhunk://#diff-642f4c959248f881106878f7df1590f5bb813cbe4ddbf00d399689f634425f55L81-R158) `src/structures/IDeepSeekSchema.ts`: [[2]](diffhunk://#diff-dedb8b4473db573daaf04c754d0ed3557da396191b9652f7cd3218f27191c590L79-R156) `src/structures/ILlamaSchema.ts`: [[3]](diffhunk://#diff-904c3625d17f221eb2f6f8ade813af43da66378993d0b5a7cd852093366c38b0R84-R162)

### Type Checker Export Updates:

* Updated `ClaudeTypeChecker`, `DeepSeekTypeChecker`, and `LlamaTypeChecker` to use `export const` instead of `export import`, making the exports explicit and consistent with modern TypeScript practices. (`src/utils/ClaudeTypeChecker.ts`: [[1]](diffhunk://#diff-27c4a72ce89485033ec7d8d81fa886cacef5098804c0d59b887c8783717a9035L3-R3) `src/utils/DeepSeekTypeChecker.ts`: [[2]](diffhunk://#diff-74925cd60d35b9b6cbb2ea2f6edfa0ac14dddd6b269e4b27b4bea4910c93bd2fL3-R3) `src/utils/LlamaTypeChecker.ts`: [[3]](diffhunk://#diff-2157feed4712d051b88c206b5d946a1a8066f05721675b54ffc9e9c1136878abL3-R3)