### PR TITLE
Fix `ILlmApplication.IValidationHook` type

### DIFF
--- a/src/structures/ILlmApplication.ts
+++ b/src/structures/ILlmApplication.ts
@@ -140,7 +140,7 @@ export namespace ILlmApplication {
    */
   export type IValidationHook<Class extends object> = {
     [K in keyof Class]?: Class[K] extends (args: infer Argument) => unknown
-      ? (input: Argument) => IValidation<unknown>
+      ? (input: unknown) => IValidation<Argument>
       : never;
   };
 }


### PR DESCRIPTION
This pull request updates the `IValidationHook` type in `ILlmApplication.ts` to improve type safety for validation hooks. The main change reverses the type parameter in the validation function to ensure the input is correctly typed as `unknown` and the validation result matches the expected argument type.

Type safety improvement:

* Updated the `IValidationHook` type so that validation functions now accept an input of type `unknown` and return an `IValidation` of the expected argument type, rather than the reverse. This ensures more robust and predictable type checking for validation hooks.