### PR TITLE
`IChatGptSchema.title` in description as JSDocTag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/openapi",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,13 +70,13 @@ importers:
         version: 0.24.0
       '@nestia/core':
         specifier: ^6.0.1
-        version: 6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
+        version: 6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
       '@nestia/e2e':
         specifier: ^6.0.1
         version: 6.0.1
       '@nestia/fetcher':
         specifier: ^6.0.1
-        version: 6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3))
+        version: 6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3))
       '@nestjs/common':
         specifier: ^11.0.16
         version: 11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -117,15 +117,15 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^9.1.1
-        version: 9.1.1(@samchon/openapi@)(typescript@5.8.3)
+        specifier: ^9.5.0-dev.20250710
+        version: 9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
     devDependencies:
       '@nestia/sdk':
         specifier: ^6.0.1
-        version: 6.0.1(@nestia/core@6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3))(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))(typescript@5.8.3)
+        version: 6.0.1(@nestia/core@6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3))(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))(typescript@5.8.3)
       '@types/multer':
         specifier: ^1.4.12
         version: 1.4.12
@@ -466,6 +466,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -1957,6 +1960,13 @@ packages:
       '@samchon/openapi': '>=4.0.0 <5.0.0'
       typescript: '>=4.8.0 <5.9.0'
 
+  typia@9.5.0-dev.20250710:
+    resolution: {integrity: sha512-xy1/y/Y6ePi74ex1T7ezJxnV2sRJ9s2/lvZi8zf7uqVDa7PgvUGjgnZzWDTaZHAZkTY5jBi3ak5lQkfchRjIGg==}
+    hasBin: true
+    peerDependencies:
+      '@samchon/openapi': '>=4.4.1 <5.0.0'
+      typescript: '>=4.8.0 <5.9.0'
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -2198,9 +2208,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestia/core@6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)':
+  '@nestia/core@6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)':
     dependencies:
-      '@nestia/fetcher': 6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3))
+      '@nestia/fetcher': 6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3))
       '@nestjs/common': 11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.0.16(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@samchon/openapi': 4.0.0
@@ -2221,15 +2231,15 @@ snapshots:
 
   '@nestia/e2e@6.0.1': {}
 
-  '@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3))':
+  '@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3))':
     dependencies:
       '@samchon/openapi': 'link:'
-      typia: 9.1.1(@samchon/openapi@)(typescript@5.8.3)
+      typia: 9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)
 
-  '@nestia/sdk@6.0.1(@nestia/core@6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3))(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))(typescript@5.8.3)':
+  '@nestia/sdk@6.0.1(@nestia/core@6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3))(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
-      '@nestia/core': 6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
-      '@nestia/fetcher': 6.0.1(@samchon/openapi@)(typia@9.1.1(@samchon/openapi@)(typescript@5.8.3))
+      '@nestia/core': 6.0.1(@nestia/fetcher@6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3)))(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
+      '@nestia/fetcher': 6.0.1(@samchon/openapi@)(typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3))
       '@nestjs/common': 11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.0.16(@nestjs/common@11.0.16(file-type@20.4.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.0.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@samchon/openapi': 4.0.0
@@ -2399,6 +2409,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
@@ -3998,9 +4010,9 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typia@9.1.1(@samchon/openapi@)(typescript@5.8.3):
+  typia@9.1.1(@samchon/openapi@4.0.0)(typescript@5.8.3):
     dependencies:
-      '@samchon/openapi': 'link:'
+      '@samchon/openapi': 4.0.0
       commander: 10.0.1
       comment-json: 4.2.5
       inquirer: 8.2.6
@@ -4008,9 +4020,10 @@ snapshots:
       randexp: 0.5.3
       typescript: 5.8.3
 
-  typia@9.1.1(@samchon/openapi@4.0.0)(typescript@5.8.3):
+  typia@9.5.0-dev.20250710(@samchon/openapi@)(typescript@5.8.3):
     dependencies:
-      '@samchon/openapi': 4.0.0
+      '@samchon/openapi': 'link:'
+      '@standard-schema/spec': 1.0.0
       commander: 10.0.1
       comment-json: 4.2.5
       inquirer: 8.2.6

--- a/src/composers/llm/GeminiSchemaComposer.ts
+++ b/src/composers/llm/GeminiSchemaComposer.ts
@@ -84,15 +84,9 @@ export namespace GeminiSchemaComposer {
       schema: result.value,
       closure: (v) => {
         if (v.title !== undefined) {
-          if (v.description === undefined) v.description = v.title;
-          else {
-            const title: string = v.title.endsWith(".")
-              ? v.title.substring(0, v.title.length - 1)
-              : v.title;
-            v.description = v.description.startsWith(title)
-              ? v.description
-              : `${title}.\n\n${v.description}`;
-          }
+          v.description = !!v.description?.length
+            ? `${v.description}\n\n@title ${v.title}`
+            : `@title ${v.title}`;
           delete v.title;
         }
         if (

--- a/test/package.json
+++ b/test/package.json
@@ -32,7 +32,7 @@
     "randexp": "^0.5.3",
     "source-map-support": "^0.5.21",
     "tstl": "^3.0.0",
-    "typia": "^9.1.1",
+    "typia": "^9.5.0-dev.20250710",
     "uuid": "^11.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
```txt
Some description.

@title some title
```

Also, this strategy would be adjusted to the `typia` too. `typia` will no more define `IJsonSchema.title` from description comment. It will compose `IJsonSchema.title` only by `@title` tag.

```typescript
export interface Something {
  /**
   * The first line is not title.
   */
  first: string;

  /**
   * The title only comes from JSDocTag like below.
   *
   * @title this is the title
   */
  second: number;
}
```