### PR TITLE
JSDoc comments on universal LLM types.

### DIFF
--- a/src/structures/IHttpLlmApplication.ts
+++ b/src/structures/IHttpLlmApplication.ts
@@ -2,7 +2,6 @@ import { OpenApi } from "../OpenApi";
 import { IHttpLlmFunction } from "./IHttpLlmFunction";
 import { IHttpMigrateRoute } from "./IHttpMigrateRoute";
 import { ILlmSchema } from "./ILlmSchema";
-import { ILlmSchemaV3 } from "./ILlmSchemaV3";
 
 /**
  * Application of LLM function call from OpenAPI document.
@@ -19,10 +18,9 @@ import { ILlmSchemaV3 } from "./ILlmSchemaV3";
  * {@link IHttpLlmFunction} type which represents LLM function calling schema. By
  * the way, if there're some types which does not supported by LLM, the
  * operation would be failed and pushed into the
- * {@link IHttpLlmApplication.errors}. Otherwise not, the operation would be
+ * {@link IHttpLlmApplication.errors}. Otherwise, the operation would be
  * successfully converted to {@link IHttpLlmFunction} and its type schemas are
- * downgraded to {@link OpenApiV3.IJsonSchema} and converted to
- * {@link ILlmSchemaV3}.
+ * converted to {@link ILlmSchema}.
  *
  * For reference, the arguments type is composed by below rule.
  *
@@ -88,7 +86,7 @@ export namespace IHttpLlmApplication {
      * understand the parameter.
      *
      * For example, if the parameter type has configured
-     * {@link IGeminiSchema.IString.contentMediaType} which indicates file
+     * {@link ILlmSchema.IString.contentMediaType} which indicates file
      * uploading, it must be composed by human, not by LLM (Large Language
      * Model).
      *
@@ -102,7 +100,7 @@ export namespace IHttpLlmApplication {
      * When writing the function, note that returning value `true` means to be a
      * human composing the value, and `false` means to LLM composing the value.
      * Also, when predicating the schema, it would better to utilize the
-     * {@link GeminiTypeChecker} like features.
+     * {@link LlmTypeChecker} like features.
      *
      * @default null
      * @param schema Schema to be separated.

--- a/src/structures/IHttpLlmController.ts
+++ b/src/structures/IHttpLlmController.ts
@@ -30,12 +30,11 @@ import { IHttpResponse } from "./IHttpResponse";
  *     {
  *       protocol: "http",
  *       name: "shopping",
- *       application: HttpLlm.application(
- *         model: "chatgpt",
+ *       application: HttpLlm.application({
  *         document: await fetch(
  *           "https://shopping-be.wrtn.io/editor/swagger.json",
  *         ).then((r) => r.json()),
- *       ),
+ *       }),
  *       connection: {
  *         host: "https://shopping-be.wrtn.io",
  *         headers: {
@@ -56,7 +55,6 @@ import { IHttpResponse } from "./IHttpResponse";
  * - {@link ILlmController} for TypeScript
  *
  * @author Jeongho Nam - https://github.com/samchon
- * @template Model Type of the LLM model
  * @reference https://wrtnlabs.io/agentica/docs/core/controller/swagger/
  */
 export interface IHttpLlmController {

--- a/src/structures/IHttpLlmFunction.ts
+++ b/src/structures/IHttpLlmFunction.ts
@@ -19,11 +19,7 @@ import { IValidation } from "./IValidation";
  *
  * For reference, different between `IHttpLlmFunction` and its origin source
  * {@link OpenApi.IOperation} is, `IHttpLlmFunction` has converted every type
- * schema information from {@link OpenApi.IJsonSchema} to {@link ILlmSchemaV3} to
- * escape {@link OpenApi.IJsonSchema.IReference reference types}, and downgrade
- * the version of the JSON schema to OpenAPI 3.0. It's because LLM function call
- * feature cannot understand both reference types and OpenAPI 3.1
- * specification.
+ * schema information from {@link OpenApi.IJsonSchema} to {@link ILlmSchema}.
  *
  * Additionally, the properties' rule is:
  *
@@ -93,7 +89,7 @@ export interface IHttpLlmFunction {
    *
    * If you've configured {@link IHttpLlmApplication.IOptions.keyword} as `true`,
    * number of {@link IHttpLlmFunction.parameters} are always 1 and the first
-   * parameter's type is always {@link ILlmSchemaV3.IObject}. The properties'
+   * parameter's type is always {@link ILlmSchema.IObject}. The properties'
    * rule is:
    *
    * - `pathParameters`: Path parameters of {@link IHttpMigrateRoute.parameters}

--- a/src/structures/ILlmApplication.ts
+++ b/src/structures/ILlmApplication.ts
@@ -7,8 +7,8 @@ import { IValidation } from "./IValidation";
  *
  * `ILlmApplication` is a data structure representing a collection of
  * {@link ILlmFunction LLM function calling schemas}, composed from a native
- * TypeScript class (or interface) type by the `typia.llm.application<App,
- * Model>()` function.
+ * TypeScript class (or interface) type by the `typia.llm.application<App>()`
+ * function.
  *
  * Also, there can be some parameters (or their nested properties) which must be
  * composed by Human, not by LLM. File uploading feature or some sensitive
@@ -58,7 +58,7 @@ export namespace ILlmApplication {
      * understand the parameter.
      *
      * For example, if the parameter type has configured
-     * {@link IGeminiSchema.IString.contentMediaType} which indicates file
+     * {@link ILlmSchema.IString.contentMediaType} which indicates file
      * uploading, it must be composed by human, not by LLM (Large Language
      * Model).
      *
@@ -72,7 +72,7 @@ export namespace ILlmApplication {
      * When writing the function, note that returning value `true` means to be a
      * human composing the value, and `false` means to LLM composing the value.
      * Also, when predicating the schema, it would better to utilize the
-     * {@link GeminiTypeChecker} like features.
+     * {@link LlmTypeChecker} like features.
      *
      * @default null
      * @param schema Schema to be separated.

--- a/src/structures/ILlmController.ts
+++ b/src/structures/ILlmController.ts
@@ -24,11 +24,11 @@ import { ILlmApplication } from "./ILlmApplication";
  *     model: "gpt-4o-mini",
  *   },
  *   controllers: [
- *     typia.llm.controller<ReactNativeFileSystem, "chatgpt">(
+ *     typia.llm.controller<ReactNativeFileSystem>(
  *       "filesystem",
  *       new ReactNativeFileSystem(),
  *     ),
- *     typia.llm.controller<ReactNativeGallery, "chatgpt">(
+ *     typia.llm.controller<ReactNativeGallery>(
  *       "gallery",
  *       new ReactNativeGallery(),
  *     ),
@@ -47,7 +47,6 @@ import { ILlmApplication } from "./ILlmApplication";
  * - {@link IMcpLlmController} for MCP
  *
  * @author Jeongho Nam - https://github.com/samchon
- * @template Model Type of the LLM model
  * @template Class Class type of the function executor
  * @reference https://typia.io/docs/llm/controller/
  * @reference https://wrtnlabs.io/agentica/docs/core/controller/typescript/

--- a/src/structures/ILlmFunction.ts
+++ b/src/structures/ILlmFunction.ts
@@ -21,7 +21,6 @@ import { IValidation } from "./IValidation";
  * [`typia`](https://github.com/samchon/typia) library.
  *
  * @author Jeongho Nam - https://github.com/samchon
- * @template Model Type of the LLM model
  * @reference https://platform.openai.com/docs/guides/function-calling
  */
 export interface ILlmFunction {

--- a/src/structures/ILlmSchema.ts
+++ b/src/structures/ILlmSchema.ts
@@ -45,6 +45,24 @@ import { IJsonSchemaAttribute } from "./IJsonSchemaAttribute";
  * - {@link ILlmSchema.properties} and {@link ILlmSchema.required} are always
  *   defined
  *
+ * ## Strict Mode
+ *
+ * When {@link ILlmSchema.IConfig.strict} mode is enabled, the schema
+ * transformation follows OpenAI's structured output requirements:
+ *
+ * - Every {@link ILlmSchema.IObject.additionalProperties} is forced to `false`
+ * - Every property in {@link ILlmSchema.IObject.properties} becomes
+ *   {@link ILlmSchema.IObject.required}
+ * - All constraint properties are removed from the schema and moved to
+ *   {@link IJsonSchemaAttribute.description} in a JSDoc-like format:
+ *
+ *   - Numeric constraints: `minimum`, `maximum`, `exclusiveMinimum`,
+ *       `exclusiveMaximum`, `multipleOf`
+ *   - String constraints: `minLength`, `maxLength`, `pattern`, `format`,
+ *       `contentMediaType`
+ *   - Array constraints: `minItems`, `maxItems`, `uniqueItems`
+ *   - Example: `@minimum 0`, `@maximum 100`, `@format uuid`
+ *
  * @author Jeongho Nam - https://github.com/samchon
  */
 export type ILlmSchema =

--- a/src/structures/IMcpLlmApplication.ts
+++ b/src/structures/IMcpLlmApplication.ts
@@ -12,10 +12,10 @@ import { IMcpLlmFunction } from "./IMcpLlmFunction";
  * construction.
  *
  * About each function of MCP server, there can be {@link errors} during the
- * composition, if the target {@link model} does not support the function's
- * {@link IMcpLlmFunction.parameters} type. For example, Google Gemini model does
- * not support union type, so that the function containing the union type would
- * be placed into the {@link errors} list instead of {@link functions}.
+ * composition, if the function's {@link IMcpLlmFunction.parameters} type has
+ * some unsupported types for the LLM function calling. In that case, the
+ * function would be placed into the {@link errors} list instead of
+ * {@link functions}.
  *
  * Also, each function has its own {@link IMcpLlmFunction.validate} function for
  * correcting AI agent's mistakes, and this is the reason why `@samchon/openapi`
@@ -42,7 +42,7 @@ export interface IMcpLlmApplication {
   options: IMcpLlmApplication.IOptions;
 }
 export namespace IMcpLlmApplication {
-  /** Options for the HTTP LLM application schema composition. */
+  /** Options for the MCP LLM application schema composition. */
   export interface IOptions extends ILlmSchema.IConfig {
     /**
      * Maximum length of function name.

--- a/src/structures/IMcpLlmController.ts
+++ b/src/structures/IMcpLlmController.ts
@@ -40,7 +40,6 @@ import { IMcpLlmApplication } from "./IMcpLlmApplication";
  *   controllers: [
  *     await assertMcpController({
  *       name: "calculator",
- *       model: "chatgpt",
  *       client,
  *     }),
  *   ],

--- a/src/structures/IMcpLlmFunction.ts
+++ b/src/structures/IMcpLlmFunction.ts
@@ -72,14 +72,6 @@ export interface IMcpLlmFunction {
    * rate soars to 99% at the second trial, and I've never failed at the third
    * trial.
    *
-   * > If you've {@link separated} parameters, use the
-   * > {@link IMcpLlmFunction.ISeparated.validate} function instead when validating
-   * > the LLM composed arguments.
-   *
-   * > In that case, This `validate` function would be meaningful only when you've
-   * > merged the LLM and human composed arguments by
-   * > {@link McpLlm.mergeParameters} function.
-   *
    * @param args Arguments to validate
    * @returns Validation result
    */


### PR DESCRIPTION
This pull request primarily updates documentation and type references across several files to improve clarity and consistency in how LLM schema types are described. The changes remove references to the deprecated `ILlmSchemaV3` in favor of `ILlmSchema`, update example usage to reflect current APIs, and clarify strict mode behavior for schema transformation. Additionally, some redundant or outdated documentation is cleaned up.

**Documentation and Type Reference Updates:**

- Replaced all references to `ILlmSchemaV3` with `ILlmSchema` in documentation comments and type annotations, ensuring consistency and removing deprecated terminology. [[1]](diffhunk://#diff-6e6bececd1bc7bc3c702e37136705a8f14fb4a04438d2cc56b49b8a9dad83e5dL5) [[2]](diffhunk://#diff-6e6bececd1bc7bc3c702e37136705a8f14fb4a04438d2cc56b49b8a9dad83e5dL22-R23) [[3]](diffhunk://#diff-40aad91cda9d576516527b8ece8e58e9f4ad7779a1c6830cb7d92408fcfa32cbL22-R22) [[4]](diffhunk://#diff-40aad91cda9d576516527b8ece8e58e9f4ad7779a1c6830cb7d92408fcfa32cbL96-R92)
- Updated references from `IGeminiSchema` and `GeminiTypeChecker` to `ILlmSchema` and `LlmTypeChecker` to reflect current naming conventions. [[1]](diffhunk://#diff-6e6bececd1bc7bc3c702e37136705a8f14fb4a04438d2cc56b49b8a9dad83e5dL91-R89) [[2]](diffhunk://#diff-6e6bececd1bc7bc3c702e37136705a8f14fb4a04438d2cc56b49b8a9dad83e5dL105-R103) [[3]](diffhunk://#diff-67eb841887aa18f7a1f8f29f618e1249fcee2e6b888e6d9ff37300a6985cc4e8L61-R61) [[4]](diffhunk://#diff-67eb841887aa18f7a1f8f29f618e1249fcee2e6b888e6d9ff37300a6985cc4e8L75-R75)

**Example and API Usage Corrections:**

- Updated example code for `HttpLlm.application` and `typia.llm.controller` to use the latest function signatures, removing the explicit `model` and generic parameters. [[1]](diffhunk://#diff-495940f576302e7a4ed292562b086e7e57f899a546c2aa34df28432ab2f346c7L33-R37) [[2]](diffhunk://#diff-d74801e9b4ef7caf13506eef3a763311c89aa53d032a5dab989aa27a4ef5a7c1L27-R31) [[3]](diffhunk://#diff-d74801e9b4ef7caf13506eef3a763311c89aa53d032a5dab989aa27a4ef5a7c1L50) [[4]](diffhunk://#diff-276cef79b95444f3b3c3319e903d0a9121db2992abfd63f3fffb922189e170e6L43)
- Removed the `@template Model` documentation from interfaces where the generic is no longer required. [[1]](diffhunk://#diff-495940f576302e7a4ed292562b086e7e57f899a546c2aa34df28432ab2f346c7L59) [[2]](diffhunk://#diff-d74801e9b4ef7caf13506eef3a763311c89aa53d032a5dab989aa27a4ef5a7c1L50) [[3]](diffhunk://#diff-25c6cbd1c80f38bb0f80a4a8abbe94cbfa3c66b7e99c4d65ebc41d05f9efc4eeL24)

**Schema Transformation Clarification:**

- Added a new section documenting "Strict Mode" in `ILlmSchema`, explaining how schema constraints are handled and moved into descriptions to comply with OpenAI's structured output requirements.

**Other Documentation Improvements:**

- Clarified the error handling and options documentation in `IMcpLlmApplication` and related interfaces, including fixing comments about MCP vs HTTP application options. [[1]](diffhunk://#diff-140c0d5f926889bdec178ba6d2d9c80682ef1d6910aae39cd3a7996c39292c0cL15-R18) [[2]](diffhunk://#diff-140c0d5f926889bdec178ba6d2d9c80682ef1d6910aae39cd3a7996c39292c0cL45-R45)
- Removed outdated or redundant validation documentation from `IMcpLlmFunction`.
- Updated documentation to reflect that `typia.llm.application` no longer takes a `Model` generic parameter.