### PR TITLE
Make reference option of AI schema to be default `true`.

### DIFF
--- a/src/composers/LlmSchemaComposer.ts
+++ b/src/composers/LlmSchemaComposer.ts
@@ -1,11 +1,4 @@
-import { IChatGptSchema } from "../structures/IChatGptSchema";
-import { IClaudeSchema } from "../structures/IClaudeSchema";
-import { IDeepSeekSchema } from "../structures/IDeepSeekSchema";
-import { IGeminiSchema } from "../structures/IGeminiSchema";
-import { ILlamaSchema } from "../structures/ILlamaSchema";
 import { ILlmSchema } from "../structures/ILlmSchema";
-import { ILlmSchemaV3 } from "../structures/ILlmSchemaV3";
-import { ILlmSchemaV3_1 } from "../structures/ILlmSchemaV3_1";
 import { ChatGptTypeChecker } from "../utils/ChatGptTypeChecker";
 import { ClaudeTypeChecker } from "../utils/ClaudeTypeChecker";
 import { DeepSeekTypeChecker } from "../utils/DeepSeekTypeChecker";
@@ -88,30 +81,13 @@ const INVERTS = {
 };
 
 const DEFAULT_CONFIGS = {
-  chatgpt: {
-    reference: false,
-    strict: false,
-  } satisfies IChatGptSchema.IConfig,
-  claude: {
-    reference: false,
-  } satisfies IClaudeSchema.IConfig,
-  deepseek: {
-    reference: false,
-  } satisfies IDeepSeekSchema.IConfig,
-  gemini: {
-    recursive: 3,
-  } satisfies IGeminiSchema.IConfig,
-  llama: {
-    reference: false,
-  } satisfies ILlamaSchema.IConfig,
-  "3.0": {
-    constraint: true,
-    recursive: 3,
-  } satisfies ILlmSchemaV3.IConfig,
-  "3.1": {
-    constraint: true,
-    reference: false,
-  } satisfies ILlmSchemaV3_1.IConfig,
+  chatgpt: ChatGptSchemaComposer.DEFAULT_CONFIG,
+  claude: ClaudeSchemaComposer.DEFAULT_CONFIG,
+  deepseek: DeepSeekSchemaComposer.DEFAULT_CONFIG,
+  gemini: GeminiSchemaComposer.DEFAULT_CONFIG,
+  llama: LlamaSchemaComposer.DEFAULT_CONFIG,
+  "3.0": LlmSchemaV3Composer.DEFAULT_CONFIG,
+  "3.1": LlmSchemaV3_1Composer.DEFAULT_CONFIG,
 };
 
 const TYPE_CHECKERS = {

--- a/src/composers/llm/ChatGptSchemaComposer.ts
+++ b/src/composers/llm/ChatGptSchemaComposer.ts
@@ -17,6 +17,11 @@ export namespace ChatGptSchemaComposer {
   /** @internal */
   export const IS_DEFS = true;
 
+  export const DEFAULT_CONFIG: IChatGptSchema.IConfig = {
+    reference: true,
+    strict: false,
+  };
+
   /* -----------------------------------------------------------
     CONVERTERS
   ----------------------------------------------------------- */

--- a/src/composers/llm/ClaudeSchemaComposer.ts
+++ b/src/composers/llm/ClaudeSchemaComposer.ts
@@ -9,6 +9,10 @@ export namespace ClaudeSchemaComposer {
   /** @internal */
   export const IS_DEFS = true;
 
+  export const DEFAULT_CONFIG: IClaudeSchema.IConfig = {
+    reference: true,
+  };
+
   export const parameters = (props: {
     config: IClaudeSchema.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/DeepSeekSchemaComposer.ts
+++ b/src/composers/llm/DeepSeekSchemaComposer.ts
@@ -9,6 +9,10 @@ export namespace DeepSeekSchemaComposer {
   /** @internal */
   export const IS_DEFS = true;
 
+  export const DEFAULT_CONFIG: IDeepSeekSchema.IConfig = {
+    reference: true,
+  };
+
   export const parameters = (props: {
     config: IDeepSeekSchema.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/GeminiSchemaComposer.ts
+++ b/src/composers/llm/GeminiSchemaComposer.ts
@@ -15,6 +15,10 @@ export namespace GeminiSchemaComposer {
   /** @internal */
   export const IS_DEFS = false;
 
+  export const DEFAULT_CONFIG: IGeminiSchema.IConfig = {
+    recursive: 3,
+  };
+
   export const parameters = (props: {
     config: IGeminiSchema.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/LlamaSchemaComposer.ts
+++ b/src/composers/llm/LlamaSchemaComposer.ts
@@ -9,6 +9,10 @@ export namespace LlamaSchemaComposer {
   /** @internal */
   export const IS_DEFS = true;
 
+  export const DEFAULT_CONFIG: ILlamaSchema.IConfig = {
+    reference: true,
+  };
+
   export const parameters = (props: {
     config: ILlamaSchema.IConfig;
     components: OpenApi.IComponents;

--- a/src/composers/llm/LlmSchemaV3Composer.ts
+++ b/src/composers/llm/LlmSchemaV3Composer.ts
@@ -16,6 +16,11 @@ export namespace LlmSchemaV3Composer {
   /** @internal */
   export const IS_DEFS = false;
 
+  export const DEFAULT_CONFIG: ILlmSchemaV3.IConfig = {
+    recursive: 3,
+    constraint: true,
+  };
+
   /* -----------------------------------------------------------
     CONVERTERS
   ----------------------------------------------------------- */

--- a/src/composers/llm/LlmSchemaV3_1Composer.ts
+++ b/src/composers/llm/LlmSchemaV3_1Composer.ts
@@ -16,6 +16,11 @@ export namespace LlmSchemaV3_1Composer {
   /** @internal */
   export const IS_DEFS = true;
 
+  export const DEFAULT_CONFIG: ILlmSchemaV3_1.IConfig = {
+    reference: true,
+    constraint: true,
+  };
+
   /* -----------------------------------------------------------
     CONVERTERS
   ----------------------------------------------------------- */

--- a/src/structures/IChatGptSchema.ts
+++ b/src/structures/IChatGptSchema.ts
@@ -315,7 +315,7 @@ export namespace IChatGptSchema {
      * of ChatGPT, and want to reduce the LLM token cost, you can configure this
      * property to `true`.
      *
-     * @default false
+     * @default true
      */
     reference: boolean;
 

--- a/src/structures/IClaudeSchema.ts
+++ b/src/structures/IClaudeSchema.ts
@@ -78,7 +78,7 @@ export namespace IClaudeSchema {
      * LLM model, and want to reduce the LLM token cost, you can configure this
      * property to `true`.
      *
-     * @default false
+     * @default true
      */
     reference: boolean;
   }

--- a/src/structures/IDeepSeekSchema.ts
+++ b/src/structures/IDeepSeekSchema.ts
@@ -76,7 +76,7 @@ export namespace IDeepSeekSchema {
      * LLM model, and want to reduce the LLM token cost, you can configure this
      * property to `true`.
      *
-     * @default false
+     * @default true
      */
     reference: boolean;
   }

--- a/src/structures/ILlamaSchema.ts
+++ b/src/structures/ILlamaSchema.ts
@@ -82,7 +82,7 @@ export namespace ILlamaSchema {
      * LLM model, and want to reduce the LLM token cost, you can configure this
      * property to `true`.
      *
-     * @default false
+     * @default true
      */
     reference: boolean;
   }

--- a/src/structures/ILlmSchemaV3_1.ts
+++ b/src/structures/ILlmSchemaV3_1.ts
@@ -128,7 +128,7 @@ export namespace ILlmSchemaV3_1 {
      * LLM model, and want to reduce the LLM token cost, you can configure this
      * property to `true`.
      *
-     * @default false
+     * @default true
      */
     reference: boolean;
   }

--- a/test/src/features/llm/schema/validate_llm_schema_enum.ts
+++ b/test/src/features/llm/schema/validate_llm_schema_enum.ts
@@ -27,7 +27,10 @@ const validate_llm_schema_enum = <Model extends "chatgpt" | "gemini" | "3.0">(
   > = LlmSchemaComposer.schema(model)({
     components: collection.components,
     schema: collection.schemas[0],
-    config: LlmSchemaComposer.defaultConfig(model) as any,
+    config: {
+      ...LlmSchemaComposer.defaultConfig(model),
+      reference: false,
+    } as any,
     $defs: {},
   }) as IResult<ILlmSchema<Model>, IOpenApiSchemaError>;
   TestValidator.equals("success")(result.success);

--- a/test/src/features/llm/schema/validate_llm_schema_enum_reference.ts
+++ b/test/src/features/llm/schema/validate_llm_schema_enum_reference.ts
@@ -52,7 +52,10 @@ const validate_llm_schema_enum_reference = <
   > = LlmSchemaComposer.schema(model)({
     components,
     schema,
-    config: LlmSchemaComposer.defaultConfig(model) as any,
+    config: {
+      ...LlmSchemaComposer.defaultConfig(model),
+      reference: false,
+    } as any,
     $defs: {},
   }) as IResult<ILlmSchema<Model>, IOpenApiSchemaError>;
   TestValidator.equals(


### PR DESCRIPTION
This pull request refactors the `DEFAULT_CONFIGS` structure in `src/composers/LlmSchemaComposer.ts` to use centralized default configurations from individual schema composers and updates the default values for the `reference` property across multiple schema structures. Additionally, it modifies test cases to explicitly override the `reference` property when validating schemas.

### Refactoring and Centralization of Default Configurations:

* [`src/composers/LlmSchemaComposer.ts`](diffhunk://#diff-058da3c4ceb4aa02b198488eef3b8dd547d7c0f0ee2b2355e1d104527b1d597dL91-R90): Replaced hardcoded `DEFAULT_CONFIGS` values with references to `DEFAULT_CONFIG` constants defined in individual schema composers. This improves maintainability by centralizing configuration definitions.
* Individual schema composer files (`ChatGptSchemaComposer`, `ClaudeSchemaComposer`, `DeepSeekSchemaComposer`, `GeminiSchemaComposer`, `LlamaSchemaComposer`, `LlmSchemaV3Composer`, `LlmSchemaV3_1Composer`): Added `DEFAULT_CONFIG` constants for each schema composer to define default configurations. [[1]](diffhunk://#diff-d0c4b1bc6bd6c1280622ba3db00bf102c54ccb57a60d124822ff0d592628d9cfR20-R24) [[2]](diffhunk://#diff-09e976921cbf7ded8e1667800e245195ac7a939f7640fdd806acedcb69f91d65R12-R15) [[3]](diffhunk://#diff-f0215727a07245d1744da98eff3ac7c220234ce702500f68245b7738f2310adbR12-R15) [[4]](diffhunk://#diff-4e9da1f0bdac90742383f58756d5fe60a9d5de3293d24f67f6015f9e88d54759R18-R21) [[5]](diffhunk://#diff-5b7ae0e3be666c887786a4fdb4dfc30b7f0505900ff35bca89338d2f9d3ec0b6R12-R15) [[6]](diffhunk://#diff-02fa51db5bda226c48ccb28078266cc34a34d5dab1af1223bd8000ee688cd7b4R19-R23) [[7]](diffhunk://#diff-77518819d0e39da5042e7d25b6345cea620bf8c2f3c181f2bee598b499334881R19-R23)

### Updates to Default Values for `reference` Property:

* Schema structure files (`IChatGptSchema`, `IClaudeSchema`, `IDeepSeekSchema`, `ILlamaSchema`, `ILlmSchemaV3_1`): Changed the default value of the `reference` property from `false` to `true` in the documentation comments, aligning with the new default configurations. [[1]](diffhunk://#diff-e3f5f136085423d1963db8ab983cc4962935d5b88b9687ad5ff9ee8631971d28L318-R318) [[2]](diffhunk://#diff-642f4c959248f881106878f7df1590f5bb813cbe4ddbf00d399689f634425f55L81-R81) [[3]](diffhunk://#diff-dedb8b4473db573daaf04c754d0ed3557da396191b9652f7cd3218f27191c590L79-R79) [[4]](diffhunk://#diff-904c3625d17f221eb2f6f8ade813af43da66378993d0b5a7cd852093366c38b0L85-R85) [[5]](diffhunk://#diff-72e41eeadd5016cdfe8a554caae2e2bb215b4b929ff01b52fa5f79efd14bd3abL131-R131)

### Test Case Adjustments:

* Test files (`validate_llm_schema_enum.ts`, `validate_llm_schema_enum_reference.ts`): Updated test configurations to explicitly set `reference: false` when validating schemas, ensuring tests reflect scenarios where the `reference` property is overridden. [[1]](diffhunk://#diff-b6771b7816853a7afbe379a53b632ab0edaa7b5f7eab5299608e250f5c3334c8L30-R33) [[2]](diffhunk://#diff-f8d7496cb88a18a0a6c654234b499a5f190fd4c9a42ea55c06e9c2003d0534a2L55-R58)