### PR TITLE
Fix `ClaudeSchemaComposer.invert()` function bug for `oneOf` type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -640,7 +640,12 @@ export namespace LlmSchemaV3_1Composer {
         ...props.schema,
         $ref: `#/components/schemas/${key}`,
       };
-    } else if (
+    } else if (LlmTypeCheckerV3_1.isOneOf(props.schema))
+      return {
+        ...props.schema,
+        oneOf: props.schema.oneOf.map(next),
+      };
+    else if (
       LlmTypeCheckerV3_1.isInteger(props.schema) ||
       LlmTypeCheckerV3_1.isNumber(props.schema)
     )

--- a/test/src/executable/validate.ts
+++ b/test/src/executable/validate.ts
@@ -1,0 +1,245 @@
+import { OpenApi, OpenApiTypeChecker } from "@samchon/openapi";
+import { ClaudeSchemaComposer } from "@samchon/openapi/lib/composers/llm/ClaudeSchemaComposer";
+
+const components: OpenApi.IComponents = {};
+const schema: OpenApi.IJsonSchema = ClaudeSchemaComposer.invert({
+  components,
+  schema: {
+    type: "array",
+    items: {
+      $ref: "#/$defs/marketplace-purchase",
+    },
+  },
+  $defs: {
+    "IApiMarketplaceListingPlansAccounts.GetQuery": {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+    "marketplace-purchase": {
+      title: "Marketplace Purchase",
+      description: "Marketplace Purchase",
+      type: "object",
+      properties: {
+        url: {
+          type: "string",
+        },
+        type: {
+          type: "string",
+        },
+        id: {
+          type: "integer",
+        },
+        login: {
+          type: "string",
+        },
+        organization_billing_email: {
+          type: "string",
+        },
+        email: {
+          oneOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "null",
+            },
+          ],
+        },
+        marketplace_pending_change: {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                is_installed: {
+                  type: "boolean",
+                },
+                effective_date: {
+                  type: "string",
+                },
+                unit_count: {
+                  oneOf: [
+                    {
+                      type: "integer",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+                id: {
+                  type: "integer",
+                },
+                plan: {
+                  $ref: "#/$defs/marketplace-listing-plan",
+                },
+              },
+              required: [],
+            },
+            {
+              type: "null",
+            },
+          ],
+        },
+        marketplace_purchase: {
+          type: "object",
+          properties: {
+            billing_cycle: {
+              type: "string",
+            },
+            next_billing_date: {
+              oneOf: [
+                {
+                  type: "string",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
+            is_installed: {
+              type: "boolean",
+            },
+            unit_count: {
+              oneOf: [
+                {
+                  type: "integer",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
+            on_free_trial: {
+              type: "boolean",
+            },
+            free_trial_ends_on: {
+              oneOf: [
+                {
+                  type: "string",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
+            updated_at: {
+              type: "string",
+            },
+            plan: {
+              $ref: "#/$defs/marketplace-listing-plan",
+            },
+          },
+          required: [],
+        },
+      },
+      required: ["url", "id", "type", "login", "marketplace_purchase"],
+    },
+    "marketplace-listing-plan": {
+      title: "Marketplace Listing Plan",
+      description: "Marketplace Listing Plan",
+      type: "object",
+      properties: {
+        url: {
+          example: "https://api.github.com/marketplace_listing/plans/1313",
+          type: "string",
+          format: "uri",
+        },
+        accounts_url: {
+          example:
+            "https://api.github.com/marketplace_listing/plans/1313/accounts",
+          type: "string",
+          format: "uri",
+        },
+        id: {
+          example: 1313,
+          type: "integer",
+        },
+        number: {
+          example: 3,
+          type: "integer",
+        },
+        name: {
+          example: "Pro",
+          type: "string",
+        },
+        description: {
+          example: "A professional-grade CI solution",
+          type: "string",
+        },
+        monthly_price_in_cents: {
+          example: 1099,
+          type: "integer",
+        },
+        yearly_price_in_cents: {
+          example: 11870,
+          type: "integer",
+        },
+        price_model: {
+          example: "FLAT_RATE",
+          oneOf: [
+            {
+              const: "FREE",
+            },
+            {
+              const: "FLAT_RATE",
+            },
+            {
+              const: "PER_UNIT",
+            },
+          ],
+        },
+        has_free_trial: {
+          example: true,
+          type: "boolean",
+        },
+        unit_name: {
+          oneOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "null",
+            },
+          ],
+        },
+        state: {
+          example: "published",
+          type: "string",
+        },
+        bullets: {
+          example: ["Up to 25 private repositories", "11 concurrent builds"],
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: [
+        "url",
+        "accounts_url",
+        "id",
+        "number",
+        "name",
+        "description",
+        "has_free_trial",
+        "price_model",
+        "unit_name",
+        "monthly_price_in_cents",
+        "state",
+        "yearly_price_in_cents",
+        "bullets",
+      ],
+    },
+  },
+});
+
+OpenApiTypeChecker.visit({
+  components,
+  schema,
+  closure: (schema) => {
+    if (OpenApiTypeChecker.isReference(schema)) {
+      console.log(schema.$ref);
+    }
+  },
+});


### PR DESCRIPTION
This pull request introduces updates to the `@samchon/openapi` package, focusing on enhancing schema handling and adding comprehensive test cases. The key changes include a version bump, improvements to schema composition logic, and the addition of a detailed test for schema validation.

### Package Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `4.3.2` to `4.3.3` to reflect the new changes.

### Schema Handling Enhancements:
* [`src/composers/llm/LlmSchemaV3_1Composer.ts`](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L643-R648): Enhanced the schema composition logic by adding support for `oneOf` schemas in the `LlmSchemaV3_1Composer` class. This ensures proper handling of schemas with multiple possible types.

### New Test for Schema Validation:
* [`test/src/executable/validate.ts`](diffhunk://#diff-ec8f1bcd07dc7b1bbf569118cd313133c59ec51b99394290649f71562155428dR1-R245): Added a comprehensive test case to validate schemas using the `ClaudeSchemaComposer` and `OpenApiTypeChecker`. The test includes a complex schema with nested objects, arrays, and `oneOf` conditions, ensuring robust validation of OpenAPI components.