### PR TITLE
Fix discrimiantor mapping property of AI schemas

### DIFF
--- a/src/composers/llm/ChatGptSchemaComposer.ts
+++ b/src/composers/llm/ChatGptSchemaComposer.ts
@@ -601,9 +601,24 @@ export namespace ChatGptSchemaComposer {
           ? { ...union[0] }
           : {
               oneOf: union.map((u) => ({ ...u, nullable: undefined })),
-              discriminator: ChatGptTypeChecker.isAnyOf(props.schema)
-                ? props.schema["x-discriminator"]
-                : undefined,
+              discriminator:
+                ChatGptTypeChecker.isAnyOf(props.schema) &&
+                props.schema["x-discriminator"] !== undefined
+                  ? {
+                      property: props.schema["x-discriminator"],
+                      mapping:
+                        props.schema["x-discriminator"].mapping !== undefined
+                          ? Object.fromEntries(
+                              Object.entries(
+                                props.schema["x-discriminator"].mapping,
+                              ).map(([key, value]) => [
+                                key,
+                                `#/components/schemas/${value.split("/").at(-1)}`,
+                              ]),
+                            )
+                          : undefined,
+                    }
+                  : undefined,
             }),
     };
   };

--- a/test/src/features/llm/chatgpt/test_chatgpt_schema_discriminator.ts
+++ b/test/src/features/llm/chatgpt/test_chatgpt_schema_discriminator.ts
@@ -26,7 +26,11 @@ export const test_chatgpt_schema_discriminator = (): void => {
   TestValidator.predicate("discriminator")(
     () =>
       ChatGptTypeChecker.isAnyOf(result.value) &&
-      result.value["x-discriminator"] !== undefined,
+      result.value["x-discriminator"] !== undefined &&
+      result.value["x-discriminator"].mapping !== undefined &&
+      Object.values(result.value["x-discriminator"].mapping).every((k) =>
+        k.startsWith("#/$defs/"),
+      ),
   );
 
   const invert: OpenApi.IJsonSchema = ChatGptSchemaComposer.invert({
@@ -36,7 +40,12 @@ export const test_chatgpt_schema_discriminator = (): void => {
   });
   TestValidator.predicate("invert")(
     () =>
-      OpenApiTypeChecker.isOneOf(invert) && invert.discriminator !== undefined,
+      OpenApiTypeChecker.isOneOf(invert) &&
+      invert.discriminator !== undefined &&
+      invert.discriminator.mapping !== undefined &&
+      Object.values(invert.discriminator.mapping).every((k) =>
+        k.startsWith("#/components/schemas/"),
+      ),
   );
 };
 

--- a/test/src/features/llm/schema/validate_llm_schema_discriminator.ts
+++ b/test/src/features/llm/schema/validate_llm_schema_discriminator.ts
@@ -10,8 +10,17 @@ import {
 import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 import typia, { IJsonSchemaUnit } from "typia";
 
+export const test_claude_schema_discriminator = (): void =>
+  validate_llm_schema_discriminator("claude");
+
+export const test_deepseek_schema_discriminator = (): void =>
+  validate_llm_schema_discriminator("deepseek");
+
 export const test_llama_schema_discriminator = (): void =>
   validate_llm_schema_discriminator("llama");
+
+export const test_llama_v31_schema_discriminator = (): void =>
+  validate_llm_schema_discriminator("3.1");
 
 const validate_llm_schema_discriminator = (
   vendor: "claude" | "deepseek" | "llama" | "3.1",
@@ -32,7 +41,11 @@ const validate_llm_schema_discriminator = (
   TestValidator.predicate("discriminator")(
     () =>
       LlmTypeCheckerV3_1.isOneOf(result.value) &&
-      result.value.discriminator !== undefined,
+      result.value.discriminator !== undefined &&
+      result.value.discriminator.mapping !== undefined &&
+      Object.values(result.value.discriminator.mapping).every((k) =>
+        k.startsWith("#/$defs/"),
+      ),
   );
 
   const invert: OpenApi.IJsonSchema = LlmSchemaComposer.invert(vendor)({
@@ -42,7 +55,12 @@ const validate_llm_schema_discriminator = (
   });
   TestValidator.predicate("invert")(
     () =>
-      OpenApiTypeChecker.isOneOf(invert) && invert.discriminator !== undefined,
+      OpenApiTypeChecker.isOneOf(invert) &&
+      invert.discriminator !== undefined &&
+      invert.discriminator.mapping !== undefined &&
+      Object.values(invert.discriminator.mapping).every((k) =>
+        k.startsWith("#/components/schemas/"),
+      ),
   );
 };
 


### PR DESCRIPTION
This pull request introduces enhancements to schema composition and validation logic, focusing on improving the handling of `discriminator` properties in JSON schemas. The changes ensure better support for mapping values and add comprehensive validation checks for schema integrity.

### Schema Composition Enhancements:

* **Improved `discriminator` handling in `ChatGptSchemaComposer`:** Added support for mapping values in the `discriminator` property, ensuring mappings are transformed into appropriate schema references (`#/components/schemas/...`).
* **Enhanced `discriminator` logic in `LlmSchemaV3_1Composer`:** Extended the `discriminator` handling to include validation of mappings and filtering of schema references, ensuring compatibility with the `union` structure. [[1]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881L329-R352) [[2]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R670-R686)

### Validation Logic Improvements:

* **Validation updates in `test_chatgpt_schema_discriminator`:** Added checks for the presence and correctness of `discriminator.mapping`, verifying that all mapping values start with `#/$defs/` or `#/components/schemas/`. [[1]](diffhunk://#diff-bc6c808870d8651db2765a0c5036daf02875f4a73489f67123f63cf72186fd81L29-R33) [[2]](diffhunk://#diff-bc6c808870d8651db2765a0c5036daf02875f4a73489f67123f63cf72186fd81L39-R48)
* **Expanded test coverage in `validate_llm_schema_discriminator`:** Introduced new tests for additional vendors (`claude`, `deepseek`, and `3.1`) and enhanced validation of `discriminator.mapping` for schema integrity. [[1]](diffhunk://#diff-4b9af447bccb159f091add8c1a34c1ca94c3b7d7bfb583423bb57af3e4c9b714R13-R24) [[2]](diffhunk://#diff-4b9af447bccb159f091add8c1a34c1ca94c3b7d7bfb583423bb57af3e4c9b714L35-R48) [[3]](diffhunk://#diff-4b9af447bccb159f091add8c1a34c1ca94c3b7d7bfb583423bb57af3e4c9b714L45-R63)